### PR TITLE
(Patch 3.2 Questing) ExLogAck being used without Being Declared, was causing it not to run.

### DIFF
--- a/Questing/[O] Heavensward (Patch 3.2).xml
+++ b/Questing/[O] Heavensward (Patch 3.2).xml
@@ -178,8 +178,8 @@
                 <WaitWhile Condition="Managers.QuestLogManager.InCutscene"/>
             </If>
             <If Condition="GetQuestStep(67768) == 3">
-                <ExLog Color="&ExLogAck;" Name="Heavensward (3.2)" Message="Please complete The Antitower manually!"/>
-                <ExLog Color="&ExLogAck;" Name="Heavensward (3.2)" Message="Please restart this profile after you are done."/>
+                <LogMessage Message="[Heavensward (3.2)] Please complete the Antitower duty."/>
+                <LogMessage Message="[Heavensward (3.2)] Run this profile again once you finish the duty."/>
                 <StopBot/>
             </If>
 
@@ -514,8 +514,8 @@
                     <GetTo ZoneId="155" XYZ="223.9285, 312, -240.9699"/>
                 </If>
                 <NoCombatMoveTo Name="Emmanellain" XYZ="-133.9285, 304.1539, -300.8317"/>
-                <ExLog Color="&ExLogAck;" Name="Heavensward" Message="Please manually complete the A Spectacle for the Ages duty!"/>
-                <ExLog Color="&ExLogAck;" Name="Heavensward" Message="Run this profile again once you finish the duty."/>
+                <LogMessage Message="[Heavensward (3.2)] Please manually complete the A Spectacle for the Ages duty!"/>
+                <LogMessage Message="[Heavensward (3.2)] Run this profile again once you finish the duty."/>
                 <StopBot/>
 
                 <!-- TO DO -->


### PR DESCRIPTION
I Replaced ExLog tags with LogMessage tags.