### PR TITLE
2 second wait timer after every turn in & Jannequinard XYZ Fix.

### DIFF
--- a/Gathering/[O] [BTN] Leveling 1-60 + 1-60 Quests.xml
+++ b/Gathering/[O] [BTN] Leveling 1-60 + 1-60 Quests.xml
@@ -130,6 +130,7 @@
 					</If>
 					<If Condition="GetQuestStep(65539) == 255">
 						<TurnInPlus QuestId="65539" StepId="255" NpcId="1000815" InteractDistance="1.0" XYZ="-232.9017, 6.263501, -169.7613" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 					<While Condition="ff14bot.Managers.InventoryManager.GetBagByInventoryBagId(ff14bot.Enums.InventoryBagId.EquippedItems)[ff14bot.Enums.EquipmentSlot.MainHand].RawItemId != 2545">
 						<RunCode Name="BTNWeapon" />
@@ -184,6 +185,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="5509" QuestId="65744" StepId="255" NpcId="1000815" InteractDistance="2.0" XYZ="-232.9017, 6.263501, -169.7613" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 1 - My First Hatchet - Completed." />
 					</If>
 				</If>
@@ -249,6 +251,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="5498" QuestId="65540" StepId="255" NpcId="1000295" InteractDistance="2.0" XYZ="-236.451, 8.000312, -155.7238" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 5 - Sap for Smiles - Completed." />
 					</If>
 				</If>
@@ -320,6 +323,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="5352" QuestId="65541" StepId="255" NpcId="1000295" InteractDistance="2.0" XYZ="-236.451, 8.000312, -155.7238" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 10 - Weapons of a Feather - Completed." />
 					</If>
 				</If>
@@ -403,9 +407,11 @@
 				<If Condition="IsOnMap(133)">
 					<If Condition="GetQuestStep(65542) == 2">
 						<TurnIn ItemId="4832" RequiresHq="true" QuestId="65542" StepId="2" NpcId="1000239" InteractDistance="2.0" XYZ="167.8746, 15.69992, -117.8252" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 					<If Condition="GetQuestStep(65542) == 255">
 						<TurnIn QuestId="65542" StepId="255" NpcId="1000815" InteractDistance="2.0" XYZ="-232.9017, 6.263501, -169.7613" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 15 - Haste Makes Waste - Completed." />
 					</If>
 				</If>
@@ -469,6 +475,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="5599" QuestId="65543" StepId="255" NpcId="1000292" InteractDistance="2.0" XYZ="-235.7631, 8, -147.0039" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 20 - Dressed to Harvest - Completed." />
 					</If>
 				</If>
@@ -548,6 +555,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="5542" RequiresHq="true" QuestId="65544" StepId="255" NpcId="1000292" InteractDistance="2.0" XYZ="-235.7631, 8, -147.0039" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 25 - Aromatic Aspirations - Completed." />
 					</If>
 				</If>
@@ -631,6 +639,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="4813" RequiresHq="true" QuestId="65545" StepId="255" NpcId="1000815" InteractDistance="2.0" XYZ="-233.54, 6.246956, -170.5644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 30 - What Nature Giveth - Completed." />
 					</If>
 				</If>
@@ -713,6 +722,7 @@
 			</If>
 			<If Condition="GetQuestStep(65546) == 255">
 				<TurnIn QuestId="65546" StepId="255" NpcId="1000815" InteractDistance="2.0" XYZ="-233.54, 6.246956, -170.5644" />
+				<WaitTimer WaitTime="2"/>
 				<LogMessage Message="Level 35 - A Feast to Say the Least - Completed." />
 			</If>
 		</If>
@@ -792,6 +802,7 @@
 			</If>
 			<If Condition="GetQuestStep(65547) == 255">
 				<TurnIn ItemId="2000569" QuestId="65547" StepId="255" NpcId="1000815" InteractDistance="2.0" XYZ="-233.54, 6.246956, -170.5644" />
+				<WaitTimer WaitTime="2"/>
 				<LogMessage Message="Level 40 - Crisis of Faith - Completed." />
 			</If>
 		</If>
@@ -867,6 +878,7 @@
 					</If>
 					<If Condition="IsOnMap(133)">
 						<TurnIn ItemId="5536" RequiresHq="true" QuestId="65548" StepId="255" NpcId="1000815" InteractDistance="1.0" XYZ="-232.9017, 6.263501, -169.7613" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 45 - Botanist in a Bind - Completed." />
 					</If>
 				</If>
@@ -968,6 +980,7 @@
 				</If>
 				<If Condition="IsOnMap(133)">
 					<TurnIn QuestId="65549" StepId="255" NpcId="1000815" InteractDistance="1.0" XYZ="-232.9017, 6.263501, -169.7613" />
+					<WaitTimer WaitTime="2"/>
 					<WaitTimer WaitTime="3" />
 					<RunCode Name="BTNWeapon2" />
 					<WaitTimer WaitTime="3" />
@@ -1010,6 +1023,7 @@
 					</If>
 					<NoCombatMoveTo Name="Mujih Mewrilah" XYZ="-84.45868, 8.05915, 37.12512" />
 					<TurnIn QuestId="67584" NpcId="1013240" ItemId="2001886" XYZ="-84.45868, 8.05915, 37.12512" />
+					<WaitTimer WaitTime="2"/>
 					<LogMessage Message="Level 50 - Call From The Clouds - Completed." />
 				</If>
 			</If>
@@ -1255,6 +1269,7 @@
 							</If>
 							<NoCombatMoveTo Name="Basyle" XYZ="-670.8019, -127.9738, 639.9481" />	
 							<TurnIn ItemId="12878" RequiresHq="true" QuestId="67585" StepId="2" NpcId="1013241" InteractDistance="2.0" XYZ="-670.8019, -127.9738, 639.9481" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -1266,6 +1281,7 @@
 						</If>
 						<NoCombatMoveTo Name="Mujih Mewrilah" XYZ="-84.45868, 8.05915, 37.12512" />
 						<TurnIn RewardSlot="0" QuestId="67585" NpcId="1013240" ItemId="2001886" XYZ="-84.45868, 8.05915, 37.12512" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 53 - Onions Of Life Bestowing - Completed." />
 					</If>
 				</If>
@@ -1474,6 +1490,7 @@
 							</If>
 							<NoCombatMoveTo Name="Basyle" XYZ="-670.8019, -127.9738, 639.9481" />	
 							<TurnIn ItemId="12879" RequiresHq="true" QuestId="67586" StepId="5" NpcId="1013241" InteractDistance="2.0" XYZ="-670.8019, -127.9738, 639.9481" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -1485,6 +1502,7 @@
 						</If>
 						<NoCombatMoveTo Name="Mujih Mewrilah" XYZ="-84.45868, 8.05915, 37.12512" />
 						<TurnIn RewardSlot="0" QuestId="67586" NpcId="1013240" XYZ="-84.45868, 8.05915, 37.12512" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 55 - Two Nations, One Seed - Completed." />
 					</If>
 				</If>
@@ -1646,6 +1664,7 @@
 							</If>
 							<NoCombatMoveTo Name="Basyle" XYZ="-670.8019, -127.9738, 639.9481" />	
 							<TurnIn ItemId="12579" RequiresHq="true" QuestId="67587" StepId="3" NpcId="1013241" InteractDistance="2.0" XYZ="-670.8019, -127.9738, 639.9481" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -1657,6 +1676,7 @@
 						</If>
 						<NoCombatMoveTo Name="Mujih Mewrilah" XYZ="-84.45868, 8.05915, 37.12512" />
 						<TurnIn RewardSlot="0" QuestId="67587" NpcId="1013240" XYZ="-84.45868, 8.05915, 37.12512" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 58 - Love For Harmony - Completed." />
 					</If>
 				</If>
@@ -1760,6 +1780,7 @@
 							</If>
 							<NoCombatMoveTo Name="Martineau" XYZ="-136.9193, 14.55313, -150.3167" />
 							<TurnIn ItemId="12900" RequiresHq="true" QuestId="67588" StepId="3" NpcId="1013245" InteractDistance="2.0" XYZ="-136.9193, 14.55313, -150.3167" />
+							<WaitTimer WaitTime="2"/>
 						</If>						
 					</If>
 					<If Condition="GetQuestStep(67588) == 4">
@@ -1768,6 +1789,7 @@
 						</If>
 						<NoCombatMoveTo Name="Basyle" XYZ="-670.8019, -127.9738, 639.9481" />	
 						<TurnIn ItemId="12900" RequiresHq="true" QuestId="67588" StepId="4" NpcId="1013241" InteractDistance="2.0" XYZ="-670.8019, -127.9738, 639.9481" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 					<If Condition="GetQuestStep(67588) == 5">
 						<If Condition="not IsOnMap(401)">
@@ -1799,6 +1821,7 @@
 						</If>
 						<NoCombatMoveTo Name="Fufucha" XYZ="-232.9017, 6.263501, -169.7613" />
 						<TurnIn RewardSlot="1" QuestId="67588" NpcId="1000815" XYZ="-232.9017, 6.263501, -169.7613" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 60 - Seeds Know No Borders - Completed." />
 					</If>
 				</If>

--- a/Gathering/[O] [FSH] Leveling 1-70 + 1-60 Quests.xml
+++ b/Gathering/[O] [FSH] Leveling 1-70 + 1-60 Quests.xml
@@ -115,7 +115,8 @@
 						<GetTo ZoneId="129" XYZ="-84.08636, 18.60033, -12.41393" /> <!-- Limsa Lominsa Lower Decks -->
 					</If>
 					<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />					
-					<TurnInPlus QuestId="66643" StepId="255" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />					
+					<TurnInPlus QuestId="66643" StepId="255" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+					<WaitTimer WaitTime="2"/>					
 				</If>
 				<While Condition="ff14bot.Managers.InventoryManager.GetBagByInventoryBagId(ff14bot.Enums.InventoryBagId.EquippedItems)[ff14bot.Enums.EquipmentSlot.MainHand].RawItemId != 2571">
 					<RunCode Name="FSHWeapon" />
@@ -157,6 +158,7 @@
 					</If>
 					<MoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 					<TurnIn ItemId="4870" QuestId="66644" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -267,7 +269,8 @@
 						</If>
 						<If Condition="NqHasAtLeast(4874,3)">
 							<MoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
-							<TurnIn ItemId="4874" QuestId="66645" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />					
+							<TurnIn ItemId="4874" QuestId="66645" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+							<WaitTimer WaitTime="2"/>					
 						</If>
 					</If>
 				</If>
@@ -321,6 +324,7 @@
 							</If>
 							<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />							
 							<TurnIn ItemId="4930" RequiresHq="true" QuestId="66646" StepId="255" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -469,6 +473,7 @@
 						</If>
 						<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 						<TurnIn QuestId="66647" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -582,6 +587,7 @@
 							</If>
 							<NoCombatMoveTo Name="Chuchuroon" XYZ="-185.8396, 4, 169.604" />
 							<TurnIn ItemId="4955" QuestId="66648" NpcId="1003516" XYZ="-185.8396, 4, 169.604" />
+							<WaitTimer WaitTime="2"/>
 						</If>						
 					</If>
 				</If>
@@ -697,6 +703,7 @@
 							</If>
 							<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 							<TurnIn ItemId="4963" QuestId="66649" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -844,6 +851,7 @@
 						</If>
 						<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 						<TurnIn QuestId="66650" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1057,6 +1065,7 @@
 							</If>
 							<NoCombatMoveTo Name="Tocktix" XYZ="-184.7715, 4, 169.2683" />
 							<TurnIn ItemId="5033" QuestId="66651" StepId="255" NpcId="1003628" XYZ="-184.7715, 4, 169.2683" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -1191,6 +1200,7 @@
 							</If>
 							<NoCombatMoveTo Name="Sybell" XYZ="-171.8929, 4, 175.3108" />
 							<TurnIn ItemId="4905" QuestId="66652" NpcId="1003629" XYZ="-171.8929, 4, 175.3108" />
+							<WaitTimer WaitTime="2"/>
 						</If>						
 					</If>
 				</If>
@@ -1317,6 +1327,7 @@
 							</If>
 							<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 							<TurnIn ItemId="5040" QuestId="66653" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -1453,6 +1464,7 @@
 							</If>
 							<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 							<TurnIn ItemId="4917" QuestId="66654" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 
@@ -1464,6 +1476,7 @@
 						</If>
 						<NoCombatMoveTo Name="Sisipu" XYZ="-165.2705, 5.250006, 164.2938" />
 						<TurnIn QuestId="66654" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1501,6 +1514,7 @@
 						</If>
 						<NoCombatMoveTo Name="Ansaulme" XYZ="100.3585, 15.00001, 24.3075" />
 						<TurnIn QuestId="67621" NpcId="1013250" ItemId="2001886" XYZ="100.3585, 15.00001, 24.3075" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1780,6 +1794,7 @@
 							</If>
 							<NoCombatMoveTo Name="Ansaulme" XYZ="456.0768, 200.2136, 668.635" />
 							<TurnIn ItemId="12713" RequiresHq="true" QuestId="67622" NpcId="1013252" XYZ="459.6169, 200.2377, 665.8884" />
+							<WaitTimer WaitTime="2"/>
 						</If>						
 					</If>
 				</If>
@@ -1918,6 +1933,7 @@
 							</If>	
 							<NoCombatMoveTo Name="Reyna" XYZ="523.6133, -51.424, 62.54675" />
 							<TurnIn ItemId="12769" RequiresHq="true" StepId="3" QuestId="67623" NpcId="1013254" XYZ="523.6133, -51.424, 62.54675" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -1928,7 +1944,8 @@
 							<GetTo ZoneId="418" XYZ="-56.30568, 8.113304, 38.95942" /> <!-- Foundation -->
 						</If>
 						<NoCombatMoveTo Name="Ansaulme" XYZ="100.3585, 15.00001, 24.3075" />						
-						<TurnIn QuestId="67623" StepId="255" NpcId="1013250" XYZ="100.3585, 15.00001, 24.3075" />	
+						<TurnIn QuestId="67623" StepId="255" NpcId="1013250" XYZ="100.3585, 15.00001, 24.3075" />
+						<WaitTimer WaitTime="2"/>	
 					</If>
 				</If>
 			</If>
@@ -2074,6 +2091,7 @@
 							</If>
 							<NoCombatMoveTo Name="Mogukk" XYZ="441.306, -29.3383, 218.1277" />
 							<TurnIn ItemId="12793" RequiresHq="true" StepId="4" QuestId="67624" NpcId="1013824" XYZ="441.306, -29.3383, 218.1277" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -2085,6 +2103,7 @@
 						</If>
 						<NoCombatMoveTo Name="Ansaulme" XYZ="100.3585, 15.00001, 24.3075" />
 						<TurnIn ItemId="12793" RequiresHq="true" StepId="255" QuestId="67624" NpcId="1013250" XYZ="100.3585, 15.00001, 24.3075" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -2318,7 +2337,8 @@
 							<GetTo ZoneId="401" XYZ="-626.617, -122.5, 539.8152" /> <!-- Camp Cloudtop -->
 						</If>
 						<NoCombatMoveTo Name="Ansaulme" XYZ="400.7477, -123.263, 674.9523" />
-						<TurnIn ItemId="12829" RequiresHq="true" StepId="255" QuestId="67625" NpcId="1013830" XYZ="400.7477, -123.263, 674.9523" />		
+						<TurnIn ItemId="12829" RequiresHq="true" StepId="255" QuestId="67625" NpcId="1013830" XYZ="400.7477, -123.263, 674.9523" />
+						<WaitTimer WaitTime="2"/>		
 					</If>
 					<StopBot />					
 				</If>

--- a/Gathering/[O] [MIN] Leveling 1-70 + 1-60 Quests.xml
+++ b/Gathering/[O] [MIN] Leveling 1-70 + 1-60 Quests.xml
@@ -140,6 +140,7 @@
 					</If>
 					<If Condition="GetQuestStep(66133) == 255">
 						<TurnInPlus QuestId="66133" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 					<While Condition="ff14bot.Managers.InventoryManager.GetBagByInventoryBagId(ff14bot.Enums.InventoryBagId.EquippedItems)[ff14bot.Enums.EquipmentSlot.MainHand].RawItemId != 2519">
 						<RunCode Name="MINWeapon" />
@@ -197,6 +198,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5106" QuestId="66135" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 1 - My First Pickaxe - Completed." />
 					</If>
 				</If>
@@ -270,6 +272,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5432" QuestId="66136" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 5 - Know Thy Land - Completed." />
 					</If>
 				</If>
@@ -344,6 +347,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5124" QuestId="66138" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 10 - The Cutting Edge - Completed." />
 					</If>
 				</If>
@@ -428,6 +432,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5519" QuestId="66139" RequiresHq="true" StepId="255" NpcId="1003909" InteractDistance="1.0" XYZ="18.72768, 9.00961, 168.2022" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 15 - Getting in Deep - Completed." />
 					</If>
 				</If>
@@ -506,6 +511,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5599" QuestId="66140" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 20 - Old Wisdom, New Ways - Completed." />
 					</If>
 				</If>
@@ -584,6 +590,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5491" QuestId="66141" RequiresHq="true" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 25 - Water From Stone - Completed." />
 					</If>
 				</If>
@@ -673,6 +680,7 @@
 			</If>
 			<If Condition="GetQuestStep(66142) == 255">
 				<TurnIn QuestId="66142" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+				<WaitTimer WaitTime="2"/>
 				<LogMessage Message="Level 30 - Obsidian Race - Completed." />
 			</If>
 		</If>
@@ -757,6 +765,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5138" QuestId="66179" RequiresHq="true" StepId="255" NpcId="1003910" InteractDistance="1.0" XYZ="-5.622513, 6.2, 165.3229" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 35 - Amethysts Are Forever - Completed." />
 					</If>
 				</If>
@@ -831,6 +840,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5168" QuestId="66180" RequiresHq="true" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 40 - To Die For - Completed." />
 					</If>
 				</If>
@@ -905,6 +915,7 @@
 					</If>
 					<If Condition="IsOnMap(131)">
 						<TurnIn ItemId="5115" QuestId="66181" RequiresHq="true" StepId="255" NpcId="1003910" InteractDistance="1.0" XYZ="-5.622513, 6.2, 165.3229" />
+						<WaitTimer WaitTime="2"/>
 						<LogMessage Message="Level 45 - Gulley of Woes - Completed." />
 					</If>
 				</If>
@@ -999,6 +1010,7 @@
 					<If Condition="IsOnMap(131)">
 						<HandOverPlus ItemId="5121" QuestId="66182" StepId="5" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
 						<TurnIn QuestId="66182" StepId="255" NpcId="1002298" InteractDistance="1.0" XYZ="-16.45324, 6.2, 157.4644" />
+						<WaitTimer WaitTime="2"/>
 						<WaitTimer WaitTime="3" />
 						<RunCode Name="MINWeapon2" />
 						<WaitTimer WaitTime="3" />
@@ -1050,6 +1062,7 @@
 					</If>
 					<NoCombatMoveTo Name="Haimirich" XYZ="86.81773, 15.00001, 36.22687" />
 					<TurnIn QuestId="67616" NpcId="1013230" ItemId="0" XYZ="85.19104, 15.00001, 40.66516" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1182,6 +1195,7 @@
 						<If Condition="HqHasAtLeast(12534,10)">
 							<NoCombatMoveTo Name="Haimirich" XYZ="299.6719, 157.9135, 103.2578" />
 							<TurnIn ItemId="12534" RequiresHq="true" QuestId="67617" StepId="2" NpcId="1013233" InteractDistance="2.0" XYZ="299.6719, 157.9135, 103.2578" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>					
 					
@@ -1193,6 +1207,7 @@
 						</If>
 						<NoCombatMoveTo Name="Haimirich" XYZ="86.81773, 15.00001, 36.22687" />	
 						<TurnIn QuestId="67617" NpcId="1013230" XYZ="85.19104, 15.00001, 40.66516" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1266,6 +1281,7 @@
 						<If Condition="HqHasAtLeast(12537,10)">
 							<NoCombatMoveTo Name="Haimirich" XYZ="388.3573, -43.08157, -368.9174" />
 							<TurnIn ItemId="12537" RequiresHq="true" QuestId="67618" StepId="4" NpcId="1013933" XYZ="388.3573, -43.08157, -368.9174" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -1277,6 +1293,7 @@
 						</If>
 						<NoCombatMoveTo Name="Haimirich" XYZ="86.81773, 15.00001, 36.22687" />
 						<TurnIn QuestId="67618" NpcId="1013230" XYZ="85.19104, 15.00001, 40.66516" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1400,6 +1417,7 @@
 						<If Condition="HqHasAtLeast(12537,10)">
 							<NoCombatMoveTo Name="Haimirich" XYZ="388.3573, -43.08157, -368.9174" />
 							<TurnIn ItemId="12537" RequiresHq="true" QuestId="67618" StepId="4" NpcId="1013933" XYZ="388.3573, -43.08157, -368.9174" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 					
@@ -1411,6 +1429,7 @@
 						</If>
 						<NoCombatMoveTo Name="Haimirich" XYZ="86.81773, 15.00001, 36.22687" />
 						<TurnIn QuestId="67618" NpcId="1013230" XYZ="85.19104, 15.00001, 40.66516" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1533,7 +1552,8 @@
 						</If>
 						<If Condition="HqHasAtLeast(12535,10)">
 							<NoCombatMoveTo Name="Haimirich" XYZ="552.3003, 94.17663, 161.7609" />	
-							<TurnIn ItemId="12535" RequiresHq="true" QuestId="67619" StepId="4" NpcId="1013943" XYZ="552.3003, 94.17663, 161.7609" />	
+							<TurnIn ItemId="12535" RequiresHq="true" QuestId="67619" StepId="4" NpcId="1013943" XYZ="552.3003, 94.17663, 161.7609" />
+							<WaitTimer WaitTime="2"/>	
 						</If>						
 					</If>
 					
@@ -1545,6 +1565,7 @@
 						</If>
 						<NoCombatMoveTo Name="Haimirich" XYZ="86.81773, 15.00001, 36.22687" />
 						<TurnIn QuestId="67619" NpcId="1013230" XYZ="85.19104, 15.00001, 40.66516" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1663,7 +1684,8 @@
 								<GetTo ZoneId="478" XYZ="68.67902, 207.3838, -6.457279" /> <!-- Idyllshire -->
 							</If>
 							<NoCombatMoveTo Name="Goblin Trader" XYZ="59.67798, 207.1303, 3.311157" />	
-							<TurnIn ItemId="12538" RequiresHq="true" QuestId="67620" StepId="3" NpcId="1013958" XYZ="59.67798, 207.1303, 3.311157" />	
+							<TurnIn ItemId="12538" RequiresHq="true" QuestId="67620" StepId="3" NpcId="1013958" XYZ="59.67798, 207.1303, 3.311157" />
+							<WaitTimer WaitTime="2"/>	
 						</If>										
 					</If>
 					<If Condition="GetQuestStep(67620) == 4">
@@ -1696,6 +1718,7 @@
 						</If>
 						<NoCombatMoveTo Name="Haimirich" XYZ="86.81773, 15.00001, 36.22687" />
 						<TurnIn QuestId="67620" NpcId="1013230" XYZ="85.19104, 15.00001, 40.66516" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>

--- a/Questing/Job Unlocks/[O] Astrologian.xml
+++ b/Questing/Job Unlocks/[O] Astrologian.xml
@@ -39,16 +39,16 @@
             <LogMessage Message="[Astrologian] Unlocking your Astrologian job!" />
 
             <If Condition="not HasQuest(67548)">
-                <GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" /> <!-- Jannequinard -->
+                <GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" /> <!-- Jannequinard -->
                 <RunCode Name="Stairway_to_the_Heavens" />
                 <If Condition="IsQuestAcceptQualified(67548)">
-                    <PickupQuest NpcId="1012222" QuestId="67548" XYZ="202.3804, -5.399966, -58.9151" />
+                    <PickupQuest NpcId="1012222" QuestId="67548" XYZ="198.9282, -5.399965, -59.27039" />
                 </If>
             </If>
             <If Condition="HasQuest(67548)">
                 <If Condition="GetQuestStep(67548) == 1">
-                    <GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" /> <!-- Jannequinard -->
-                    <TalkTo NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" QuestId="67548" StepId="1" />
+                    <GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" /> <!-- Jannequinard -->
+                    <TalkTo NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" QuestId="67548" StepId="1" />
                 </If>
                 <While Condition="GetQuestStep(67548) == 2">
                     <GetTo ZoneId="419" XYZ="195.0865, -5.399962, -65.65961" /> <!-- Heurriette -->
@@ -57,8 +57,8 @@
                     <TalkTo NpcId="1012224" XYZ="175.1277, -5.434915, -57.93854" QuestId="67548" StepId="2" />
                 </While>
                 <If Condition="GetQuestStep(67548) == 3">
-                    <GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" /> <!-- Jannequinard -->
-                    <TalkTo NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" QuestId="67548" StepId="3" />
+                    <GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" /> <!-- Jannequinard -->
+                    <TalkTo NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" QuestId="67548" StepId="3" />
                 </If>
                 <If Condition="GetQuestStep(67548) == 4">
                     <GetTo ZoneId="155" XYZ="198.6571, 293.33, 418.5701" /> <!-- Jannequinard -->

--- a/Questing/Side Story Quests/[O] Hildibrand.xml
+++ b/Questing/Side Story Quests/[O] Hildibrand.xml
@@ -89,6 +89,7 @@
 					</If>
 					<NoCombatMoveTo Name="Nashu Mhakaracca" XYZ="4.483184, 7.274037, 885.5565" />
 					<TurnInPlus QuestId="66740" NpcId="1005710" XYZ="4.483184, 7.274037, 885.5565" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -123,6 +124,7 @@
 					</If>
 					<MoveTo Name="Wymond" XYZ="-68.0353, 4, -126.8051" />
 					<TurnIn QuestId="66741" NpcId="1001285" XYZ="-68.0353, 4, -126.8051" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -184,6 +186,7 @@
 					</If>
 					<MoveTo Name="Hildibrand" XYZ="-144.7624, 12, 0.9917603" />
 					<TurnIn QuestId="66742" NpcId="1005716" XYZ="-144.7624, 12, 0.9917603" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -294,6 +297,7 @@
 					</If>
 					<NoCombatMoveTo Name="Eleazar" XYZ="-526.8788, 5.404997, -246.5095" />
 					<TurnIn QuestId="66743" NpcId="1005731" XYZ="-526.8788, 5.404997, -246.5095" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -363,6 +367,7 @@
 					</If>
 					<NoCombatMoveTo Name="Hildibrand" XYZ="-68.00946, 13.44318, 157.5188" />
 					<TurnIn QuestId="66851" NpcId="1008716" ItemId="2001220" XYZ="-68.00946, 13.44318, 157.5188" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -400,6 +405,7 @@
 					</If>
 					<NoCombatMoveTo Name="Ahriman Carcass" XYZ="111.1925, 19.42468, 121.2024" />
 					<TurnIn QuestId="66852" NpcId="2003666" XYZ="111.1925, 19.42468, 121.2024" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -437,6 +443,7 @@
 					</If>
 					<NoCombatMoveTo Name="Briardien" XYZ="-420.2793, 23.11401, -367.1779" />
 					<TurnIn QuestId="66853" NpcId="1008735" XYZ="-420.2793, 23.11401, -367.1779" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -507,6 +514,7 @@
 					</If>
 					<NoCombatMoveTo Name="Durilda" XYZ="-421.4695, 23.11401, -367.5746" />
 					<TurnIn QuestId="66854" NpcId="1008788" XYZ="-421.4695, 23.11401, -367.5746" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -593,6 +601,7 @@
 					</If>
 					<NoCombatMoveTo Name="Food Supply" XYZ="515.9838, 9.384277, 525.8105" />
 					<TurnIn QuestId="66974" NpcId="2004317" XYZ="515.9838, 9.384277, 525.8105" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -646,6 +655,7 @@
 					</If>
 					<NoCombatMoveTo Name="Tiny Trader" XYZ="311.5435, -36.40591, 344.7166" />
 					<TurnIn QuestId="66975" NpcId="1009331" XYZ="311.5435, -36.40591, 344.7166" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -724,6 +734,7 @@
 					</If>
 					<NoCombatMoveTo Name="Arabella" XYZ="-46.86047, 75.95115, 10.87964" />
 					<TurnIn QuestId="66976" NpcId="1009337" XYZ="-46.86047, 75.95115, 10.87964" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -793,6 +804,7 @@
 					</If>
 					<NoCombatMoveTo Name="Destination" XYZ="523.4607, 17.83771, 455.2528" />
 					<TurnIn QuestId="66977" NpcId="2004328" XYZ="523.4607, 17.83771, 455.2528" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -860,6 +872,7 @@
 					</If>
 					<MoveTo Name="Nashu Mhakaracca" XYZ="-142.7177, 12, -3.92157" />
 					<TurnIn QuestId="65702" NpcId="1010287" XYZ="-142.7177, 12, -3.92157" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -911,6 +924,7 @@
 					</If>
 					<MoveTo Name="Hildibrand" XYZ="-144.7319, 12, -5.661133" />
 					<TurnIn QuestId="65738" NpcId="1010290" XYZ="-144.7319, 12, -5.661133" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -968,6 +982,7 @@
 					</If>
 					<MoveTo Name="Syntgoht" XYZ="140.4897, 4.009998, -59.80017" />
 					<TurnIn QuestId="65739" NpcId="1001679" ItemId="2001509" XYZ="140.4897, 4.009998, -59.80017" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1024,6 +1039,7 @@
 					</If>
 					<MoveTo Name="Dour Meadow" XYZ="-69.5354, 6.983969, 0.07623291" />
 					<TurnIn QuestId="65740" NpcId="1010330" XYZ="-69.5354, 6.983969, 0.07623291" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1071,6 +1087,7 @@
 					</If>
 					<NoCombatMoveTo Name="Hildibrand" XYZ="363.546, 74.74335, 171.1299" />
 					<TurnIn QuestId="66026" NpcId="1011677" XYZ="363.546, 74.74335, 171.1299" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1127,6 +1144,7 @@
 					</If>
 					<MoveTo Name="Phillice" XYZ="-118.1506, 40, 96.29968" />
 					<TurnIn QuestId="66027" NpcId="1011675" XYZ="-118.1506, 40, 96.29968" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1189,6 +1207,7 @@
 					</If>
 					<MoveTo Name="Godbert" XYZ="39.07837, 34, 27.2373" />
 					<TurnIn QuestId="66028" NpcId="1011697" XYZ="39.07837, 34, 27.2373" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1233,6 +1252,7 @@
 					</If>
 					<MoveTo Name="Julyan" XYZ="42.89307, 34, 29.34302" />
 					<TurnIn QuestId="66029" NpcId="1011707" ItemIds="2001559,2001560" XYZ="42.89307, 34, 29.34302" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>
@@ -1284,6 +1304,7 @@
 					</If>
 					<MoveTo Name="Hildibrand" XYZ="141.0696, 29.64365, 173.7239" />
 					<TurnIn QuestId="66038" NpcId="1011723" XYZ="141.0696, 29.64365, 173.7239" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 		</If>

--- a/Questing/[O] A Realm Reborn (Immortal Flames).xml
+++ b/Questing/[O] A Realm Reborn (Immortal Flames).xml
@@ -45,6 +45,7 @@
                     <If Condition="GetQuestStep(65575) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65575" NpcId="1001140" XYZ="23.78882, -8, 115.8617" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -79,6 +80,7 @@
                         <If Condition="GetQuestStep(65659) == 255">
                             <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                             <TurnIn QuestId="65659" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -118,6 +120,7 @@
                         <If Condition="GetQuestStep(65557) == 255">
                             <GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
                             <TurnIn QuestId="65557" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -154,6 +157,7 @@
                         <If Condition="GetQuestStep(65660) == 255">
                             <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                             <TurnIn QuestId="65660" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -193,6 +197,7 @@
                         <If Condition="GetQuestStep(65558) == 255">
                             <GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
                             <TurnIn QuestId="65558" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -229,6 +234,7 @@
                         <If Condition="GetQuestStep(65621) == 255">
                             <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                             <TurnIn QuestId="65621" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -268,6 +274,7 @@
                         <If Condition="GetQuestStep(65559) == 255">
                             <GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
                             <TurnIn QuestId="65559" NpcId="1000254" ItemId="2000074" XYZ="157.7019, 15.90038, -270.3442" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
                     </If>
 				</If>
@@ -300,6 +307,7 @@
                     <If Condition="GetQuestStep(65556) == 255">
                         <GetTo ZoneId="133" XYZ="-243.1525, -4.000004, -7.950012" /> <!-- Braya -->
                         <TurnIn QuestId="65556" NpcId="1000705" XYZ="-243.1525, -4.000004, -7.950012" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -317,6 +325,7 @@
                     <If Condition="GetQuestStep(65585) == 255">
                         <GetTo ZoneId="133" XYZ="56.50415, 7.999024, -132.1279" /> <!-- Millicent -->
                         <TurnIn QuestId="65585" NpcId="1000429" XYZ="56.50415, 7.999024, -132.1279" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -334,6 +343,7 @@
                     <If Condition="GetQuestStep(65537) == 255">
                         <GetTo ZoneId="132" XYZ="197.4364, 0.002604693, 57.1145" /> <!-- Chansteloup -->
                         <TurnIn QuestId="65537" NpcId="1000195" ItemId="2000079" XYZ="197.4364, 0.002604693, 57.1145" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -351,6 +361,7 @@
 					<If Condition="GetQuestStep(65560) == 255">
                         <GetTo ZoneId="133" XYZ="168.658, 15.5, -95.99457" /> <!-- Parnell -->
 						<TurnIn QuestId="65560" NpcId="1000233" ItemId="2000079" XYZ="168.658, 15.5, -95.99457" />
+						<WaitTimer WaitTime="2"/>
 					</If>
                 </If>
             </If>
@@ -372,6 +383,7 @@
 					<If Condition="GetQuestStep(65563) == 255">
                         <GetTo ZoneId="133" XYZ="-33.76825, 7.317207, -117.052" /> <!-- Artor -->
 						<TurnIn QuestId="65563" NpcId="1000789" ItemId="2000024" XYZ="-33.76825, 7.317207, -117.052" />
+						<WaitTimer WaitTime="2"/>
 					</If>
                 </If>
             </If>
@@ -408,6 +420,7 @@
                     <If Condition="GetQuestStep(65577) == 255">
                         <GetTo ZoneId="133" XYZ="-175.5551, 11.03255, -159.8383" /> <!-- Samiane -->
 					    <TurnIn QuestId="65577" NpcId="1000300" ItemId="2000084" XYZ="-175.5551, 11.03255, -159.8383" />
+					    <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -438,6 +451,7 @@
                     <If Condition="GetQuestStep(65578) == 255">
                         <GetTo ZoneId="133" XYZ="-53.57446, 7.202537, -118.3643" /> <!-- Estaine -->
                         <TurnIn QuestId="65578" NpcId="1000286" XYZ="-53.57446, 7.202537, -118.3643" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -469,6 +483,7 @@
                     <If Condition="GetQuestStep(65574) == 255">
                         <GetTo ZoneId="133" XYZ="143.0532, 14.25037, -250.721" /> <!-- Ceinguled -->
                         <TurnIn QuestId="65574" NpcId="1000248" ItemId="2000081,2000082,2000083" XYZ="143.0532, 14.25037, -250.721" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -506,6 +521,7 @@
                     <If Condition="GetQuestStep(65576) == 255">
                         <GetTo ZoneId="132" XYZ="-77.95837, -3.695303, 53.08606" /> <!-- Nicoliaux -->
                         <TurnIn QuestId="65576" NpcId="1000162" XYZ="-77.95837, -3.695303, 53.08606" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -533,6 +549,7 @@
 					<If Condition="GetQuestStep(65567) == 255">
                         <GetTo ZoneId="133" XYZ="-243.1525, -4.000004, -7.950012" /> <!-- Braya -->
 						<TurnIn QuestId="65567" NpcId="1000705" ItemId="2000098" XYZ="-243.1525, -4.000004, -7.950012" />
+						<WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -550,6 +567,7 @@
                     <If Condition="GetQuestStep(65562) == 255">
                         <GetTo ZoneId="133" XYZ="-164.3245, 4.185062, -17.50214" /> <!-- Waldew -->
                         <TurnIn QuestId="65562" NpcId="1000315" ItemId="2000028" XYZ="-164.3245, 4.185062, -17.50214" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -571,6 +589,7 @@
 					<If Condition="GetQuestStep(65561) == 255">
                         <GetTo ZoneId="133" XYZ="141.5579, 15.5, -274.4335" /> <!-- Boiselont -->
 						<TurnIn QuestId="65561" NpcId="1000263" XYZ="141.5579, 15.5, -274.4335" />
+						<WaitTimer WaitTime="2"/>
 					</If>
                 </If>
             </If>
@@ -605,6 +624,7 @@
 					<If Condition="GetQuestStep(65573) == 255">
                         <GetTo ZoneId="132" XYZ="197.4364, 0.002604693, 57.1145" /> <!-- Chansteloup -->
 						<TurnIn QuestId="65573" NpcId="1000195" XYZ="197.4364, 0.002604693, 57.1145" />
+						<WaitTimer WaitTime="2"/>
 					</If>
                 </If>
             </If>
@@ -622,6 +642,7 @@
                     <If Condition="GetQuestStep(65570) == 255">
                         <GetTo ZoneId="148" XYZ="106.8589, -8, -75.66956" /> <!-- Tsubh Khamazom -->
                         <TurnIn QuestId="65570" NpcId="1000408" ItemId="2000080" XYZ="106.8589, -8, -75.66956" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -647,6 +668,7 @@
                         </If>
                         <GetTo ZoneId="154" XYZ="345.51, -5.550671, 343.8925" /> <!-- Bodwine -->
                         <TurnIn QuestId="65568" NpcId="1000629" ItemId="2000029" XYZ="345.51, -5.550671, 343.8925" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -664,6 +686,7 @@
                     <If Condition="GetQuestStep(65564) == 255">
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65564" NpcId="1000421" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -706,6 +729,7 @@
                     <If Condition="GetQuestStep(65706) == 255">
                         <GetTo ZoneId="154" XYZ="345.51, -5.550671, 343.8925" /> <!-- Bodwine -->
                         <TurnIn QuestId="65706" NpcId="1000629" XYZ="345.51, -5.550671, 343.8925" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -735,6 +759,7 @@
                     <If Condition="GetQuestStep(65709) == 255">
                         <GetTo ZoneId="154" XYZ="328.2673, -4.994704, 321.7975" /> <!-- Vionne -->
                         <TurnIn QuestId="65709" NpcId="1000632" XYZ="328.2673, -4.994704, 321.7975" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -761,6 +786,7 @@
                     <If Condition="GetQuestStep(65746) == 255">
                         <GetTo ZoneId="148" XYZ="106.8589, -8, -75.66956" /> <!-- Tsubh Khamazom -->
                         <TurnIn QuestId="65746" NpcId="1000408" XYZ="106.8589, -8, -75.66956" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -782,6 +808,7 @@
                     <If Condition="GetQuestStep(65731) == 255">
                         <GetTo ZoneId="154" XYZ="384.634, -5.819738, -136.4919" /> <!-- Linyeve -->
                         <TurnIn QuestId="65731" NpcId="1000671" ItemId="2000143" XYZ="384.634, -5.819738, -136.4919" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -819,6 +846,7 @@
                         <WaitTimer WaitTime="20" />
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65737" NpcId="1000421" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -856,6 +884,7 @@
                     <If Condition="GetQuestStep(65981) == 255">
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65981" NpcId="1000421" ItemId="2000229" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -888,6 +917,7 @@
                     <If Condition="GetQuestStep(65735) == 255">
                         <GetTo ZoneId="154" XYZ="301.1672, -5.570122, 321.1261" /> <!-- Q'djawana -->
                         <TurnIn QuestId="65735" NpcId="1000627" XYZ="301.1672, -5.570122, 321.1261" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -913,6 +943,7 @@
                     <If Condition="GetQuestStep(65707) == 255">
                         <GetTo ZoneId="154" XYZ="357.9614, 8.934158, 214.4656" /> <!-- Guithrit -->
                         <TurnIn QuestId="65707" NpcId="1000612" ItemId="2000144" XYZ="357.9614, 8.934158, 214.4656" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -934,6 +965,7 @@
                     <If Condition="GetQuestStep(65639) == 255">
                         <GetTo ZoneId="154" XYZ="400.656, -5.884903, -104.9058" /> <!-- Dametta -->
                         <TurnIn QuestId="65639" NpcId="1000656" ItemId="2000075" XYZ="400.656, -5.884903, -104.9058" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -955,6 +987,7 @@
                     <If Condition="GetQuestStep(65732) == 255">
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65732" NpcId="1000421" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -989,6 +1022,7 @@
                     <If Condition="GetQuestStep(65631) == 255">
                         <GetTo ZoneId="154" XYZ="320.5157, -5.861279, -79.88104" /> <!-- Eadbert -->
                         <TurnIn QuestId="65631" NpcId="1000640" XYZ="320.5157, -5.861279, -79.88104" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1020,6 +1054,7 @@
                     <If Condition="GetQuestStep(65710) == 255">
                         <GetTo ZoneId="154" XYZ="357.9614, 8.934158, 214.4656" /> <!-- Guithrit -->
                         <TurnIn QuestId="65710" NpcId="1000612" XYZ="357.9614, 8.934158, 214.4656" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1041,6 +1076,7 @@
                     <If Condition="GetQuestStep(65733) == 255">
                         <GetTo ZoneId="148" XYZ="135.2407, -7, -67.0329" /> <!--Mariustel -->
                         <TurnIn QuestId="65733" NpcId="1000411" ItemId="2000142" XYZ="135.2407, -7, -67.0329" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1062,6 +1098,7 @@
                         </If>
                         <GetTo ZoneId="148" XYZ="204.7607, -5.255962, -99.44305" /> <!-- Arold -->
                         <TurnIn ItemId="4552" QuestId="65708" NpcId="1000430" XYZ="204.7607, -5.255962, -99.44305" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1083,6 +1120,7 @@
                     <If Condition="GetQuestStep(65664) == 255">
                         <GetTo ZoneId="148" XYZ="201.8309, -5.541967, -107.2557" /> <!-- Monranguin -->
                         <TurnIn QuestId="65664" NpcId="1000449" ItemId="2000062" XYZ="201.8309, -5.541967, -107.2557" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1117,6 +1155,7 @@
                     <If Condition="GetQuestStep(65634) == 255">
                         <GetTo ZoneId="154" XYZ="400.656, -5.884903, -104.9058" /> <!-- Dametta -->
                         <TurnIn QuestId="65634" NpcId="1000656" ItemId="2000077" XYZ="400.656, -5.884903, -104.9058" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1138,6 +1177,7 @@
                     <If Condition="GetQuestStep(65633) == 255">
                         <GetTo ZoneId="154" XYZ="320.5157, -5.861279, -79.88104" /> <!-- Eadbert -->
                         <TurnIn QuestId="65633" NpcId="1000640" XYZ="320.5157, -5.861279, -79.88104" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -1174,6 +1214,7 @@
                     <If Condition="GetQuestStep(65711) == 255">
                         <GetTo ZoneId="148" XYZ="287.9224, -3.296992, -32.6391" /> <!-- Pauline -->
                         <TurnIn QuestId="65711" NpcId="1000685" ItemId="2000141,2000146,2000147" XYZ="287.9224, -3.296992, -32.6391" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1201,6 +1242,7 @@
                     <If Condition="GetQuestStep(65663) == 255">
                         <GetTo ZoneId="148" XYZ="286.9154, -3.372314, -31.47937" /> <!-- Gabineaux -->
                         <TurnIn QuestId="65663" NpcId="1000461" XYZ="286.9154, -3.372314, -31.47937" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1222,6 +1264,7 @@
                     <If Condition="GetQuestStep(65666) == 255">
                         <GetTo ZoneId="148" XYZ="270.5576, -5.600098, -9.658997" /> <!-- Ealdfrith -->
                         <TurnIn QuestId="65666" NpcId="1000455" XYZ="270.5576, -5.600098, -9.658997" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1260,6 +1303,7 @@
                     <If Condition="GetQuestStep(65635) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn NpcId="1000100" QuestId="65635" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1281,6 +1325,7 @@
                     <If Condition="GetQuestStep(65734) == 255">
                         <GetTo ZoneId="148" XYZ="287.9224, -3.296992, -32.6391" /> <!-- Pauline -->
                         <TurnIn QuestId="65734" NpcId="1000685" XYZ="287.9224, -3.296992, -32.6391" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1321,6 +1366,7 @@
                     <If Condition="GetQuestStep(65661) == 255">
                         <GetTo ZoneId="148" XYZ="106.8589, -8, -75.66956" /> <!-- Tsubh Khamazom -->
                         <TurnIn QuestId="65661" NpcId="1000408" ItemId="2000071" XYZ="106.8589, -8, -75.66956" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1368,6 +1414,7 @@
                     <If Condition="GetQuestStep(65665) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65665" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1474,6 +1521,7 @@
                     <If Condition="GetQuestStep(65911) == 255">
                         <GetTo ZoneId="148" XYZ="-56.38214, -0.031689, 40.97046" /> <!-- Kukuvachi -->
                         <TurnIn QuestId="65911" NpcId="1000742" XYZ="-56.38214, -0.031689, 40.97046" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1500,6 +1548,7 @@
                     <If Condition="GetQuestStep(65914) == 255">
                         <GetTo ZoneId="148" XYZ="-125.2308, 4.157372, -43.59509" /> <!-- Roseline -->
                         <TurnIn QuestId="65914" NpcId="1000748" XYZ="-125.2308, 4.157372, -43.59509" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1517,6 +1566,7 @@
                     <If Condition="GetQuestStep(65712) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65712" NpcId="1000470" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1548,6 +1598,7 @@
                     <If Condition="GetQuestStep(65910) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65910" NpcId="1000470" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1573,6 +1624,7 @@
                     <If Condition="GetQuestStep(65912) == 255">
                         <GetTo ZoneId="148" XYZ="-125.2308, 4.157372, -43.59509" /> <!-- Roseline -->
                         <TurnIn QuestId="65912" NpcId="1000748" XYZ="-125.2308, 4.157372, -43.59509" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1600,6 +1652,7 @@
                     <If Condition="GetQuestStep(65693) == 255">
                         <GetTo ZoneId="148" XYZ="-60.47156, 0.2, 6.301941" /> <!-- Luquelot -->
                         <TurnIn NpcId="1000471" QuestId="65693" XYZ="-60.47156, 0.2, 6.301941" ItemId="2000093" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1633,6 +1686,7 @@
                     <If Condition="GetQuestStep(65922) == 255">
                         <GetTo ZoneId="148" XYZ="181.8113, -32.12504, 321.7975" /> <!-- Waltheof -->
                         <TurnIn QuestId="65922" NpcId="1000501" XYZ="181.8113, -32.12504, 321.7975" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1669,6 +1723,7 @@
                     <If Condition="GetQuestStep(65913) == 255">
                         <GetTo ZoneId="148" XYZ="-193.225, 56.26458, -116.4721" /> <!-- Theodore -->
                         <TurnIn QuestId="65913" NpcId="1000436" XYZ="-193.225, 56.26458, -116.4721" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1694,6 +1749,7 @@
                     <If Condition="GetQuestStep(65915) == 255">
                         <GetTo ZoneId="148" XYZ="-125.2308, 4.157372, -43.59509" /> <!-- Roseline -->
                         <TurnIn QuestId="65915" NpcId="1000748" ItemId="2000191" XYZ="-125.2308, 4.157372, -43.59509" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1719,6 +1775,7 @@
                     <If Condition="GetQuestStep(65916) == 255">
                         <GetTo ZoneId="148" XYZ="-66.7583, 0.2, 11.36792" /> <!-- Eylgar -->
                         <TurnIn QuestId="65916" NpcId="1000741" ItemId="2000188" XYZ="-66.7583, 0.2, 11.36792" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1756,6 +1813,7 @@
                     <If Condition="GetQuestStep(65919) == 255">
                         <GetTo ZoneId="148" XYZ="-41.9776, -31.86214, 338.3077" /> <!-- Balarr -->
                         <TurnIn QuestId="65919" NpcId="1002946" XYZ="-41.9776, -31.86214, 338.3077" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1777,6 +1835,7 @@
                     <If Condition="GetQuestStep(65921) == 255">
                         <GetTo ZoneId="148" XYZ="182.5131, -32.14725, 320.3936" /> <!-- Berthe -->
                         <TurnIn QuestId="65921" NpcId="1000502" ItemId="2000185" XYZ="182.5131, -32.14725, 320.3936" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1802,6 +1861,7 @@
                     <If Condition="GetQuestStep(65694) == 255">
                         <GetTo ZoneId="148" XYZ="-44.14441, 0.7438907, -32.88324" /> <!-- Margault -->
                         <TurnIn QuestId="65694" NpcId="1000473" ItemId="2000094" XYZ="-44.14441, 0.7438907, -32.88324" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1823,6 +1883,7 @@
                     <If Condition="GetQuestStep(65692) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65692" NpcId="1000470" ItemId="2000092" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1844,6 +1905,7 @@
                     <If Condition="GetQuestStep(65917) == 255">
                         <GetTo ZoneId="148" XYZ="47.95898, -24, 228.5343" /> <!-- Lothaire -->
                         <TurnIn QuestId="65917" NpcId="1000491" XYZ="47.95898, -24, 228.5343" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1877,6 +1939,7 @@
                     <If Condition="GetQuestStep(65696) == 255">
                         <GetTo ZoneId="148" XYZ="48.78308, -24.00267, 220.0503" /> <!-- Finnea -->
                         <TurnIn QuestId="65696" NpcId="1000494" XYZ="48.78308, -24.00267, 220.0503" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1898,6 +1961,7 @@
                     <If Condition="GetQuestStep(65918) == 255">
                         <GetTo ZoneId="148" XYZ="47.95898, -24, 228.5343" /> <!-- Lothaire -->
                         <TurnIn QuestId="65918" NpcId="1000491" XYZ="47.95898, -24, 228.5343" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1919,6 +1983,7 @@
                     <If Condition="GetQuestStep(65920) == 255">
                         <GetTo ZoneId="148" XYZ="178.3322, -32.01522, 333.3027" /> <!-- Armelle -->
                         <TurnIn QuestId="65920" NpcId="1000503" XYZ="178.3322, -32.01522, 333.3027" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1940,6 +2005,7 @@
                     <If Condition="GetQuestStep(65695) == 255">
                         <GetTo ZoneId="148" XYZ="178.3322, -32.01522, 333.3027" /> <!-- Armelle -->
                         <TurnIn QuestId="65695" NpcId="1000503" XYZ="178.3322, -32.01522, 333.3027" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1966,6 +2032,7 @@
                     <If Condition="GetQuestStep(65923) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65923" NpcId="1000470" ItemId="2000237" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2026,6 +2093,7 @@
                     <If Condition="GetQuestStep(65697) == 255">
                         <GetTo ZoneId="148" XYZ="-60.47156, 0.2, 6.301941" /> <!-- Luquelot -->
                         <TurnIn QuestId="65697" NpcId="1000471" XYZ="-60.47156, 0.2, 6.301941" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2043,6 +2111,7 @@
                     <If Condition="GetQuestStep(65982) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65982" NpcId="1000100" ItemId="2000240" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2096,6 +2165,7 @@
                         </If>
                         <MoveTo Name="Lewin" XYZ="2.869185, 0.5000247, -3.373355" />
                         <TurnIn QuestId="65983" NpcId="1003061" XYZ="-0.01531982, 0.500025, -4.379395" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2130,6 +2200,7 @@
                     <If Condition="GetQuestStep(65984) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65984" NpcId="1000100" ItemId="2000250" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2164,6 +2235,7 @@
                         </If>
 					    <MoveTo Name="Kan-E-Senna" XYZ="4.898132, -1.92944, -0.1983643" />
                         <TurnIn QuestId="65985" NpcId="1003027" XYZ="4.898132, -1.92944, -0.1983643" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2195,6 +2267,7 @@
                     <If Condition="GetQuestStep(66961) == 255">
                         <GetTo ZoneId="132" XYZ="-87.84625, -3.308192, 41.70288" /> <!-- Yedythe -->
                         <TurnIn QuestId="66961" NpcId="1007792" XYZ="-87.84625, -3.308192, 41.70288" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2349,6 +2422,7 @@
                         </If>
                         <GetTo ZoneId="131" XYZ="-24.12457, 38, 85.31323" /> <!-- Bartholomew -->
                         <TurnIn QuestId="66043" NpcId="1001821" ItemId="2000457" XYZ="-24.12457, 38, 85.31323" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -2366,6 +2440,7 @@
                     <If Condition="GetQuestStep(66210) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66210" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -2408,6 +2483,7 @@
                     <If Condition="GetQuestStep(66964) == 255">
                         <MoveTo Name="Spinning Blade" Distance="3" XYZ="40.8522, -8, 111.6578" />
                         <TurnIn QuestId="66964" NpcId="1000373" XYZ="40.08533, -8.072083, 113.2372" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If> -->
@@ -2435,6 +2511,7 @@
                     <If Condition="GetQuestStep(65643) == 255">
                         <GetTo ZoneId="128" XYZ="18.00043, 40.21601, -5.336614" /> <!-- Baderon -->
                         <TurnIn QuestId="65643" NpcId="1002697" XYZ="18.00043, 40.21601, -5.336614" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2482,6 +2559,7 @@
                         <If Condition="GetQuestStep(65647) == 255">
                             <GetTo ZoneId="129" XYZ="-60.44104, 18.00032, -4.348877" /> <!-- Ahldskyf -->
                             <TurnIn ItemId="2000447" QuestId="65647" NpcId="1003604" XYZ="-60.44104, 18.00032, -4.348877" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
                     </If>
                 </If>
@@ -2508,6 +2586,7 @@
                         <If Condition="GetQuestStep(65645) == 255">
                             <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                             <TurnIn QuestId="65645" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2547,6 +2626,7 @@
                         <If Condition="GetQuestStep(65989) == 255">
                             <GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
                             <TurnIn QuestId="65989" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2596,6 +2676,7 @@
                         <If Condition="GetQuestStep(65647) == 255">
                             <GetTo ZoneId="129" XYZ="-60.44104, 18.00032, -4.348877" /> <!-- Ahldskyf -->
                             <TurnIn ItemId="2000447" QuestId="65647" NpcId="1003604" XYZ="-60.44104, 18.00032, -4.348877" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
                     </If>
                 </If>
@@ -2622,6 +2703,7 @@
                         <If Condition="GetQuestStep(65644) == 255">
                             <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                             <TurnIn QuestId="65644" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2661,6 +2743,7 @@
                         <If Condition="GetQuestStep(65847) == 255">
                             <GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
                             <TurnIn QuestId="65847" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2684,6 +2767,7 @@
                     <If Condition="GetQuestStep(65649) == 255">
                         <GetTo ZoneId="129" XYZ="-103.0227, 18.00033, 15.12834" /> <!-- Sweetnix Rosycheeks -->
                         <TurnIn QuestId="65649" NpcId="1001209" XYZ="-103.7461, 18.50033, 16.03717" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2705,6 +2789,7 @@
                     <If Condition="GetQuestStep(65859) == 255">
                         <GetTo ZoneId="129" XYZ="-60.86829, 18.00033, 7.492188" /> <!-- J'nasshym -->
                         <TurnIn QuestId="65859" NpcId="1003355" XYZ="-60.86829, 18.00033, 7.492188" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2726,6 +2811,7 @@
                     <If Condition="GetQuestStep(65648) == 255">
                         <GetTo ZoneId="129" XYZ="-146.2248, 18.21202, 16.29534" /> <!-- Frydwyb -->
                         <TurnIn QuestId="65648" NpcId="1003275" XYZ="-147.1123, 18.2, 14.3587" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2757,6 +2843,7 @@
                     <If Condition="GetQuestStep(65650) == 255">
                         <GetTo ZoneId="129" XYZ="-262.9282, 16.2, 51.40759" /> <!-- Baensyng -->
                         <TurnIn QuestId="65650" NpcId="1003272" ItemId="2000460" XYZ="-262.9282, 16.2, 51.40759" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2778,6 +2865,7 @@
                     <If Condition="GetQuestStep(65651) == 255">
                         <GetTo ZoneId="128" XYZ="-57.85454, 42.3, -162.0198" /> <!-- Latisha -->
                         <TurnIn QuestId="65651" NpcId="1001537" ItemId="2000449" XYZ="-58.85406, 42.29973, -164.0803" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2809,6 +2897,7 @@
                     <If Condition="GetQuestStep(65653) == 255">
                         <GetTo ZoneId="128" XYZ="-49.27142, 43.99999, -146.3799" /> <!-- R'sushmo -->
                         <TurnIn QuestId="65653" NpcId="1000957" XYZ="-49.27142, 43.99999, -146.3799" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2840,6 +2929,7 @@
                     <If Condition="GetQuestStep(65654) == 255">
                         <GetTo ZoneId="128" XYZ="18.38708, 47.6, -162.1271" /> <!-- Carvallain -->
                         <TurnIn QuestId="65654" NpcId="1000915" XYZ="18.38708, 47.6, -162.1271" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2857,6 +2947,7 @@
                     <If Condition="GetQuestStep(65655) == 255">
                         <GetTo ZoneId="129" XYZ="-6.729248, 20.33335, -0.7477417" /> <!-- N'delika -->
                         <TurnIn QuestId="65655" NpcId="1002433" ItemId="2000453" XYZ="-6.729248, 20.33335, -0.7477417" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2888,6 +2979,7 @@
                     <If Condition="GetQuestStep(65656) == 255">
                         <GetTo ZoneId="129" XYZ="-165.2705, 5.250006, 164.2938" /> <!-- Sisipu -->
                         <TurnIn QuestId="65656" NpcId="1000857" XYZ="-165.2705, 5.250006, 164.2938" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2911,6 +3003,7 @@
                     <If Condition="GetQuestStep(65657) == 255">
                         <GetTo ZoneId="128" XYZ="-32.02869, 41.49999, 208.3923" /> <!-- H'naanza -->
                         <TurnIn QuestId="65657" NpcId="1001000" XYZ="-32.02869, 41.49999, 208.3923" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2932,6 +3025,7 @@
                     <If Condition="GetQuestStep(66197) == 255">
                         <GetTo ZoneId="128" XYZ="17.74986, 40.21601, -5.134305" /> <!-- Baderon -->
                         <TurnIn QuestId="66197" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2957,6 +3051,7 @@
                     <If Condition="GetQuestStep(65652) == 255">
                         <GetTo ZoneId="128" XYZ="-65.62909, 41.99999, -139.4522" /> <!-- H'lahono -->
                         <TurnIn QuestId="65652" NpcId="1000959" ItemId="2000450" XYZ="-65.62909, 41.99999, -139.4522" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2995,6 +3090,7 @@
                     <If Condition="GetQuestStep(65658) == 255">
                         <GetTo ZoneId="128" XYZ="17.74986, 40.21601, -5.134305" /> <!-- Baderon -->
                         <TurnIn QuestId="65658" NpcId="1000972" ItemId="2000454" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3012,6 +3108,7 @@
                     <If Condition="GetQuestStep(66199) == 255">
                         <GetTo ZoneId="135" XYZ="277.943, 45.14374, 33.64612" /> <!-- Ancreta -->
                         <TurnIn QuestId="66199" NpcId="1002605" XYZ="277.943, 45.14374, 33.64612" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3041,6 +3138,7 @@
                     <If Condition="GetQuestStep(66198) == 255">
                         <GetTo ZoneId="128" XYZ="46.67737, 44.65992, 137.1023" /> <!-- O'kalkaya -->
                         <TurnIn QuestId="66198" NpcId="1000919" XYZ="46.67737, 44.65992, 137.1023" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3058,6 +3156,7 @@
                     <If Condition="GetQuestStep(65998) == 255">
                         <GetTo ZoneId="134" XYZ="205.4218, 112.7266, -223.7576" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="65998" NpcId="1002626" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3123,6 +3222,7 @@
                     <If Condition="GetQuestStep(66007) == 255">
                         <GetTo ZoneId="134" XYZ="232.6614, 113.0774, -240.6281" /> <!-- Grynewyda -->
                         <TurnIn QuestId="66007" NpcId="1002633" XYZ="232.5627, 113.0739, -240.2533" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3148,6 +3248,7 @@
                     <If Condition="GetQuestStep(66011) == 255">
                         <GetTo ZoneId="135" XYZ="548.6381, 89.28905, -74.32672" /> <!-- Anaoc -->
                         <TurnIn QuestId="66011" NpcId="1002571" ItemId="2000427" XYZ="548.6381, 89.28905, -74.32672" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3179,6 +3280,7 @@
                     <If Condition="GetQuestStep(66017) == 255">
                         <GetTo ZoneId="135" XYZ="540.5203, 89, -74.02161" /> <!-- Moegramm -->
                         <TurnIn QuestId="66017" NpcId="1002657" XYZ="540.5203, 89, -74.02161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3241,6 +3343,7 @@
                         <WaitTimer WaitTime="20" />
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="65999" NpcId="1002626" XYZ="205.052, 112.6122, -222.6982" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3277,6 +3380,7 @@
                     <If Condition="GetQuestStep(66079) == 255">
                         <GetTo ZoneId="134" XYZ="207.2633, 112.8604, -222.4308" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66079" NpcId="1002626" ItemId="2000522" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3312,6 +3416,7 @@
                     <If Condition="GetQuestStep(66008) == 255">
                         <GetTo ZoneId="134" XYZ="198.0769, 112.0542, -229.7374" /> <!-- Bhirdraeg -->
                         <TurnIn QuestId="66008" NpcId="1002628" ItemId="2000351" XYZ="197.8636, 112.0171, -229.7246" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3333,6 +3438,7 @@
                     <If Condition="GetQuestStep(66012) == 255">
                         <GetTo ZoneId="135" XYZ="704.8293, 67.3221, -308.4612" /> <!-- Weitzaren -->
                         <TurnIn QuestId="66012" NpcId="1002652" ItemId="2000428" XYZ="704.8293, 67.3221, -308.4612" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3364,6 +3470,7 @@
                     <If Condition="GetQuestStep(66016) == 255">
                         <GetTo ZoneId="135" XYZ="540.5203, 89, -74.02161" /> <!-- Moegramm -->
                         <TurnIn QuestId="66016" NpcId="1002657" ItemId="2000436" XYZ="540.5203, 89, -74.02161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3385,6 +3492,7 @@
                     <If Condition="GetQuestStep(66000) == 255">
                         <GetTo ZoneId="134" XYZ="203.3827, 111.9367, -215.7475" /> <!-- Gurcant -->
                         <TurnIn QuestId="66000" NpcId="1002627" XYZ="203.3264, 111.7238, -213.9163" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
             </If>
@@ -3412,6 +3520,7 @@
                     <If Condition="GetQuestStep(66009) == 255">
                         <GetTo ZoneId="134" XYZ="197.8636, 112.0171, -229.7246" /> <!-- Bhirdraeg -->
                         <TurnIn QuestId="66009" NpcId="1002628" XYZ="197.8636, 112.0171, -229.7246" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3439,6 +3548,7 @@
                     <If Condition="GetQuestStep(66006) == 255">
                         <GetTo ZoneId="134" XYZ="188.5862, 65.20107, 292.8663" /> <!-- Ostfyr -->
                         <TurnIn QuestId="66006" NpcId="1002119" XYZ="188.5862, 65.20107, 292.8663" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3462,6 +3572,7 @@
                     <If Condition="GetQuestStep(66020) == 255">
                         <GetTo ZoneId="135" XYZ="704.8293, 67.3221, -308.4612" /> <!-- Weitzaren -->
                         <TurnIn QuestId="66020" NpcId="1002652" XYZ="704.8293, 67.3221, -308.4612" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3489,6 +3600,7 @@
                     <If Condition="GetQuestStep(66018) == 255">
                         <GetTo ZoneId="135" XYZ="532.8297, 88.99998, -72.09894" /> <!-- Arenlona -->
                         <TurnIn QuestId="66018" NpcId="1002659" XYZ="532.8297, 88.99998, -72.09894" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3514,6 +3626,7 @@
                     <If Condition="GetQuestStep(66001) == 255">
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66001" NpcId="1002626" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3547,6 +3660,7 @@
                     <If Condition="GetQuestStep(66021) == 255">
                         <GetTo ZoneId="135" XYZ="312.4895, 75.94093, -308.217" /> <!-- Broenruht -->
                         <TurnIn QuestId="66021" NpcId="1002658" XYZ="312.4895, 75.94093, -308.217" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3568,6 +3682,7 @@
                     <If Condition="GetQuestStep(66019) == 255">
                         <GetTo ZoneId="135" XYZ="532.8297, 88.99998, -72.09894" /> <!-- Arenlona -->
                         <TurnIn QuestId="66019" NpcId="1002659" ItemId="2000439" XYZ="532.8297, 88.99998, -72.09894" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3589,6 +3704,7 @@
                     <If Condition="GetQuestStep(66013) == 255">
                         <GetTo ZoneId="135" XYZ="567.8033, 84.62209, -99.59564" /> <!-- Skarnmhar -->
                         <TurnIn QuestId="66013" NpcId="1002591" ItemId="2000429" XYZ="567.8033, 84.62209, -99.59564" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3618,6 +3734,7 @@
                     <If Condition="GetQuestStep(66022) == 255">
                         <GetTo ZoneId="134" XYZ="207.2633, 112.8604, -222.4308" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66022" NpcId="1002626" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3657,6 +3774,7 @@
                     <If Condition="GetQuestStep(66002) == 255">
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66002" NpcId="1002626" ItemId="2000357" XYZ="205.052, 112.6122, -222.6982" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3678,6 +3796,7 @@
                         </If>
                         <GetTo ZoneId="134" XYZ="2.5177, 57.76339, -292.8054" /> <!-- Wydaloef -->
                         <TurnIn ItemId="4552" QuestId="66010" NpcId="1002632" XYZ="2.5177, 57.76339, -292.8054" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3717,6 +3836,7 @@
                     <If Condition="GetQuestStep(66014) == 255">
                         <GetTo ZoneId="135" XYZ="548.6381, 89.28905, -74.32672" /> <!-- Anaoc -->
                         <TurnIn QuestId="66014" NpcId="1002571" XYZ="548.6381, 89.28905, -74.32672" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3762,6 +3882,7 @@
                     <If Condition="GetQuestStep(66015) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66015" RewardSlot="2" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3793,6 +3914,7 @@
                     <If Condition="GetQuestStep(66003) == 255">
                         <GetTo ZoneId="134" XYZ="0.04577637, 57.85028, -308.7664" /> <!-- Pfrewahl -->
                         <TurnIn QuestId="66003" NpcId="1002631" ItemId="2000347" XYZ="0.04577637, 57.85028, -308.7664" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3818,6 +3940,7 @@
                     <If Condition="GetQuestStep(66004) == 255">
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66004" NpcId="1002626" XYZ="205.052, 112.6122, -222.6982" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3869,6 +3992,7 @@
                     <If Condition="GetQuestStep(66005) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66005" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3912,6 +4036,7 @@
                     <If Condition="GetQuestStep(65935) == 255">
                         <GetTo ZoneId="134" XYZ="-293.9957, 7.54, -225.5436" /> <!-- W'dhovaka -->
                         <TurnIn NpcId="1003242" QuestId="65935" XYZ="-293.9957, 7.54, -225.5436" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3929,6 +4054,7 @@
                     <If Condition="GetQuestStep(65933) == 255">
                         <GetTo ZoneId="134" XYZ="-283.6805, 10.59338, -249.3478" /> <!-- Wyrkrhit -->
                         <TurnIn QuestId="65933" NpcId="1003239" XYZ="-283.6805, 10.59338, -249.3478" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -3950,6 +4076,7 @@
                     <If Condition="GetQuestStep(65936) == 255">
                         <GetTo ZoneId="134" XYZ="-282.3682, 7.54, -236.8658" /> <!-- Kazai Buoyzai -->
                         <TurnIn NpcId="1003243" ItemId="2000340" QuestId="65936" XYZ="-282.3682, 7.54, -236.8658" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3971,6 +4098,7 @@
                     <If Condition="GetQuestStep(65937) == 255">
                         <GetTo ZoneId="134" XYZ="-282.3682, 7.54, -236.8658" /> <!-- Kazai Buoyzai -->
                         <TurnIn NpcId="1003243" QuestId="65937" XYZ="-282.3682, 7.54, -236.8658" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3998,6 +4126,7 @@
                     <If Condition="GetQuestStep(65934) == 255">
                         <GetTo ZoneId="134" XYZ="-283.6805, 10.59338, -249.3478" /> <!-- Wyrkrhit -->
                         <TurnIn QuestId="65934" NpcId="1003239" XYZ="-283.6805, 10.59338, -249.3478" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4038,6 +4167,7 @@
                     <If Condition="GetQuestStep(65943) == 255">
                         <GetTo ZoneId="135" XYZ="102.2507, 68.15523, 328.9387" /> <!-- Doesrael -->
                         <TurnIn QuestId="65943" NpcId="1002231" XYZ="102.2507, 68.15523, 328.9387" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4059,6 +4189,7 @@
                     <If Condition="GetQuestStep(65938) == 255">
                         <GetTo ZoneId="138" XYZ="650.7209, 7.856782, 527.2144" /> <!-- Lyulf -->
                         <TurnIn QuestId="65938" NpcId="1003244" ItemId="2000342" XYZ="650.7209, 7.856782, 527.2144" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4080,6 +4211,7 @@
                     <If Condition="GetQuestStep(65940) == 255">
                         <GetTo ZoneId="138" XYZ="650.7209, 7.856782, 527.2144" /> <!-- Lyulf -->
                         <TurnIn QuestId="65940" NpcId="1003244" ItemId="2000345" XYZ="650.7209, 7.856782, 527.2144" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4119,6 +4251,7 @@
                     <If Condition="GetQuestStep(65939) == 255">
                         <GetTo ZoneId="128" XYZ="-32.02869, 41.49999, 208.3923" /> <!-- H'naanza -->
                         <TurnIn QuestId="65939" NpcId="1001000" XYZ="-32.02869, 41.49999, 208.3923" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4136,6 +4269,7 @@
                     <If Condition="GetQuestStep(65942) == 255">
                         <GetTo ZoneId="135" XYZ="247.364, 14.02301, 611.9325" /> <!-- Ahtbyrm -->
                         <TurnIn QuestId="65942" NpcId="1002238" ItemId="2000217" XYZ="247.364, 14.02301, 611.9325" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4166,6 +4300,7 @@
                     <If Condition="GetQuestStep(65945) == 255">
                         <GetTo ZoneId="135" XYZ="225.3298, 14.09604, 621.0269" /> <!-- Wafufu -->
                         <TurnIn QuestId="65945" NpcId="1002233" ItemId="2000218" XYZ="225.3298, 14.09604, 621.0269" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4209,6 +4344,7 @@
                     <If Condition="GetQuestStep(65944) == 255">
                         <GetTo ZoneId="135" XYZ="181.2618, 9.065946, 611.5358" /> <!-- Yulgi Honalgi -->
                         <TurnIn QuestId="65944" NpcId="1002232" XYZ="181.2618, 9.065946, 611.5358" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4237,6 +4373,7 @@
                     <If Condition="GetQuestStep(65941) == 255">
                         <GetTo ZoneId="138" XYZ="650.7209, 7.856782, 527.2144" /> <!-- Lyulf -->
                         <TurnIn QuestId="65941" NpcId="1003244" ItemId="2000346" XYZ="650.7209, 7.856782, 527.2144" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4256,6 +4393,7 @@
                         <SendChat Message="/targetnpc" />
                         <SendChat Message="/doubt" />
                         <TurnIn QuestId="65948" NpcId="1002274" XYZ="-34.65332, 8.921356, 861.4479" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4295,6 +4433,7 @@
                     <If Condition="GetQuestStep(65951) == 255">
                         <GetTo ZoneId="135" XYZ="247.364, 14.02301, 611.9325" /> <!-- Ahtbyrm -->
                         <TurnIn QuestId="65951" NpcId="1002238" XYZ="247.364, 14.02301, 611.9325" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4326,6 +4465,7 @@
                     <If Condition="GetQuestStep(65947) == 255">
                         <GetTo ZoneId="135" XYZ="185.1072, 14.09593, 677.3326" /> <!-- Mimidoa -->
                         <TurnIn QuestId="65947" NpcId="1002236" XYZ="185.1072, 14.09593, 677.3326" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4353,6 +4493,7 @@
                     <If Condition="GetQuestStep(65953) == 255">
                         <GetTo ZoneId="135" XYZ="167.5593, 14.09592, 683.9244" /> <!-- Ghimthota -->
                         <TurnIn QuestId="65953" NpcId="1002237" ItemId="2000225" XYZ="167.5593, 14.09592, 683.9244" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4380,6 +4521,7 @@
                     <If Condition="GetQuestStep(65952) == 255">
                         <GetTo ZoneId="135" XYZ="-34.71429, 8.921356, 844.9683" /> <!-- A'zumyn -->
                         <TurnIn QuestId="65952" NpcId="1002446" XYZ="-34.71429, 8.921356, 844.9683" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4401,6 +4543,7 @@
                     <If Condition="GetQuestStep(65946) == 255">
                         <GetTo ZoneId="135" XYZ="284.7791, 6.340552, 615.1675" /> <!-- Hezzkhezl -->
                         <TurnIn QuestId="65946" NpcId="1002454" ItemId="2000219" XYZ="284.7791, 6.340552, 615.1675" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4430,6 +4573,7 @@
                     <If Condition="GetQuestStep(65949) == 255">
                         <GetTo ZoneId="135" XYZ="167.5593, 14.09592, 683.9244" /> <!-- Ghimthota -->
                         <TurnIn QuestId="65949" NpcId="1002237" XYZ="167.5593, 14.09592, 683.9244" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4487,6 +4631,7 @@
                     <If Condition="GetQuestStep(65950) == 255">
                         <GetTo ZoneId="135" XYZ="167.5593, 14.09592, 683.9244" /> <!-- Ghimthota -->
                         <TurnIn QuestId="65950" NpcId="1002237" XYZ="167.5593, 14.09592, 683.9244" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4504,6 +4649,7 @@
                     <If Condition="GetQuestStep(66225) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66225" NpcId="1000972" ItemId="2000520" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -4546,6 +4692,7 @@
                     <If Condition="GetQuestStep(66080) == 255">
                         <GetTo ZoneId="128" XYZ="-3.03656, 48.168, -261.7075" /> <!-- Reyner -->
                         <TurnIn QuestId="66080" NpcId="1003282" XYZ="-3.03656, 48.168, -261.7075" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4571,6 +4718,7 @@
                     <If Condition="GetQuestStep(66226) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66226" NpcId="1000972" ItemId="2000523" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4606,6 +4754,7 @@
                         </If>
 					    <MoveTo Name="Merlwyb" XYZ="-0.04577637, 1.600142, -7.003906" />
                         <TurnIn QuestId="66081" NpcId="1002694" XYZ="-0.04577637, 1.600142, -7.003906" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4633,6 +4782,7 @@
                     <If Condition="GetQuestStep(66962) == 255">
                         <GetTo ZoneId="129" XYZ="-186.2059, 16, 56.9314" /> <!-- Dodozan -->
                         <TurnIn NpcId="1003505" ItemId="2001250" QuestId="66962" XYZ="-186.2059, 16, 56.9314" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4774,6 +4924,7 @@
                         </If>
                         <GetTo ZoneId="131" XYZ="-24.12457, 38, 85.31323" /> <!-- Bartholomew -->
                         <TurnIn QuestId="66082" NpcId="1001821" ItemId="2000459" XYZ="-24.12457, 38, 85.31323" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4791,6 +4942,7 @@
                     <If Condition="GetQuestStep(66210) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66210" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4850,6 +5002,7 @@
                         <WaitTimer WaitTime="2" />
                         <RunCode Name="MeetGreetAndDeceit_ThankYou" />
                         <TurnIn NpcId="1000984" QuestId="66023" XYZ="5.264343, 39.51757, -6.240967" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If> -->
@@ -4888,6 +5041,7 @@
                     <If Condition="GetQuestStep(66130) == 255">
                         <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                         <TurnIn QuestId="66130" NpcId="1003988" XYZ="21.07263, 7.45, -78.84338" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -4922,6 +5076,7 @@
                         <If Condition="GetQuestStep(66104) == 255">
                             <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi-->
                             <TurnIn QuestId="66104" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -4961,6 +5116,7 @@
                         <If Condition="GetQuestStep(65789) == 255">
                             <GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
                             <TurnIn QuestId="65789" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
                     </If>
                 </If>
@@ -4997,6 +5153,7 @@
                         <If Condition="GetQuestStep(66105) == 255">
                             <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                             <TurnIn QuestId="66105" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -5036,6 +5193,7 @@
                         <If Condition="GetQuestStep(66069) == 255">
                             <GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
                             <TurnIn QuestId="66069" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -5072,6 +5230,7 @@
                         <If Condition="GetQuestStep(66106) == 255">
                             <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                             <TurnIn QuestId="66106" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -5111,6 +5270,7 @@
                         <If Condition="GetQuestStep(65881) == 255">
                             <GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
                             <TurnIn QuestId="65881" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -5130,6 +5290,7 @@
                     <If Condition="GetQuestStep(65686) == 255">
                         <GetTo ZoneId="130" XYZ="-151.5984, 12, 16.22028" /> <!-- Didilata -->
                         <TurnIn QuestId="65686" NpcId="1001288" XYZ="-151.5984, 12, 16.22028" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5147,6 +5308,7 @@
                     <If Condition="GetQuestStep(65687) == 255">
                         <GetTo ZoneId="130" XYZ="-207.9042, 18.5, 70.7865" /> <!-- Mamane -->
                         <TurnIn QuestId="65687" NpcId="1001289" ItemId="2000245" XYZ="-207.9042, 18.5, 70.7865" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5164,6 +5326,7 @@
                     <If Condition="GetQuestStep(65685) == 255">
                         <GetTo ZoneId="130" XYZ="-90.0741, 2.099913, -53.69653" /> <!-- Josias -->
                         <TurnIn QuestId="65685" NpcId="1002278" ItemId="2000136" XYZ="-90.0741, 2.099913, -53.69653" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5195,6 +5358,7 @@
                     <If Condition="GetQuestStep(65689) == 255">
                         <GetTo ZoneId="131" XYZ="-94.3564, 6.599976, 22.51699" /> <!-- Wolkan -->
                         <TurnIn QuestId="65689" NpcId="1003896" XYZ="-96.17767, 6.599968, 21.28632" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5224,6 +5388,7 @@
                     <If Condition="GetQuestStep(65932) == 255">
                         <GetTo ZoneId="131" XYZ="-89.49426, 7.008114, 10.84912" /> <!-- Genevieve -->
                         <TurnIn QuestId="65932" NpcId="1001675" ItemId="2000198" XYZ="-89.49426, 7.008114, 10.84912" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5287,6 +5452,7 @@
                     <If Condition="GetQuestStep(65703) == 255">
                         <GetTo ZoneId="131" XYZ="144.3046, 6.392003, 89.12781" /> <!-- Juliana -->
                         <TurnIn QuestId="65703" NpcId="1007621" XYZ="144.3046, 6.392003, 89.12781" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5307,6 +5473,7 @@
 				<If Condition="GetQuestStep(65701) == 255">
                     <GetTo ZoneId="131" XYZ="-18.02094, 6.2, 154.5281" /> <!-- Crooked Haft -->
 					<TurnIn QuestId="65701" NpcId="1001299" XYZ="-18.02094, 6.2, 154.5281" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 
@@ -5329,6 +5496,7 @@
 				    <If Condition="GetQuestStep(65928) == 255">
                         <GetTo ZoneId="131" XYZ="142.1682, 7.492003, 104.7227" /> <!-- Yellow Moon -->
 					    <TurnIn QuestId="65928" NpcId="1001691" XYZ="142.1682, 7.492003, 104.7227" />
+					    <WaitTimer WaitTime="2"/>
 				    </If>
                 </If>
 			</If>
@@ -5362,6 +5530,7 @@
                     <If Condition="GetQuestStep(65929) == 255">
                         <GetTo ZoneId="131" XYZ="-107.1947, 40.2, 132.0057" /> <!-- Leucu -->
                         <TurnIn QuestId="65929" NpcId="1001945" XYZ="-107.1947, 40.2, 132.0057" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5379,6 +5548,7 @@
                     <If Condition="GetQuestStep(65930) == 255">
                         <GetTo ZoneId="131" XYZ="94.83472, 7.980469, -34.01245" /> <!-- Landebert -->
                         <TurnIn QuestId="65930" NpcId="1001657" ItemId="2000196" XYZ="94.83472, 7.980469, -34.01245" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5396,6 +5566,7 @@
                     <If Condition="GetQuestStep(65931) == 255">
                         <GetTo ZoneId="131" XYZ="140.4897, 4.009998, -59.80017" /> <!-- Nedrick Ironheart -->
                         <TurnIn QuestId="65931" NpcId="1001679" ItemId="2000197" XYZ="140.4897, 4.009998, -59.80017" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5423,6 +5594,7 @@
                     <If Condition="GetQuestStep(65699) == 255">
                         <GetTo ZoneId="130" XYZ="-109.9108, 4.500089, -73.80792" /> <!-- Jajakuta -->
                         <TurnIn QuestId="65699" NpcId="1003898" ItemId="2000138" XYZ="-109.9108, 4.500089, -73.80792" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5444,6 +5616,7 @@
                     <If Condition="GetQuestStep(66108) == 255">
                         <GetTo ZoneId="130" XYZ="-196.1498, 18, 62.24817" /> <!-- Erasmus -->
                         <TurnIn QuestId="66108" NpcId="1003897" ItemId="2000385" XYZ="-195.4528, 18, 60.53247" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5469,6 +5642,7 @@
                     <If Condition="GetQuestStep(66107) == 255">
                         <GetTo ZoneId="131" XYZ="-94.3564, 6.599976, 22.51699" /> <!-- Wolkan -->
                         <TurnIn QuestId="66107" NpcId="1003896" XYZ="-96.17767, 6.599968, 21.28632" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5492,6 +5666,7 @@
                     <If Condition="GetQuestStep(65925) == 255">
                         <GetTo ZoneId="141" XYZ="87.17468, 2.137739, 324.361" /> <!-- Giginasu -->
                         <TurnIn QuestId="65925" NpcId="1001497" ItemId="2000241" XYZ="87.17468, 2.137739, 324.361" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5513,6 +5688,7 @@
                     <If Condition="GetQuestStep(65926) == 255">
                         <GetTo ZoneId="140" XYZ="223.1632, 52.03812, 141.2222" /> <!-- Oswell -->
                         <TurnIn QuestId="65926" NpcId="1001992" ItemId="2000410" XYZ="223.1632, 52.03812, 141.2222" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5540,6 +5716,7 @@
                     <If Condition="GetQuestStep(65758) == 255">
                         <GetTo ZoneId="140" XYZ="223.1632, 52.03812, 141.2222" /> <!-- Oswell -->
                         <TurnIn QuestId="65758" NpcId="1001992" ItemId="2000148" XYZ="223.1632, 52.03812, 141.2222" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5557,6 +5734,7 @@
                     <If Condition="GetQuestStep(66131) == 255">
                         <GetTo ZoneId="141" XYZ="75.33374, 2.135708, 316.3347" /> <!-- Papashan -->
                         <TurnIn QuestId="66131" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5602,6 +5780,7 @@
                     <If Condition="GetQuestStep(65767) == 255">
                         <GetTo ZoneId="140" XYZ="228.4733, 52.03812, 133.1654" /> <!-- Imme -->
                         <TurnIn QuestId="65767" NpcId="1002001" XYZ="228.4733, 52.03812, 133.1654" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5623,6 +5802,7 @@
                     <If Condition="GetQuestStep(65759) == 255">
                         <GetTo ZoneId="140" XYZ="221.3015, 52.78683, 142.3208" /> <!-- Guntram -->
                         <TurnIn QuestId="65759" NpcId="1002006" ItemId="2000149" XYZ="221.3015, 52.78683, 142.3208" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5677,6 +5857,7 @@
                     <If Condition="GetQuestStep(66207) == 255">
                         <GetTo ZoneId="141" XYZ="75.33374, 2.135708, 316.3347" /> <!-- Papashan -->
                         <TurnIn QuestId="66207" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5710,6 +5891,7 @@
                     <If Condition="GetQuestStep(66086) == 255">
                         <GetTo ZoneId="141" XYZ="75.33374, 2.135708, 316.3347" /> <!-- Papashan -->
                         <TurnIn QuestId="66086" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5737,6 +5919,7 @@
                     <If Condition="GetQuestStep(65760) == 255">
                         <GetTo ZoneId="140" XYZ="-253.4371, 33.23899, 404.0436" /> <!-- Kikipu -->
                         <TurnIn QuestId="65760" NpcId="1002014" ItemId="2000354,2000355" XYZ="-253.4371, 33.23899, 404.0436" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5765,6 +5948,7 @@
                     <If Condition="GetQuestStep(65762) == 255">
                         <GetTo ZoneId="140" XYZ="-253.4371, 33.23899, 404.0436" /> <!-- Kikipu -->
                         <TurnIn QuestId="65762" NpcId="1002014" XYZ="-253.4371, 33.23899, 404.0436" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5792,6 +5976,7 @@
                     <If Condition="GetQuestStep(65857) == 255">
                         <GetTo ZoneId="141" XYZ="67.06335, 0.9387207, 255.6344" /> <!-- Hihiyaja -->
                         <TurnIn QuestId="65857" NpcId="1001457" XYZ="67.06335, 0.9387207, 255.6344" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5812,6 +5997,7 @@
 				<If Condition="GetQuestStep(65839) == 255">
                     <GetTo ZoneId="141" XYZ="-99.4126, -11.39856, -41.73346" /> <!-- Roger -->
 					<TurnIn QuestId="65839" NpcId="1001541" ItemId="2000238" XYZ="-99.4126, -11.39856, -41.73346" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 
@@ -5838,6 +6024,7 @@
                     <If Condition="GetQuestStep(65858) == 255">
                         <GetTo ZoneId="141" XYZ="-97.06268, -11.35, -48.69159" /> <!-- Wowobaru -->
                         <TurnIn QuestId="65858" NpcId="1001460" ItemId="2000214" XYZ="-97.06268, -11.35, -48.69159" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5864,6 +6051,7 @@
                     <If Condition="GetQuestStep(65840) == 255">
                         <GetTo ZoneId="141" XYZ="-97.06268, -11.35, -48.69159" /> <!-- Wowobaru -->
                         <TurnIn QuestId="65840" NpcId="1001460" ItemId="2000211" XYZ="-97.06268, -11.35, -48.69159" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5885,6 +6073,7 @@
                     <If Condition="GetQuestStep(65763) == 255">
                         <GetTo ZoneId="140" XYZ="-56.07697, 55.42117, 322.4382" /> <!-- Adelard -->
                         <TurnIn QuestId="65763" NpcId="1002049" ItemId="2000164" XYZ="-56.07697, 55.42117, 322.4382" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5928,6 +6117,7 @@
                     <If Condition="GetQuestStep(65764) == 255">
                         <GetTo ZoneId="140" XYZ="-253.4982, 33.24354, 409.964" /> <!-- Galfridus -->
                         <TurnIn QuestId="65764" NpcId="1002044" ItemId="2000153" XYZ="-253.4982, 33.24354, 409.964" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5952,6 +6142,7 @@
                     <If Condition="GetQuestStep(65860) == 255">
                         <GetTo ZoneId="141" XYZ="-96.84007, -11.35, -42.03054" /> <!-- Roger -->
                         <TurnIn QuestId="65860" NpcId="1001541" ItemId="2000234" XYZ="-99.4126, -11.39856, -41.73346" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -5979,6 +6170,7 @@
                     <If Condition="GetQuestStep(65765) == 255">
                         <GetTo ZoneId="140" XYZ="-253.4982, 33.24354, 409.964" /> <!-- Galfridus -->
                         <TurnIn QuestId="65765" NpcId="1002044" ItemId="2000154" XYZ="-253.4982, 33.24354, 409.964" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6006,6 +6198,7 @@
                     <If Condition="GetQuestStep(65761) == 255">
                         <GetTo ZoneId="140" XYZ="-255.2377, 33.23877, 407.2786" /> <!-- Fafafono -->
                         <TurnIn QuestId="65761" NpcId="1002027" ItemId="2000150" XYZ="-255.2377, 33.23877, 407.2786" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6027,6 +6220,7 @@
                     <If Condition="GetQuestStep(65841) == 255">
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65841" NpcId="1001447" ItemId="2000168" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6065,6 +6259,7 @@
                         <WaitTimer WaitTime="20" />
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65842" NpcId="1001447" ItemId="2000410" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6085,6 +6280,7 @@
 					</If>
                     <GetTo ZoneId="141" XYZ="-13.04651, -2.090576, -184.4053" /> <!-- Osbert -->
 					<TurnIn QuestId="65924" NpcId="1001445" ItemId="4552" XYZ="-13.04651, -2.090576, -184.4053" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 
@@ -6126,6 +6322,7 @@
                     <If Condition="GetQuestStep(65766) == 255">
                         <GetTo ZoneId="130" XYZ="21.69085, 6.999996, -80.55646" /> <!-- Momodi -->
                         <TurnIn QuestId="65766" RewardSlot="2" NpcId="1001353" ItemId="2000165" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6147,6 +6344,7 @@
                     <If Condition="GetQuestStep(65843) == 255">
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65843" NpcId="1001447" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6168,6 +6366,7 @@
                     <If Condition="GetQuestStep(65862) == 255">
                         <GetTo ZoneId="141" XYZ="-40.4212, -2.033629, -201.7091" /> <!-- Beringaer -->
                         <TurnIn QuestId="65862" NpcId="1001436" ItemId="2000177" XYZ="-40.4212, -2.033629, -201.7091" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6195,6 +6394,7 @@
                     <If Condition="GetQuestStep(65844) == 255">
                         <GetTo ZoneId="141" XYZ="-40.11603, -1.434406, -153.2464" /> <!-- Zezeda -->
                         <TurnIn QuestId="65844" NpcId="1001439" ItemId="2000216" XYZ="-40.11603, -1.434406, -153.2464" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6223,6 +6423,7 @@
                     <If Condition="GetQuestStep(65863) == 255">
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65863" NpcId="1001447" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6273,6 +6474,7 @@
                     <If Condition="GetQuestStep(65856) == 255">
                         <GetTo ZoneId="130" XYZ="21.69085, 6.999996, -80.55646" /> <!-- Momodi -->
                         <TurnIn QuestId="65856" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6315,6 +6517,7 @@
                         <!-- <WaitTimer WaitTime="2" />
                         <RunCode Name="LendMeYourEarsAlready_Goodbye" />
                         <TurnIn NpcId="1001313" QuestId="66965" XYZ="16.37286, 7.999979, -106.2181" />
+                        <WaitTimer WaitTime="2"/>
                     </While>
 				</If>
 			</If> -->
@@ -6354,6 +6557,7 @@
                     <If Condition="GetQuestStep(65875) == 255">
                         <GetTo ZoneId="140" XYZ="58.78721, 45.14532, -209.3917" /> <!-- Zuzutyro -->
                         <TurnIn QuestId="65875" NpcId="1002056" ItemId="2000374" XYZ="56.71765, 45.65808, -207.4464" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6382,6 +6586,7 @@
                     <If Condition="GetQuestStep(65873) == 255">
                         <GetTo ZoneId="140" XYZ="83.78723, 45.1469, -211.841" /> <!-- Chechezan -->
                         <TurnIn QuestId="65873" NpcId="1002064" XYZ="83.78723, 45.1469, -211.841" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6399,6 +6604,7 @@
                     <If Condition="GetQuestStep(66159) == 255">
                         <GetTo ZoneId="140" XYZ="60.9292, 45.14532, -205.005" /> <!-- Dadanen -->
                         <TurnIn QuestId="66159" NpcId="1002065" XYZ="60.9292, 45.14532, -205.005" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6416,6 +6622,7 @@
                     <If Condition="GetQuestStep(65864) == 255">
                         <GetTo ZoneId="140" XYZ="240.9857, 58.35799, -160.998" /> <!-- Drunken Stag -->
                         <TurnIn QuestId="65864" NpcId="1002061" ItemId="2000368" XYZ="240.9857, 58.35799, -160.998" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6443,6 +6650,7 @@
                     <If Condition="GetQuestStep(66039) == 255">
                         <GetTo ZoneId="140" XYZ="240.9857, 58.35799, -160.998" /> <!-- Drunken Stag -->
                         <TurnIn QuestId="66039" NpcId="1002061" ItemId="2000369" XYZ="240.9857, 58.35799, -160.998" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6480,6 +6688,7 @@
                     <If Condition="GetQuestStep(66040) == 255">
                         <GetTo ZoneId="140" XYZ="240.589, 58.02814, -159.5026" /> <!-- Torrid Whisper -->
                         <TurnIn QuestId="66040" NpcId="1002062" ItemId="2000370,2000371,2000372" XYZ="240.589, 58.02814, -159.5026" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6501,6 +6710,7 @@
                     <If Condition="GetQuestStep(65877) == 255">
                         <GetTo ZoneId="140" XYZ="264.2098, 53.08137, -5.844238" /> <!-- Nononzo -->
                         <TurnIn QuestId="65877" NpcId="1003814" ItemId="2000376" XYZ="264.2098, 53.08137, -5.844238" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6522,6 +6732,7 @@
                     <If Condition="GetQuestStep(65865) == 255">
                         <GetTo ZoneId="140" XYZ="59.61694, 45.14532, -215.9" /> <!-- Fufulupa -->
                         <TurnIn QuestId="65865" NpcId="1002058" XYZ="59.61694, 45.14532, -215.9" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6543,6 +6754,7 @@
                     <If Condition="GetQuestStep(65866) == 255">
                         <GetTo ZoneId="141" XYZ="94.46863, 0.3407532, -272.6024" /> <!-- Leofric -->
                         <TurnIn QuestId="65866" NpcId="1001605" ItemId="2000377" XYZ="94.46863, 0.3407532, -272.6024" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6560,6 +6772,7 @@
                     <If Condition="GetQuestStep(66067) == 255">
                         <GetTo ZoneId="141" XYZ="-40.06683, -1.962267, -200.0071" /> <!-- Beringaer -->
                         <TurnIn QuestId="66067" NpcId="1001436" ItemId="2000380" XYZ="-40.4212, -2.033629, -201.7091" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6587,6 +6800,7 @@
                     <If Condition="GetQuestStep(66066) == 255">
                         <GetTo ZoneId="141" XYZ="96.26917, 0.340753, -270.6188" /> <!-- Blayves -->
                         <TurnIn QuestId="66066" NpcId="1001602" ItemId="2000379" XYZ="96.26917, 0.340753, -270.6188" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6614,6 +6828,7 @@
                     <If Condition="GetQuestStep(66109) == 255">
                         <GetTo ZoneId="141" XYZ="93.24792, 0.3407532, -272.6024" /> <!-- Amalberga -->
                         <TurnIn QuestId="66109" NpcId="1001484" ItemId="2000378" XYZ="93.24792, 0.3407532, -272.6024" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6641,6 +6856,7 @@
                     <If Condition="GetQuestStep(66042) == 255">
                         <GetTo ZoneId="140" XYZ="-292.8635, 18.34269, -179.188" /> <!-- Edalene -->
                         <TurnIn QuestId="66042" NpcId="1002070" XYZ="-290.3945, 17.75621, -165.6062" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6672,6 +6888,7 @@
                     <If Condition="GetQuestStep(65867) == 255">
                         <GetTo ZoneId="141" XYZ="94.46863, 0.3407532, -272.6024" /> <!-- Leofric -->
                         <TurnIn QuestId="65867" NpcId="1001605" XYZ="94.46863, 0.3407532, -272.6024" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6692,6 +6909,7 @@
                         <!-- Maybe set Horizon as the home point here? -->
 
                         <TurnIn QuestId="65868" NpcId="1002058" ItemId="2000381" XYZ="59.61694, 45.14532, -215.9" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6719,6 +6937,7 @@
                     <If Condition="GetQuestStep(66041) == 255">
                         <GetTo ZoneId="140" XYZ="-176.9589, 15.65209, -270.985" /> <!-- Totoruna -->
                         <TurnIn QuestId="66041" NpcId="1002066" XYZ="-176.9589, 15.65209, -270.985" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6751,6 +6970,7 @@
                     <If Condition="GetQuestStep(65878) == 255">
                         <GetTo ZoneId="140" XYZ="-284.4435, 13.48067, -146.8986" /> <!-- Osment -->
                         <TurnIn QuestId="65878" NpcId="1002069" XYZ="-284.4435, 13.48067, -146.8986" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6768,6 +6988,7 @@
                     <If Condition="GetQuestStep(65869) == 255">
                         <GetTo ZoneId="140" XYZ="-176.9589, 15.65209, -270.985" /> <!-- Totoruna -->
                         <TurnIn QuestId="65869" NpcId="1002066" XYZ="-176.9589, 15.65209, -270.985" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6785,6 +7006,7 @@
                     <If Condition="GetQuestStep(65870) == 255">
                         <GetTo ZoneId="140" XYZ="-284.5045, 13.48067, -144.9455" /> <!-- Raffe -->
                         <TurnIn QuestId="65870" NpcId="1002068" XYZ="-284.5045, 13.48067, -144.9455" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6816,6 +7038,7 @@
                     <If Condition="GetQuestStep(65871) == 255">
                         <GetTo ZoneId="140" XYZ="-324.7883, 17.58331, -127.6113" /> <!-- Merilda -->
                         <TurnIn QuestId="65871" NpcId="1002071" ItemId="2000382,2000383,2000384" XYZ="-324.7883, 17.58331, -127.6113" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6864,6 +7087,7 @@
                         <SendChat Message="/targetnpc" />
                         <SendChat Message="/dance" />
                         <TurnIn QuestId="66963" NpcId="1007798" XYZ="-13.7179, 34.02289, -51.86548" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If> -->
@@ -6898,6 +7122,7 @@
                     <If Condition="GetQuestStep(65872) == 255">
                         <GetTo ZoneId="140" XYZ="59.61694, 45.14532, -215.9" /> <!-- Fufulupa -->
                         <TurnIn QuestId="65872" NpcId="1002058" XYZ="59.61694, 45.14532, -215.9" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6915,6 +7140,7 @@
                     <If Condition="GetQuestStep(66164) == 255">
                         <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                         <TurnIn QuestId="66164" NpcId="1001353" ItemId="2000396" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -6969,6 +7195,7 @@
                         </If>
 					    <MoveTo Name="Papashan" XYZ="0.01519775, 0.01480777, -1.693787" />
                         <TurnIn QuestId="66087" NpcId="1004003" XYZ="0.01519775, 0.01480777, -1.693787" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -7003,6 +7230,7 @@
                     <If Condition="GetQuestStep(66177) == 255">
                         <GetTo ZoneId="130" XYZ="21.75308, 6.999996, -80.53974" /> <!-- Momodi -->
                         <TurnIn QuestId="66177" NpcId="1001353" ItemId="2000405" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -7035,6 +7263,7 @@
                         </If>
                         <GetTo ZoneId="130" XYZ="-139.2996, 4.1, -113.4814" /> <!-- Raubahn -->
                         <TurnIn QuestId="66088" NpcId="1004004" XYZ="-139.2996, 4.1, -113.4814" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -7179,6 +7408,7 @@
                         </If>
                         <GetTo ZoneId="133" XYZ="-159.411, 4.054098, -4.104736" /> <!-- Silent Conjurer -->
                         <TurnIn QuestId="66064" NpcId="1000460" ItemId="2000446" XYZ="-159.411, 4.054098, -4.104736" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -7205,6 +7435,7 @@
                         </If>
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66209" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -7270,6 +7501,7 @@
                 <If Condition="GetQuestStep(65781) == 255">
                     <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                     <TurnIn QuestId="65781" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7309,6 +7541,7 @@
                 <If Condition="GetQuestStep(66746) == 255">
                     <GetTo ZoneId="128" XYZ="-44.44952, 40, 61.81433" /> <!-- Flustered Man -->
                     <TurnIn QuestId="66746" NpcId="1005515" ItemId="2001110,2001111,2001112" XYZ="-44.44952, 40, 61.81433" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7330,6 +7563,7 @@
                 <If Condition="GetQuestStep(66967) == 255">
                     <GetTo ZoneId="129" XYZ="-183.4516, 1.999996, 210.3946" /> <!-- Wastlleid -->
                     <TurnIn QuestId="66967" NpcId="1005410" ItemId="2001297" XYZ="-183.4516, 1.999996, 210.3946" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7359,6 +7593,7 @@
                 <If Condition="GetQuestStep(66825) == 255">
                     <GetTo ZoneId="138" XYZ="246.8757, -25.00046, 246.1737" /> <!-- Skribyld -->
                     <TurnIn QuestId="66825" NpcId="1005394" ItemId="2001110" XYZ="246.8757, -25.00046, 246.1737" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7388,6 +7623,7 @@
                 <If Condition="GetQuestStep(66826) == 255">
                     <GetTo ZoneId="138" XYZ="246.8757, -25.00046, 246.1737" /> <!-- Skribyld -->
                     <TurnIn QuestId="66826" NpcId="1005394" ItemId="2001084" XYZ="246.8757, -25.00046, 246.1737" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7413,6 +7649,7 @@
                 <If Condition="GetQuestStep(66827) == 255">
                     <GetTo ZoneId="138" XYZ="246.8757, -25.00046, 246.1737" /> <!-- Skribyld -->
                     <TurnIn QuestId="66827" NpcId="1005394" ItemId="2001086" XYZ="246.8757, -25.00046, 246.1737" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7434,6 +7671,7 @@
                 <If Condition="GetQuestStep(66678) == 255">
                     <GetTo ZoneId="138" XYZ="263.4292, -5.238798, 203.316" /> <!-- S'nairoh -->
                     <TurnIn QuestId="66678" NpcId="1003359" XYZ="263.6606, -4.184404, 202.1667" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7455,6 +7693,7 @@
                 <If Condition="GetQuestStep(66679) == 255">
                     <GetTo ZoneId="138" XYZ="263.6606, -4.184404, 202.1667" /> <!-- S'nairoh -->
                     <TurnIn QuestId="66679" NpcId="1003359" XYZ="263.6606, -4.184404, 202.1667" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7472,6 +7711,7 @@
                 <If Condition="GetQuestStep(66680) == 255">
                     <GetTo ZoneId="138" XYZ="65.87317, -3.118188, 61.41748" /> <!-- Falkbryda -->
                     <TurnIn QuestId="66680" NpcId="1006614" ItemId="2000967" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7493,6 +7733,7 @@
                 <If Condition="GetQuestStep(66681) == 255">
                     <GetTo ZoneId="138" XYZ="305.4703, -36.325, 351.7662" /> <!-- Ahldfoet -->
                     <TurnIn QuestId="66681" NpcId="1003393" ItemId="2000968" XYZ="305.4703, -36.325, 351.7662" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7510,6 +7751,7 @@
                 <If Condition="GetQuestStep(66682) == 255">
                     <GetTo ZoneId="138" XYZ="86.56433, -14.4917, 38.49854" /> <!-- Wiltswys -->
                     <TurnIn QuestId="66682" NpcId="1003450" ItemId="2000969" XYZ="86.56433, -14.4917, 38.49854" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7531,6 +7773,7 @@
                     </If>
                     <GetTo ZoneId="140" XYZ="-441.6419, 23.66986, -358.9685" /> <!-- Swyrgeim -->
                     <TurnIn QuestId="66235" NpcId="1004990" ItemId="4745" XYZ="-441.6419, 23.66986, -358.9685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7548,6 +7791,7 @@
                 <If Condition="GetQuestStep(66212) == 255">
                     <GetTo ZoneId="132" XYZ="25.54354, -8, 115.3249" /> <!-- Mother Miounne -->
                     <TurnIn QuestId="66212" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7575,6 +7819,7 @@
                 <If Condition="GetQuestStep(66684) == 255">
                     <GetTo ZoneId="138" XYZ="86.56433, -14.4917, 38.49854" /> <!-- Wiltswys -->
                     <TurnIn QuestId="66684" NpcId="1003450" ItemId="2000970" XYZ="86.56433, -14.4917, 38.49854" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7600,6 +7845,7 @@
                 <If Condition="GetQuestStep(66685) == 255">
                     <GetTo ZoneId="138" XYZ="26.56592, -10.28117, -83.39056" /> <!-- Nortmoen -->
                     <TurnIn QuestId="66685" NpcId="1006626" ItemId="2000971" XYZ="26.56592, -10.28117, -83.39056" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7625,6 +7871,7 @@
                 <If Condition="GetQuestStep(66686) == 255">
                     <GetTo ZoneId="138" XYZ="81.95618, -2.358437, -56.47369" /> <!-- Roehanth -->
                     <TurnIn QuestId="66686" NpcId="1003475" XYZ="81.95618, -2.358437, -56.47369" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7650,6 +7897,7 @@
                 <If Condition="GetQuestStep(66687) == 255">
                     <GetTo ZoneId="138" XYZ="65.87317, -3.118188, 61.41748" /> <!-- Falkbryda -->
                     <TurnIn QuestId="66687" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7671,6 +7919,7 @@
                 <If Condition="GetQuestStep(66683) == 255">
                     <GetTo ZoneId="138" XYZ="65.87317, -3.118188, 61.41748" /> <!-- Falkbryda -->
                     <TurnIn QuestId="66683" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7688,6 +7937,7 @@
                 <If Condition="GetQuestStep(66688) == 255">
                     <GetTo ZoneId="138" XYZ="345.7235, 1.840361, 72.86182" /> <!-- Catguistl -->
                     <TurnIn QuestId="66688" NpcId="1007638" XYZ="345.7235, 1.840361, 72.86182" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7713,6 +7963,7 @@
                 <If Condition="GetQuestStep(66213) == 255">
                     <GetTo ZoneId="132" XYZ="25.54354, -8, 115.3249" /> <!-- Mother Miounne -->
                     <TurnIn QuestId="66213" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7730,6 +7981,7 @@
                 <If Condition="GetQuestStep(66214) == 255">
                     <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                     <TurnIn QuestId="66214" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7757,6 +8009,7 @@
                 <If Condition="GetQuestStep(66960) == 255">
                     <GetTo ZoneId="140" XYZ="-472.1904, 23.00789, -320.8515" /> <!-- Tatafu -->
                     <TurnIn QuestId="66960" NpcId="1008758" ItemId="2001242" XYZ="-472.1904, 23.00789, -320.8515" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7802,6 +8055,7 @@
                 <If Condition="GetQuestStep(66196) == 255">
                     <GetTo ZoneId="130" XYZ="21.54825, 6.999996, -80.60168" /> <!-- Momodi -->
                     <TurnIn QuestId="66196" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7832,6 +8086,7 @@
                     </If>
                     <MoveTo Name="Scion Of The Seventh Dawn" XYZ="22.50702, 0.9999986, -2.02948" />
                     <TurnIn QuestId="66045" NpcId="1005012" XYZ="22.50702, 0.9999986, -2.02948" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7871,6 +8126,7 @@
                 <If Condition="GetQuestStep(66046) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66046" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7898,6 +8154,7 @@
                 <If Condition="GetQuestStep(66154) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66154" NpcId="1003929" ItemId="2000399" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7923,6 +8180,7 @@
                 <If Condition="GetQuestStep(66160) == 255">
                     <GetTo ZoneId="145" XYZ="-379.6292, -55.85506, 95.04846" /> <!-- Tutusi -->
                     <TurnIn QuestId="66160" NpcId="1003931" XYZ="-379.6292, -55.85506, 95.04846" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7950,6 +8208,7 @@
                 <If Condition="GetQuestStep(66166) == 255">
                     <GetTo ZoneId="145" XYZ="-379.6292, -55.85506, 95.04846" /> <!-- Tutusi -->
                     <TurnIn QuestId="66166" NpcId="1003931" ItemId="2000392" XYZ="-379.6292, -55.85506, 95.04846" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8000,6 +8259,7 @@
                 <If Condition="GetQuestStep(66173) == 255">
                     <GetTo ZoneId="145" XYZ="-82.20044, -58.26525, 162.5238" /> <!-- Jospaire -->
                     <TurnIn QuestId="66173" NpcId="1003941" XYZ="-82.20044, -58.26525, 162.5238" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8027,6 +8287,7 @@
                 <If Condition="GetQuestStep(66161) == 255">
                     <GetTo ZoneId="145" XYZ="-389.6392, -56.14586, 92.39331" /> <!-- Caitlyn -->
                     <TurnIn QuestId="66161" NpcId="1003932" XYZ="-389.6392, -56.14586, 92.39331" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8048,6 +8309,7 @@
                 <If Condition="GetQuestStep(66162) == 255">
                     <GetTo ZoneId="145" XYZ="-516.35, -16.22, -8.133057" /> <!-- Esmour -->
                     <TurnIn QuestId="66162" NpcId="1003946" XYZ="-516.35, -16.22, -8.133057" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8078,6 +8340,7 @@
                 <If Condition="GetQuestStep(66178) == 255">
                     <GetTo ZoneId="145" XYZ="-518.2117, -16.22, -0.8087769" /> <!-- Airell -->
                     <TurnIn QuestId="66178" NpcId="1003936" ItemId="2000406" XYZ="-518.2117, -16.22, -0.8087769" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8103,6 +8366,7 @@
                 <If Condition="GetQuestStep(66165) == 255">
                     <GetTo ZoneId="145" XYZ="-518.1201, -16.22, 0.1677856" /> <!-- Eaduuard -->
                     <TurnIn QuestId="66165" NpcId="1003937" XYZ="-518.1201, -16.22, 0.1677856" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8132,6 +8396,7 @@
                 <If Condition="GetQuestStep(66163) == 255">
                     <GetTo ZoneId="145" XYZ="-518.2117, -16.22, -0.8087769" /> <!-- Airell -->
                     <TurnIn QuestId="66163" NpcId="1003936" XYZ="-518.2117, -16.22, -0.8087769" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8163,6 +8428,7 @@
                 <If Condition="GetQuestStep(66155) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66155" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8200,6 +8466,7 @@
                 <If Condition="GetQuestStep(66156) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66156" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8227,6 +8494,7 @@
                 <If Condition="GetQuestStep(66169) == 255">
                     <GetTo ZoneId="145" XYZ="-540.9476, 4.134529, -241.0773" /> <!-- Lululo -->
                     <TurnIn NpcId="1003940" QuestId="66169" XYZ="-540.9476, 4.134529, -241.0773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8248,6 +8516,7 @@
                 <If Condition="GetQuestStep(66171) == 255">
                     <GetTo ZoneId="145" XYZ="-401.8464, -55.89148, 112.9625" /> <!-- Reremaki -->
                     <TurnIn QuestId="66171" NpcId="1004531" XYZ="-401.8464, -55.89148, 112.9625" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8269,6 +8538,7 @@
                 <If Condition="GetQuestStep(66167) == 255">
                     <GetTo ZoneId="145" XYZ="-540.0931, 4.137387, -240.9858" /> <!-- Beneger -->
                     <TurnIn QuestId="66167" NpcId="1003939" ItemId="2000511" XYZ="-540.0931, 4.137387, -240.9858" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8310,6 +8580,7 @@
                 <If Condition="GetQuestStep(66168) == 255">
                     <GetTo ZoneId="145" XYZ="-540.0931, 4.137387, -240.9858" /> <!-- Beneger -->
                     <TurnIn QuestId="66168" NpcId="1003939" XYZ="-540.0931, 4.137387, -240.9858" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8339,6 +8610,7 @@
                 <If Condition="GetQuestStep(66170) == 255">
                     <GetTo ZoneId="145" XYZ="-540.0931, 4.137387, -240.9858" /> <!-- Beneger -->
                     <TurnIn QuestId="66170" NpcId="1003939" ItemId="2000394" XYZ="-540.0931, 4.137387, -240.9858" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8356,6 +8628,7 @@
                 <If Condition="GetQuestStep(66174) == 255">
                     <GetTo ZoneId="141" XYZ="123.3386, 31, -384.9394" /> <!-- Swynbroes -->
                     <TurnIn QuestId="66174" NpcId="1001426" XYZ="123.3386, 31, -384.9394" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8381,6 +8654,7 @@
                 <If Condition="GetQuestStep(66157) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66157" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8418,6 +8692,7 @@
                 <If Condition="GetQuestStep(66158) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66158" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8467,6 +8742,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66110" NpcId="1005116" ItemId="2001110" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8506,6 +8782,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="65808" NpcId="1005116" ItemId="2000462" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8568,6 +8845,7 @@
                 <If Condition="GetQuestStep(66233) == 255">
                     <GetTo ZoneId="145" XYZ="-331.136, -22.47656, 434.8668" /> <!-- Fafajoni -->
                     <TurnIn QuestId="66233" NpcId="1004582" ItemId="2001110" XYZ="-331.136, -22.47656, 434.8668" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8633,6 +8911,7 @@
                     </If>
                     <MoveTo Name="Scion Of The Seventh Dawn" XYZ="22.50702, 0.9999986, -2.02948" />
                     <TurnIn QuestId="65879" NpcId="1005012" ItemId="2001110" XYZ="22.50702, 0.9999986, -2.02948" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8700,6 +8979,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66047" NpcId="1005122" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8745,6 +9025,7 @@
                 <If Condition="GetQuestStep(66218) == 255">
                     <GetTo ZoneId="130" XYZ="-142.8694, 4.1, -106.2359" /> --> <!-- Flame Personnel Officer -->
                     <!-- <TurnIn QuestId="66218" NpcId="1002391" XYZ="-144.3962, 4.1, -107.2252" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -8790,6 +9071,7 @@
                 <If Condition="GetQuestStep(66218) == 255">
                     <GetTo ZoneId="130" XYZ="-142.8694, 4.1, -106.2359" /> --> <!-- Flame Personnel Officer -->
                     <!-- <TurnIn QuestId="66218" NpcId="1002391" XYZ="-144.3962, 4.1, -107.2252" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -8835,6 +9117,7 @@
                 <If Condition="GetQuestStep(66218) == 255">
                     <GetTo ZoneId="130" XYZ="-142.8694, 4.1, -106.2359" /> <!-- Flame Personnel Officer -->
                     <TurnIn QuestId="66218" NpcId="1002391" XYZ="-144.3962, 4.1, -107.2252" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8861,6 +9144,7 @@
                     </If>
                     <MoveTo Name="Scion Of The Seventh Dawn" XYZ="22.50702, 0.9999986, -2.02948" />
                     <TurnIn QuestId="66221" NpcId="1005012" ItemId="2001110" XYZ="22.50702, 0.9999986, -2.02948" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8887,6 +9171,7 @@
                 <If Condition="GetQuestStep(66049) == 255">
                     <GetTo ZoneId="132" XYZ="-75.48645, -0.5013741, -5.081299" /> <!-- Vorsaile Heuloix -->
                     <TurnIn QuestId="66049" NpcId="1000168" XYZ="-75.48645, -0.5013741, -5.081299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8916,6 +9201,7 @@
                 <If Condition="GetQuestStep(65698) == 255">
                     <GetTo ZoneId="133" XYZ="-24.24664, 10.04002, -262.7451" /> <!-- Millith Ironheart -->
                     <TurnIn QuestId="65698" NpcId="1009297" XYZ="-24.24664, 10.04002, -262.7451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8958,6 +9244,7 @@
                 <If Condition="GetQuestStep(66244) == 255">
                     <GetTo ZoneId="152" XYZ="-236.9269, 3.543579, 283.4973" /> <!-- Amelain -->
                     <TurnIn QuestId="66244" NpcId="1006188" ItemId="2000826" XYZ="-236.9269, 3.543579, 283.4973" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8987,6 +9274,7 @@
                 <If Condition="GetQuestStep(66247) == 255">
                     <GetTo ZoneId="152" XYZ="-242.0539, 3.559841, 287.4646" /> <!-- Florimond -->
                     <TurnIn QuestId="66247" NpcId="1000536" XYZ="-242.0539, 3.559841, 287.4646" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9018,6 +9306,7 @@
                 <If Condition="GetQuestStep(66245) == 255">
                     <GetTo ZoneId="152" XYZ="-238.1782, 3.543561, 283.7109" /> <!-- Rolfe Hawthorne -->
                     <TurnIn QuestId="66245" NpcId="1000540" XYZ="-238.1782, 3.543561, 283.7109" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9045,6 +9334,7 @@
                 <If Condition="GetQuestStep(66248) == 255">
                     <GetTo ZoneId="152" XYZ="-246.4485, 3.54527, 279.9266" /> <!-- Ysabel Hawthorne -->
                     <TurnIn QuestId="66248" NpcId="1000615" XYZ="-246.4485, 3.54527, 279.9266" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9066,6 +9356,7 @@
                 <If Condition="GetQuestStep(66250) == 255">
                     <GetTo ZoneId="152" XYZ="-201.0377, 20.21284, 254.261" /> <!-- Minfilia -->
                     <TurnIn QuestId="66250" NpcId="1006189" XYZ="-201.0377, 20.21284, 254.261" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9093,6 +9384,7 @@
                 <If Condition="GetQuestStep(66249) == 255">
                     <GetTo ZoneId="152" XYZ="-201.0377, 20.21284, 254.261" /> <!-- Piralnaut -->
                     <TurnIn QuestId="66249" NpcId="1006189" XYZ="-201.0377, 20.21284, 254.261" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9118,6 +9410,7 @@
                 <If Condition="GetQuestStep(66246) == 255">
                     <GetTo ZoneId="152" XYZ="-238.1782, 3.543561, 283.7109" /> <!-- Rolfe Hawthorne -->
                     <TurnIn QuestId="66246" NpcId="1000540" ItemId="2000831" XYZ="-238.1782, 3.543561, 283.7109" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9159,6 +9452,7 @@
                 <If Condition="GetQuestStep(66252) == 255">
                     <GetTo ZoneId="152" XYZ="-7.248047, -8.407776, 268.2383" /> <!-- Dellexia -->
                     <TurnIn QuestId="66252" NpcId="1000587" ItemId="2000892" XYZ="-7.248047, -8.407776, 268.2383" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9188,6 +9482,7 @@
                 <If Condition="GetQuestStep(66251) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66251" NpcId="1000580" ItemId="2000573,2000574" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9220,6 +9515,7 @@
                 <If Condition="GetQuestStep(66253) == 255">
                     <GetTo ZoneId="152" XYZ="21.98816, -3.766478, 209.9794" /> <!-- Yda -->
                     <TurnIn QuestId="66253" NpcId="1006674" XYZ="21.98816, -3.766478, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9246,6 +9542,7 @@
                     <GetTo ZoneId="152" XYZ="26.87109, -3.621967, 209.6437" /> <!-- Laxio -->
                     <RunCode Name="Sylph_Says" />
                     <TurnIn QuestId="66256" NpcId="1006190" XYZ="26.87109, -3.621967, 209.6437" />
+                    <WaitTimer WaitTime="2"/>
                 </While>
             </If>
         </If>
@@ -9267,6 +9564,7 @@
                 <If Condition="GetQuestStep(66257) == 255">
                     <GetTo ZoneId="152" XYZ="26.87109, -3.621967, 209.6437" /> <!-- Laxio -->
                     <TurnIn QuestId="66257" NpcId="1006190" XYZ="26.87109, -3.621967, 209.6437" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9296,6 +9594,7 @@
                 <If Condition="GetQuestStep(66258) == 255">
                     <GetTo ZoneId="152" XYZ="-3.768982, -5.859457, 217.2732" /> <!-- Ameexia -->
                     <TurnIn QuestId="66258" NpcId="1000563" XYZ="-3.768982, -5.859457, 217.2732" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9323,6 +9622,7 @@
                 <If Condition="GetQuestStep(66259) == 255">
                     <GetTo ZoneId="152" XYZ="-3.768982, -5.859457, 217.2732" /> <!-- Ameexia -->
                     <TurnIn QuestId="66259" NpcId="1000563" ItemId="2000579" XYZ="-3.768982, -5.859457, 217.2732" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9366,6 +9666,7 @@
                 <If Condition="GetQuestStep(66254) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66254" NpcId="1000580" ItemId="2000577" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9398,6 +9699,7 @@
                 <If Condition="GetQuestStep(66255) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66255" NpcId="1000580" ItemId="2000578" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9444,6 +9746,7 @@
                 <If Condition="GetQuestStep(66260) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn NpcId="1000580" QuestId="66260" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9469,6 +9772,7 @@
                 <If Condition="GetQuestStep(66261) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66261" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9490,6 +9794,7 @@
                 <If Condition="GetQuestStep(66265) == 255">
                     <GetTo ZoneId="153" XYZ="-170.8248, 9.964111, -84.15356" /> <!-- Auphiliot -->
                     <TurnIn QuestId="66265" NpcId="1000598" XYZ="-170.8248, 9.964111, -84.15356" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9519,6 +9824,7 @@
                 <If Condition="GetQuestStep(66266) == 255">
                     <GetTo ZoneId="153" XYZ="-162.3408, 8.533126, -57.41974" /> <!-- Yoenne -->
                     <TurnIn QuestId="66266" NpcId="1006191" XYZ="-162.3408, 8.533126, -57.41974" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9555,6 +9861,7 @@
                 <If Condition="GetQuestStep(66267) == 255">
                     <GetTo ZoneId="153" XYZ="-211.5969, 6.840959, 39.78015" /> <!-- Rolandaix -->
                     <TurnIn QuestId="66267" NpcId="1000439" ItemId="2000585" XYZ="-211.5969, 6.840959, 39.78015" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9578,6 +9885,7 @@
                 <If Condition="GetQuestStep(66268) == 255">
                     <GetTo ZoneId="153" XYZ="-170.8248, 9.964111, -84.15356" /> <!-- Auphiliot -->
                     <TurnIn QuestId="66268" NpcId="1000598" XYZ="-170.8248, 9.964111, -84.15356" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9599,6 +9907,7 @@
                 <If Condition="GetQuestStep(66263) == 255">
                     <GetTo ZoneId="153" XYZ="-167.9255, 9.869228, -76.70715" /> <!-- Ianna -->
                     <TurnIn QuestId="66263" NpcId="1000594" XYZ="-167.9255, 9.869228, -76.70715" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9638,6 +9947,7 @@
                 <If Condition="GetQuestStep(66264) == 255">
                     <GetTo ZoneId="153" XYZ="-167.9255, 9.869228, -76.70715" /> <!-- Rolandaix -->
                     <TurnIn QuestId="66264" NpcId="1000594" XYZ="-167.9255, 9.869228, -76.70715" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9675,6 +9985,7 @@
                 <If Condition="GetQuestStep(66262) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66262" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9718,6 +10029,7 @@
                 <If Condition="GetQuestStep(66269) == 255">
                     <GetTo ZoneId="139" XYZ="-334.0658, -0.813661, 148.9127" /> <!-- Teteroon -->
                     <TurnIn QuestId="66269" NpcId="1006193" ItemId="2000587" XYZ="-334.0658, -0.813661, 148.9127" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9735,6 +10047,7 @@
                 <If Condition="GetQuestStep(66271) == 255">
                     <GetTo ZoneId="139" XYZ="-453.3608, 4.574484, 71.54956" /> <!-- Tanga Tonga -->
                     <TurnIn QuestId="66271" NpcId="1006195" ItemId="2000591" XYZ="-453.3608, 4.574484, 71.54956" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9775,6 +10088,7 @@
                 <If Condition="GetQuestStep(66272) == 255">
                     <GetTo ZoneId="139" XYZ="-451.3892, 4.569882, 73.56237" /> <!-- Tanga Tonga -->
                     <TurnIn QuestId="66272" NpcId="1006195" ItemId="2000592,2000593" XYZ="-453.3608, 4.574484, 71.54956" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9802,6 +10116,7 @@
                 <If Condition="GetQuestStep(66270) == 255">
                     <GetTo ZoneId="139" XYZ="-334.0658, -0.813661, 148.9127" /> <!-- Teteroon -->
                     <TurnIn QuestId="66270" NpcId="1006193" ItemId="2000589,2000590" XYZ="-334.0658, -0.813661, 148.9127" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9819,6 +10134,7 @@
                 <If Condition="GetQuestStep(66273) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66273" NpcId="1000590" ItemId="2000594" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9847,6 +10163,7 @@
                 <If Condition="GetQuestStep(66274) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66274" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9876,6 +10193,7 @@
                 <If Condition="GetQuestStep(66275) == 255">
                     <GetTo ZoneId="153" XYZ="-170.8248, 9.964111, -84.15356" /> <!-- Auphiliot -->
                     <TurnIn QuestId="66275" NpcId="1000598" XYZ="-170.8248, 9.964111, -84.15356" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9929,6 +10247,7 @@
                 <If Condition="GetQuestStep(66276) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66276" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9960,6 +10279,7 @@
                 <If Condition="GetQuestStep(66050) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66050" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9986,6 +10306,7 @@
                 <If Condition="GetQuestStep(66278) == 255">
                     <GetTo ZoneId="153" XYZ="-170.8248, 9.964111, -84.15356" /> <!-- Auphiliot -->
                     <TurnIn QuestId="66278" NpcId="1000598" XYZ="-170.8248, 9.964111, -84.15356" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10003,6 +10324,7 @@
                 <If Condition="GetQuestStep(66279) == 255">
                     <GetTo ZoneId="152" XYZ="21.46942, -4.575078, 221.7593" /> <!-- Knolexia -->
                     <TurnIn QuestId="66279" NpcId="1000576" ItemId="2000595" XYZ="21.46942, -4.575078, 221.7593" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10024,6 +10346,7 @@
                 <If Condition="GetQuestStep(66281) == 255">
                     <GetTo ZoneId="152" XYZ="21.46942, -4.575078, 221.7593" /> <!-- Knolexia -->
                     <TurnIn QuestId="66281" NpcId="1000576" ItemId="2000598" XYZ="21.46942, -4.575078, 221.7593" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10045,6 +10368,7 @@
                 <If Condition="GetQuestStep(66280) == 255">
                     <GetTo ZoneId="132" XYZ="-75.48645, -0.5013741, -5.081299" /> <!-- Vorsaile Heuloix -->
                     <TurnIn QuestId="66280" NpcId="1000168" ItemId="2000596" XYZ="-75.48645, -0.5013741, -5.081299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10087,6 +10411,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66282" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10117,6 +10442,7 @@
                 <If Condition="GetQuestStep(66283) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66283" NpcId="1006196" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10142,6 +10468,7 @@
                 <If Condition="GetQuestStep(66287) == 255">
                     <GetTo ZoneId="145" XYZ="-67.27704, -20.29624, -3.006042" /> <!-- Halmhart -->
                     <TurnInPlus QuestId="66287" NpcId="1006209" XYZ="-67.27704, -20.29624, -3.006042" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10163,6 +10490,7 @@
                 <If Condition="GetQuestStep(66286) == 255">
                     <GetTo ZoneId="145" XYZ="-91.26422, -28.91589, -60.28845" /> <!-- Gogoshu -->
                     <TurnIn QuestId="66286" NpcId="1006208" XYZ="-91.26422, -28.91589, -60.28845" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10191,6 +10519,7 @@
                 <If Condition="GetQuestStep(66285) == 255">
                     <GetTo ZoneId="145" XYZ="-65.50708, -33.1637, -54.52057" /> <!-- Claudien -->
                     <TurnIn QuestId="66285" NpcId="1006207" XYZ="-65.50708, -33.1637, -54.52057" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10214,6 +10543,7 @@
                 <If Condition="GetQuestStep(66284) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66284" NpcId="1006196" ItemId="2000602" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10235,6 +10565,7 @@
                 <If Condition="GetQuestStep(66288) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66288" NpcId="1006196" ItemId="2000601" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10288,6 +10619,7 @@
                 <If Condition="GetQuestStep(66289) == 255">
                     <GetTo ZoneId="145" XYZ="244.7089, 9.268953, -271.5649" /> <!-- Kyokyozo -->
                     <TurnIn QuestId="66289" NpcId="1006210" ItemId="2000602" XYZ="244.7089, 9.268953, -271.5649" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10309,6 +10641,7 @@
                 <If Condition="GetQuestStep(66290) == 255">
                     <GetTo ZoneId="145" XYZ="244.7089, 9.268953, -271.5649" /> <!-- Kyokyozo -->
                     <TurnIn QuestId="66290" NpcId="1006210" XYZ="244.7089, 9.268953, -271.5649" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10326,6 +10659,7 @@
                 <If Condition="GetQuestStep(66291) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66291" NpcId="1006196" ItemId="2000603" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10349,6 +10683,7 @@
                 <If Condition="GetQuestStep(66292) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66292" NpcId="1006196" ItemId="2000935" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10370,6 +10705,7 @@
                 <If Condition="GetQuestStep(66293) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66293" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10393,6 +10729,7 @@
                 <If Condition="GetQuestStep(66294) == 255">
                     <GetTo ZoneId="146" XYZ="-217.4869, 26.25821, -361.2574" /> <!-- Hihira -->
                     <TurnIn QuestId="66294" NpcId="1006211" ItemId="2000607" XYZ="-217.4869, 26.25821, -361.2574" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10428,6 +10765,7 @@
                 <If Condition="GetQuestStep(66295) == 255">
                     <GetTo ZoneId="146" XYZ="-217.4869, 26.25821, -361.2574" /> <!-- Hihira -->
                     <TurnIn QuestId="66295" NpcId="1006211" XYZ="-217.4869, 26.25821, -361.2574" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10457,6 +10795,7 @@
                 <If Condition="GetQuestStep(66296) == 255">
                     <GetTo ZoneId="146" XYZ="-138.8724, 27.26698, -427.8173" /> --> <!-- Annabel -->
                     <!-- <TurnIn QuestId="66296" NpcId="1004894" XYZ="-138.8724, 27.26698, -427.8173" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10480,6 +10819,7 @@
                 <If Condition="GetQuestStep(66297) == 255">
                     <GetTo ZoneId="146" XYZ="-181.0483, 28.21407, -402.0295" /> <!-- Gisilbehrt -->
                     <TurnIn QuestId="66297" NpcId="1006217" XYZ="-181.0483, 28.21407, -402.0295" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10506,6 +10846,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66298" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10551,6 +10892,7 @@
                 <If Condition="GetQuestStep(66299) == 255">
                     <GetTo ZoneId="153" XYZ="193.5302, 7.855128, -25.86407" /> <!-- Albreda -->
                     <TurnIn QuestId="66299" NpcId="1006219" XYZ="193.5302, 7.855128, -25.86407" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10578,6 +10920,7 @@
                 <If Condition="GetQuestStep(66302) == 255">
                     <GetTo ZoneId="153" XYZ="176.4401, 8.926453, -43.01526" /> <!-- Balan -->
                     <TurnIn QuestId="66302" NpcId="1000334" XYZ="176.4401, 8.926453, -43.01526" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10599,6 +10942,7 @@
                 <If Condition="GetQuestStep(66303) == 255">
                     <GetTo ZoneId="153" XYZ="158.4955, 18.12, -49.39355" /> <!-- Hihira -->
                     <TurnIn QuestId="66303" NpcId="1000331" XYZ="158.4955, 18.12, -49.39355" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10633,6 +10977,7 @@
                 <If Condition="GetQuestStep(66304) == 255">
                     <GetTo ZoneId="153" XYZ="213.0922, 29.49561, -164.5686" /> <!-- Fawkes -->
                     <TurnIn QuestId="66304" NpcId="1006237" ItemId="2000608" XYZ="213.0922, 29.49561, -164.5686" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10654,6 +10999,7 @@
                 <If Condition="GetQuestStep(66305) == 255">
                     <GetTo ZoneId="153" XYZ="150.1639, 8.795548, -56.32111" /> <!-- Castellaint -->
                     <TurnIn QuestId="66305" NpcId="1001186" ItemId="2000857" XYZ="150.1639, 8.795548, -56.32111" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10676,6 +11022,7 @@
                 <If Condition="GetQuestStep(66307) == 255">
                     <GetTo ZoneId="153" XYZ="151.7509, 11.64258, -73.25861" /> --> <!-- Cuthbert -->
                     <!-- <TurnIn QuestId="66307" NpcId="1000328" ItemId="2000609" XYZ="151.7509, 11.64258, -73.25861" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10694,6 +11041,7 @@
                 <If Condition="GetQuestStep(66308) == 255">
                     <GetTo ZoneId="153" XYZ="277.5157, 11.18631, -255.6039" /> --> <!-- Erimmont -->
                     <!-- <TurnIn QuestId="66308" NpcId="1000340" XYZ="277.5157, 11.18631, -255.6039" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10730,6 +11078,7 @@
                 <If Condition="GetQuestStep(66309) == 255">
                     <GetTo ZoneId="153" XYZ="197.7722, 7.855124, -22.14087" /> --> <!-- Aedoc -->
                     <!-- <TurnIn QuestId="66309" NpcId="1006238" ItemId="2000611" XYZ="197.7722, 7.855124, -22.14087" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10761,6 +11110,7 @@
                 <If Condition="GetQuestStep(66306) == 255">
                     <GetTo ZoneId="153" XYZ="150.286, 11.21873, -72.58722" /> <!-- Faucertaux -->
                     <TurnIn QuestId="66306" NpcId="1000420" XYZ="150.286, 11.21873, -72.58722" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10786,6 +11136,7 @@
                 <If Condition="GetQuestStep(66301) == 255">
                     <GetTo ZoneId="153" XYZ="207.7821, 6.103813, -39.53619" /> <!-- Meffrid -->
                     <TurnIn QuestId="66301" NpcId="1000332" XYZ="207.7821, 6.103813, -39.53619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10828,6 +11179,7 @@
                 <If Condition="GetQuestStep(66310) == 255">
                     <GetTo ZoneId="153" XYZ="209.308, 6.104166, -39.93292" /> <!-- Faramund -->
                     <TurnIn QuestId="66310" NpcId="1006680" ItemId="2000613" XYZ="209.308, 6.104166, -39.93292" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10862,6 +11214,7 @@
                 <If Condition="GetQuestStep(66311) == 255">
                     <GetTo ZoneId="153" XYZ="207.7821, 6.103813, -39.53619" /> <!-- Meffrid -->
                     <TurnIn QuestId="66311" NpcId="1000332" XYZ="207.7821, 6.103813, -39.53619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10879,6 +11232,7 @@
                 <If Condition="GetQuestStep(66312) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66312" NpcId="1006215" ItemId="2000614" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10912,6 +11266,7 @@
                 <If Condition="GetQuestStep(66316) == 255">
                     <GetTo ZoneId="146" XYZ="-218.6771, 26.13836, -352.9565" /> --> <!-- Amelot -->
                     <!-- <TurnIn QuestId="66316" NpcId="1006227" ItemId="2000615" XYZ="-218.6771, 26.13836, -352.9565" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10942,6 +11297,7 @@
                 <If Condition="GetQuestStep(66317) == 255">
                     <GetTo ZoneId="146" XYZ="-218.6771, 26.13836, -352.9565" /> --> <!-- Amelot -->
                     <!-- <TurnIn QuestId="66317" NpcId="1006227" ItemId="2000973" XYZ="-218.6771, 26.13836, -352.9565" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10966,6 +11322,7 @@
                 <If Condition="GetQuestStep(66313) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66313" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10992,6 +11349,7 @@
                 <If Condition="GetQuestStep(66314) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66314" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11013,6 +11371,7 @@
                 <If Condition="GetQuestStep(66315) == 255">
                     <GetTo ZoneId="146" XYZ="-225.9709, 26.13847, -355.0622" /> <!-- Hremfing -->
                     <TurnIn QuestId="66315" NpcId="1006226" XYZ="-225.9709, 26.13847, -355.0622" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11058,6 +11417,7 @@
                 <If Condition="GetQuestStep(66318) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66318" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11084,6 +11444,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66319" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11140,6 +11501,7 @@
                     <GetTo ZoneId="154" XYZ="13.93146, -44.8656, 257.9537" /> <!-- Medrod -->
                     <RunCode Name="Terror_at_Fallgourd" />
                     <TurnIn QuestId="66320" NpcId="1006240" XYZ="13.93146, -44.8656, 257.9537" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11177,6 +11539,7 @@
                 <If Condition="GetQuestStep(66324) == 255">
                     <GetTo ZoneId="154" XYZ="-26.64343, -40.70508, 174.4357" /> <!-- Aeluuin -->
                     <TurnIn QuestId="66324" NpcId="1002804" ItemId="2000618" XYZ="-26.2608, -40.70508, 172.7473" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11203,6 +11566,7 @@
                 <If Condition="GetQuestStep(66328) == 255">
                     <GetTo ZoneId="154" XYZ="-26.2608, -40.70508, 172.7473" /> <!-- Aeluuin -->
                     <TurnIn QuestId="66328" NpcId="1002804" XYZ="-26.2608, -40.70508, 172.7473" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11228,6 +11592,7 @@
                 <If Condition="GetQuestStep(66329) == 255">
                     <GetTo ZoneId="154" XYZ="-26.2608, -40.70508, 172.747" /> <!-- Aeluuin -->
                     <TurnIn QuestId="66329" NpcId="1002804" XYZ="-26.2608, -40.70508, 172.7473" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11251,6 +11616,7 @@
                 <If Condition="GetQuestStep(66332) == 255">
                     <GetTo ZoneId="154" XYZ="-26.2608, -40.70508, 172.7473" /> <!-- Aeluuin -->
                     <TurnIn QuestId="66332" NpcId="1002804" XYZ="-26.2608, -40.70508, 172.7473" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11268,6 +11634,7 @@
                 <If Condition="GetQuestStep(66325) == 255">
                     <GetTo ZoneId="154" XYZ="-301.0452, -13.60442, 198.4435" /> <!-- Vortefaurt -->
                     <TurnIn QuestId="66325" NpcId="1006371" ItemId="2000619" XYZ="-301.0452, -13.60442, 198.4435" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11295,6 +11662,7 @@
                 <If Condition="GetQuestStep(66326) == 255">
                     <GetTo ZoneId="154" XYZ="-293.7209, -14.4053, 204.2419" /> <!-- Oriane -->
                     <TurnIn QuestId="66326" NpcId="1006248" XYZ="-293.7209, -14.4053, 204.2419" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11316,6 +11684,7 @@
                 <If Condition="GetQuestStep(66327) == 255">
                     <GetTo ZoneId="154" XYZ="-29.89246, -40.70508, 176.9589" /> <!-- Yhom Epocan -->
                     <TurnIn QuestId="66327" NpcId="1006685" ItemId="2000622" XYZ="-29.89246, -40.70508, 176.9589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11337,6 +11706,7 @@
                 <If Condition="GetQuestStep(66330) == 255">
                     <GetTo ZoneId="154" XYZ="-23.72784, -40.25083, 174.8835" /> <!-- Gogolata -->
                     <TurnIn QuestId="66330" NpcId="1002800" XYZ="-23.72784, -40.25083, 174.8835" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11359,6 +11729,7 @@
                 <If Condition="GetQuestStep(66331) == 255">
                     <GetTo ZoneId="154" XYZ="-23.72784, -40.25083, 174.8835" /> --> <!-- Gogolata -->
                     <!-- <TurnIn QuestId="66331" NpcId="1002800" ItemId="2000625" XYZ="-23.72784, -40.25083, 174.8835" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11380,6 +11751,7 @@
                 <If Condition="GetQuestStep(66333) == 255">
                     <GetTo ZoneId="154" XYZ="-246.479, -31.5372, 392.5382" /> <!-- Ademar -->
                     <TurnIn QuestId="66333" NpcId="1006258" ItemId="2000628" XYZ="-246.479, -31.5372, 392.5382" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11407,6 +11779,7 @@
                 <If Condition="GetQuestStep(66334) == 255">
                     <GetTo ZoneId="154" XYZ="-246.479, -31.5372, 392.5382" /> <!-- Ademar -->
                     <TurnIn QuestId="66334" NpcId="1006258" ItemId="2000628" XYZ="-246.479, -31.5372, 392.5382" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11428,6 +11801,7 @@
                 <If Condition="GetQuestStep(66321) == 255">
                     <GetTo ZoneId="154" XYZ="15.3963, -44.8656, 259.327" /> <!-- Aideen -->
                     <TurnIn QuestId="66321" NpcId="1006241" XYZ="15.3963, -44.8656, 259.327" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11449,6 +11823,7 @@
                 <If Condition="GetQuestStep(66322) == 255">
                     <GetTo ZoneId="154" XYZ="13.96191, -44.8656, 255.1461" /> <!-- Ivaurault -->
                     <TurnIn QuestId="66322" NpcId="1006242" XYZ="13.96191, -44.8656, 255.1461" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11482,6 +11857,7 @@
                 <If Condition="GetQuestStep(66323) == 255">
                     <GetTo ZoneId="154" XYZ="15.3963, -44.8656, 259.327" /> <!-- Aideen -->
                     <TurnIn QuestId="66323" NpcId="1006241" ItemId="2000617" XYZ="15.3963, -44.8656, 259.327" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11503,6 +11879,7 @@
                 <If Condition="GetQuestStep(66335) == 255">
                     <GetTo ZoneId="154" XYZ="-89.22339, -45.33137, 197.5893" /> <!-- Aethelmaer -->
                     <TurnIn QuestId="66335" NpcId="1002780" ItemId="2000861" XYZ="-89.79938, -45.33138, 195.88" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11532,6 +11909,7 @@
                 <If Condition="GetQuestStep(66336) == 255">
                     <GetTo ZoneId="133" XYZ="36.81995, 16.35147, -334.5846" /> <!-- Ursandel -->
                     <TurnIn QuestId="66336" NpcId="1006263" ItemId="2000630" XYZ="36.81995, 16.35147, -334.5846" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11570,6 +11948,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66337" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11604,6 +11983,7 @@
                 <If Condition="GetQuestStep(66340) == 255">
                     <GetTo ZoneId="148" XYZ="-244.7394, 58.69352, -140.0626" /> <!-- Marcette -->
                     <TurnIn QuestId="66340" NpcId="1006261" ItemId="2000631" XYZ="-244.7394, 58.69352, -140.0626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11625,6 +12005,7 @@
                 <If Condition="GetQuestStep(66341) == 255">
                     <GetTo ZoneId="148" XYZ="-244.7394, 58.69352, -140.0626" /> <!-- Marcette -->
                     <TurnIn QuestId="66341" NpcId="1006261" ItemId="2000633" XYZ="-244.7394, 58.69352, -140.0626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11647,6 +12028,7 @@
                 <If Condition="GetQuestStep(66343) == 255">
                     <GetTo ZoneId="148" XYZ="-244.7394, 58.69352, -140.0626" /> --> <!-- Marcette -->
                     <!-- <TurnIn QuestId="66343" NpcId="1006261" ItemId="2000862" XYZ="-244.7394, 58.69352, -140.0626" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11675,6 +12057,7 @@
                 <If Condition="GetQuestStep(66342) == 255">
                     <GetTo ZoneId="148" XYZ="-243.7019, 58.71083, -141.4969" /> --> <!-- Hobriaut -->
                     <!-- <TurnIn QuestId="66342" NpcId="1006262" ItemId="2000634" XYZ="-243.7019, 58.71083, -141.4969" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11692,6 +12075,7 @@
                 <If Condition="GetQuestStep(66338) == 255">
                     <GetTo ZoneId="132" XYZ="-114.3665, -7.351946, 94.52954" /> <!-- Franchemontiaux -->
                     <TurnIn QuestId="66338" NpcId="1000171" ItemId="2000791" XYZ="-114.3665, -7.351946, 94.52954" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11723,6 +12107,7 @@
                 <If Condition="GetQuestStep(66339) == 255">
                     <GetTo ZoneId="148" XYZ="-221.8815, 54.40659, -126.2684" /> <!-- Thievenaix -->
                     <TurnIn QuestId="66339" NpcId="1006260" XYZ="-221.8815, 54.40659, -126.2684" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11820,6 +12205,7 @@
                 <If Condition="GetQuestStep(66238) == 255">
                     <GetTo ZoneId="130" XYZ="55.34448, 4.124078, -143.9079" /> <!-- Mimigun -->
                     <TurnIn QuestId="66238" NpcId="1001978" XYZ="55.34448, 4.124078, -143.9079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11865,6 +12251,7 @@
                 <If Condition="GetQuestStep(66698) == 255">
                     <GetTo ZoneId="148" XYZ="-60.47156, 0.2, 6.301941" /> <!-- Luquelot -->
                     <TurnIn QuestId="66698" NpcId="1000471" XYZ="-60.47156, 0.2, 6.301941" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11895,6 +12282,7 @@
                 <If Condition="GetQuestStep(66052) == 255">
                     <GetTo ZoneId="135" XYZ="710.9025, 66.027, -277.6685" /> <!-- Trachtoum -->
                     <TurnIn QuestId="66052" NpcId="1006264" XYZ="710.9025, 66.027, -277.6685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11916,6 +12304,7 @@
                 <If Condition="GetQuestStep(66345) == 255">
                     <GetTo ZoneId="135" XYZ="710.9025, 66.027, -277.6685" /> <!-- Trachtoum -->
                     <TurnIn QuestId="66345" NpcId="1006264" XYZ="710.9025, 66.027, -277.6685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11937,6 +12326,7 @@
                 <If Condition="GetQuestStep(66346) == 255">
                     <GetTo ZoneId="135" XYZ="710.9025, 66.027, -277.6685" /> <!-- Trachtoum -->
                     <TurnIn QuestId="66346" NpcId="1006264" XYZ="710.9025, 66.027, -277.6685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11983,6 +12373,7 @@
                 <If Condition="GetQuestStep(66347) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66347" NpcId="1006266" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12011,6 +12402,7 @@
                 <If Condition="GetQuestStep(66349) == 255">
                     <GetTo ZoneId="137" XYZ="619.0126, 23.93624, 455.1002" /> <!-- Gegeruju -->
                     <TurnIn QuestId="66349" NpcId="1006273" XYZ="619.0126, 23.93624, 455.1002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12037,6 +12429,7 @@
                 <If Condition="GetQuestStep(66348) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66348" NpcId="1006266" ItemId="2000637" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12054,6 +12447,7 @@
                 <If Condition="GetQuestStep(66350) == 255">
                     <GetTo ZoneId="153" XYZ="-231.4336, 21.51271, 339.4979" /> <!-- Landenel -->
                     <TurnIn QuestId="66350" NpcId="1006279" XYZ="-231.4336, 21.51271, 339.4979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12076,6 +12470,7 @@
                 <If Condition="GetQuestStep(66353) == 255">
                     <GetTo ZoneId="153" XYZ="-230.9453, 21.49154, 338.2467" /> <!-- Detoh Moshroca -->
                     <TurnIn QuestId="66353" NpcId="1006283" ItemId="2000639" XYZ="-230.9453, 21.49154, 338.2467" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12101,6 +12496,7 @@
                 <If Condition="GetQuestStep(66354) == 255">
                     <GetTo ZoneId="153" XYZ="-203.6927, 20.95964, 367.3304" /> <!-- Florent -->
                     <TurnIn QuestId="66354" NpcId="1002762" ItemId="2000640" XYZ="-203.6927, 20.95964, 367.3304" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12128,6 +12524,7 @@
                 <If Condition="GetQuestStep(66351) == 255">
                     <GetTo ZoneId="153" XYZ="-231.4336, 21.51271, 339.4979" /> <!-- Landenel -->
                     <TurnIn QuestId="66351" NpcId="1006279" ItemId="2000638" XYZ="-231.4336, 21.51271, 339.4979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12151,6 +12548,7 @@
                 <If Condition="GetQuestStep(66352) == 255">
                     <GetTo ZoneId="153" XYZ="-231.4336, 21.51271, 339.4979" /> <!-- Landenel -->
                     <TurnIn QuestId="66352" NpcId="1006279" XYZ="-231.4336, 21.51271, 339.4979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12180,6 +12578,7 @@
                 <If Condition="GetQuestStep(66355) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66355" NpcId="1004917" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12214,6 +12613,7 @@
                 <If Condition="GetQuestStep(66359) == 255">
                     <GetTo ZoneId="146" XYZ="-354.6655, 8.469922, 416.8002" /> <!-- U'tykha Tia -->
                     <TurnIn QuestId="66359" NpcId="1006287" XYZ="-354.6655, 8.469922, 416.8002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12239,6 +12639,7 @@
                 <If Condition="GetQuestStep(66365) == 255">
                     <GetTo ZoneId="146" XYZ="-354.6655, 8.469922, 416.8002" /> <!-- U'tykha Tia -->
                     <TurnIn QuestId="66365" NpcId="1006287" XYZ="-354.6655, 8.469922, 416.8002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12272,6 +12673,7 @@
                 <If Condition="GetQuestStep(66366) == 255">
                     <GetTo ZoneId="146" XYZ="-354.6655, 8.469922, 416.8002" /> <!-- U'tykha Tia -->
                     <TurnIn QuestId="66366" NpcId="1006287" XYZ="-354.6655, 8.469922, 416.8002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12295,6 +12697,7 @@
                 <If Condition="GetQuestStep(66360) == 255">
                     <GetTo ZoneId="146" XYZ="-361.41, 8.465333, 426.1385" /> <!-- U'khuba Tia -->
                     <TurnIn QuestId="66360" NpcId="1006288" XYZ="-361.41, 8.465333, 426.1385" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12316,6 +12719,7 @@
                 <If Condition="GetQuestStep(66361) == 255">
                     <GetTo ZoneId="146" XYZ="-361.41, 8.465333, 426.1385" /> <!-- U'khuba Tia -->
                     <TurnIn QuestId="66361" NpcId="1006288" ItemId="2000646" XYZ="-361.41, 8.465333, 426.1385" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12333,6 +12737,7 @@
                 <If Condition="GetQuestStep(66362) == 255">
                     <GetTo ZoneId="146" XYZ="-111.9249, -10.8135, 722.6825" /> <!-- Odinel -->
                     <TurnIn QuestId="66362" NpcId="1006294" ItemId="2000851" XYZ="-111.9249, -10.8135, 722.6825" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12368,6 +12773,7 @@
                 <If Condition="GetQuestStep(66363) == 255">
                     <GetTo ZoneId="146" XYZ="-113.5119, -10.75769, 723.5979" /> <!-- Mumugoi -->
                     <TurnIn QuestId="66363" NpcId="1006295" XYZ="-113.5119, -10.75769, 723.5979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12398,6 +12804,7 @@
                 <If Condition="GetQuestStep(66364) == 255">
                     <GetTo ZoneId="146" XYZ="-272.8771, 5, 474.296" /> <!-- U'rahtalo -->
                     <TurnIn QuestId="66364" NpcId="1006296" XYZ="-272.8771, 5, 474.296" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12419,6 +12826,7 @@
                 <If Condition="GetQuestStep(66356) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66356" NpcId="1004917" ItemId="2000642" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12444,6 +12852,7 @@
                 <If Condition="GetQuestStep(66357) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66357" NpcId="1004917" ItemId="2000644" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12473,6 +12882,7 @@
                 <If Condition="GetQuestStep(66358) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66358" NpcId="1004917" ItemId="2000833" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12490,6 +12900,7 @@
                 <If Condition="GetQuestStep(66367) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66367" NpcId="1006266" ItemId="2000649" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12536,6 +12947,7 @@
                 <If Condition="GetQuestStep(66368) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66368" NpcId="1006266" ItemId="2000864" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12569,6 +12981,7 @@
                 <If Condition="GetQuestStep(66369) == 255">
                     <GetTo ZoneId="137" XYZ="603.2349, 23.93624, 454.7036" /> <!-- Kuzai Tazai -->
                     <TurnIn QuestId="66369" NpcId="1006269" XYZ="603.2349, 23.93624, 454.7036" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12596,6 +13009,7 @@
                 <If Condition="GetQuestStep(66370) == 255">
                     <GetTo ZoneId="137" XYZ="603.2349, 23.93624, 454.7036" /> --> <!-- Kuzai Tazai -->
                     <!-- <TurnIn QuestId="66370" NpcId="1006269" XYZ="603.2349, 23.93624, 454.7036" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -12619,6 +13033,7 @@
                 <If Condition="GetQuestStep(66371) == 255">
                     <GetTo ZoneId="137" XYZ="603.2654, 23.93624, 455.9548" /> <!-- Fyrilsunn -->
                     <TurnIn QuestId="66371" NpcId="1006270" XYZ="603.2654, 23.93624, 455.9548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12653,6 +13068,7 @@
                 <If Condition="GetQuestStep(66374) == 255">
                     <GetTo ZoneId="137" XYZ="603.2654, 23.93624, 455.9548" /> <!-- Fyrilsunn -->
                     <TurnIn QuestId="66374" NpcId="1006270" ItemId="2000652" XYZ="603.2654, 23.93624, 455.9548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12674,6 +13090,7 @@
                 <If Condition="GetQuestStep(66372) == 255">
                     <GetTo ZoneId="137" XYZ="617.9751, 23.93624, 456.8702" /> <!-- P'ebaloh -->
                     <TurnIn QuestId="66372" NpcId="1006271" XYZ="617.9751, 23.93624, 456.8702" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12701,6 +13118,7 @@
                 <If Condition="GetQuestStep(66373) == 255">
                     <GetTo ZoneId="137" XYZ="617.9751, 23.93624, 456.8702" /> <!-- P'ebaloh -->
                     <TurnIn QuestId="66373" NpcId="1006271" XYZ="617.9751, 23.93624, 456.8702" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12722,6 +13140,7 @@
                 <If Condition="GetQuestStep(66377) == 255">
                     <GetTo ZoneId="137" XYZ="-24.42969, 71.754, -36.82013" /> <!-- Etgar -->
                     <TurnIn QuestId="66377" NpcId="1006307" XYZ="-24.42969, 71.754, -36.82013" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12743,6 +13162,7 @@
                 <If Condition="GetQuestStep(66375) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66375" NpcId="1006305" ItemId="2000653" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12764,6 +13184,7 @@
                 <If Condition="GetQuestStep(66376) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66376" NpcId="1006305" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12785,6 +13206,7 @@
                 <If Condition="GetQuestStep(66378) == 255">
                     <GetTo ZoneId="137" XYZ="-25.86407, 71.75401, -36.78955" /> <!-- Byrglaent -->
                     <TurnIn QuestId="66378" NpcId="1006306" ItemId="2000654" XYZ="-25.86407, 71.75401, -36.78955" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12807,6 +13229,7 @@
                 <If Condition="GetQuestStep(66379) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66379" NpcId="1006305" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12841,6 +13264,7 @@
                 <If Condition="GetQuestStep(66380) == 255">
                     <GetTo ZoneId="137" XYZ="-24.42969, 71.754, -36.82013" /> <!-- Etgar -->
                     <TurnIn QuestId="66380" NpcId="1006307" XYZ="-24.42969, 71.754, -36.82013" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12862,6 +13286,7 @@
                 <If Condition="GetQuestStep(66385) == 255">
                     <GetTo ZoneId="137" XYZ="-24.42969, 71.754, -36.82013" /> <!-- Etgar -->
                     <TurnIn QuestId="66385" NpcId="1006307" XYZ="-24.42969, 71.754, -36.82013" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12889,6 +13314,7 @@
                 <If Condition="GetQuestStep(66389) == 255">
                     <GetTo ZoneId="137" XYZ="617.9751, 23.93624, 456.8702" /> <!-- P'ebaloh -->
                     <TurnIn QuestId="66389" NpcId="1006271" XYZ="617.9751, 23.93624, 456.8702" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12914,6 +13340,7 @@
                 <If Condition="GetQuestStep(66387) == 255">
                     <GetTo ZoneId="137" XYZ="619.0126, 23.93624, 455.1002" /> <!-- Gegeruju -->
                     <TurnIn QuestId="66387" NpcId="1006273" XYZ="619.0126, 23.93624, 455.1002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12950,6 +13377,7 @@
                 <If Condition="GetQuestStep(66388) == 255">
                     <GetTo ZoneId="137" XYZ="619.0126, 23.93624, 455.1002" /> <!-- Y'shtola -->
                     <TurnIn QuestId="66388" NpcId="1006273" XYZ="619.0126, 23.93624, 455.1002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12971,6 +13399,7 @@
                 <If Condition="GetQuestStep(66381) == 255">
                     <GetTo ZoneId="137" XYZ="-369.0395, 54.28072, 441.2451" /> <!-- Drest -->
                     <TurnIn QuestId="66381" NpcId="1006312" ItemId="2000655" XYZ="-369.0395, 54.28072, 441.2451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12992,6 +13421,7 @@
                 <If Condition="GetQuestStep(66382) == 255">
                     <GetTo ZoneId="137" XYZ="-369.0395, 54.28072, 441.2451" /> <!-- Drest -->
                     <TurnIn QuestId="66382" NpcId="1006312" XYZ="-369.0395, 54.28072, 441.2451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13013,6 +13443,7 @@
                 <If Condition="GetQuestStep(66383) == 255">
                     <GetTo ZoneId="137" XYZ="-369.0395, 54.28072, 441.2451" /> <!-- Drest -->
                     <TurnIn QuestId="66383" NpcId="1006312" ItemId="2000656" XYZ="-369.0395, 54.28072, 441.2451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13041,6 +13472,7 @@
                 <If Condition="GetQuestStep(66384) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66384" NpcId="1006305" ItemId="2000657" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13070,6 +13502,7 @@
                 <If Condition="GetQuestStep(66386) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66386" NpcId="1006266" ItemId="2000659" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13109,6 +13542,7 @@
                 <If Condition="GetQuestStep(66390) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66390" NpcId="1006266" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13142,6 +13576,7 @@
                 <If Condition="GetQuestStep(66391) == 255">
                     <GetTo ZoneId="137" XYZ="558.9838, 20.70648, 451.1329" /> <!-- Y'shtola -->
                     <TurnIn QuestId="66391" NpcId="1006676" XYZ="558.9838, 20.70648, 451.1329" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13169,6 +13604,7 @@
                 <If Condition="GetQuestStep(66392) == 255">
                     <GetTo ZoneId="139" XYZ="479.3926, 16.2587, 128.3741" /> <!-- Riol -->
                     <TurnIn QuestId="66392" NpcId="1006341" XYZ="479.3926, 16.2587, 128.3741" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13207,6 +13643,7 @@
                 <If Condition="GetQuestStep(66393) == 255">
                     <GetTo ZoneId="139" XYZ="427.634, 4.115109, 85.92346" /> <!-- Y'shtola -->
                     <TurnIn QuestId="66393" NpcId="1006343" XYZ="427.634, 4.115109, 85.92346" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13239,6 +13676,7 @@
                 <If Condition="GetQuestStep(66403) == 255">
                     <GetTo ZoneId="139" XYZ="426.1385, 7.933096, 19.63837" /> <!-- A'rhunlika -->
                     <TurnIn QuestId="66403" NpcId="1006333" XYZ="426.1385, 7.933096, 19.63837" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13280,6 +13718,7 @@
                 <If Condition="GetQuestStep(66402) == 255">
                     <GetTo ZoneId="139" XYZ="426.9626, 8.373348, 20.00452" /> <!-- Rukusa Farusa -->
                     <TurnIn QuestId="66402" NpcId="1006332" XYZ="426.9626, 8.373348, 20.00452" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13313,6 +13752,7 @@
                 <If Condition="GetQuestStep(66404) == 255">
                     <GetTo ZoneId="139" XYZ="426.9626, 8.373348, 20.00452" /> <!-- Rukusa Farusa -->
                     <TurnIn QuestId="66404" NpcId="1006332" XYZ="426.9626, 8.373348, 20.00452" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13330,6 +13770,7 @@
                 <If Condition="GetQuestStep(66394) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                     <TurnIn QuestId="66394" NpcId="1006325" ItemId="2000665" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13361,6 +13802,7 @@
                 <If Condition="GetQuestStep(66395) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                     <TurnIn QuestId="66395" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13391,6 +13833,7 @@
                 <If Condition="GetQuestStep(66397) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                     <TurnIn QuestId="66397" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13418,6 +13861,7 @@
                 <If Condition="GetQuestStep(66400) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                     <TurnIn QuestId="66400" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13450,6 +13894,7 @@
                 <If Condition="GetQuestStep(66401) == 255">
                     <GetTo ZoneId="139" XYZ="448.0505, 4.109103, 78.96533" /> <!-- Blaugybal -->
                     <TurnIn QuestId="66401" NpcId="1006324" ItemId="2000871" XYZ="448.0505, 4.109103, 78.96533" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13489,6 +13934,7 @@
                 <If Condition="GetQuestStep(66398) == 255">
                     <GetTo ZoneId="180" XYZ="-144.152, 64.98994, -209.8879" /> <!-- Swygrael -->
                     <TurnIn QuestId="66398" NpcId="1006331" ItemId="2000929,2000669" XYZ="-144.152, 64.98994, -209.8879" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13510,6 +13956,7 @@
                 <If Condition="GetQuestStep(66399) == 255">
                     <GetTo ZoneId="180" XYZ="-144.152, 64.98994, -209.8879" /> <!-- Swygrael -->
                     <TurnIn QuestId="66399" NpcId="1006331" ItemId="2000671" XYZ="-144.152, 64.98994, -209.8879" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13531,6 +13978,7 @@
                 <If Condition="GetQuestStep(66396) == 255">
                     <GetTo ZoneId="180" XYZ="-104.1428, 62.55459, -157.4884" /> <!-- Augustine -->
                     <TurnIn QuestId="66396" NpcId="1006330" XYZ="-104.1428, 62.55459, -157.4884" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13580,6 +14028,7 @@
 
                     <GetTo ZoneId="145" XYZ="-512.4742, -16.42, -7.522766" /> <!-- Iliud -->
                     <TurnInPlus QuestId="66053" NpcId="1006355" XYZ="-512.4742, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13662,6 +14111,7 @@
                 <If Condition="GetQuestStep(66409) == 255">
                     <GetTo ZoneId="145" XYZ="-512.4742, -16.42, -7.522766" /> <!-- Iliud -->
                     <TurnIn QuestId="66409" NpcId="1006355" XYZ="-512.4742, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13683,6 +14133,7 @@
                 <If Condition="GetQuestStep(66416) == 255">
                     <GetTo ZoneId="145" XYZ="-500.3586, -17.40184, 4.470825" /> <!-- Dedeju -->
                     <TurnIn QuestId="66416" NpcId="1006365" ItemId="2000687" XYZ="-500.3586, -17.40184, 4.470825" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13704,6 +14155,7 @@
                 <If Condition="GetQuestStep(66410) == 255">
                     <GetTo ZoneId="145" XYZ="-498.3444, -17.37556, -2.548279" /> <!-- Barryn -->
                     <TurnIn QuestId="66410" NpcId="1006360" XYZ="-498.3444, -17.37556, -2.548279" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13734,6 +14186,7 @@
                 <If Condition="GetQuestStep(66411) == 255">
                     <GetTo ZoneId="145" XYZ="-498.3444, -17.37556, -2.548279" /> <!-- Barryn -->
                     <TurnIn QuestId="66411" NpcId="1006360" XYZ="-498.3444, -17.37556, -2.548279" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13757,6 +14210,7 @@
                 <If Condition="GetQuestStep(66415) == 255">
                     <GetTo ZoneId="145" XYZ="-512.932, -17.38352, 24.67383" /> <!-- Fuandrec-->
                     <TurnIn QuestId="66415" NpcId="1006363" XYZ="-512.932, -17.38352, 24.67383" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13774,6 +14228,7 @@
                 <If Condition="GetQuestStep(66300) == 255">
                     <GetTo ZoneId="146" XYZ="185.748, 13.7212, -443.1983" /> <!-- Bibimu -->
                     <TurnIn QuestId="66300" NpcId="1006220" XYZ="185.748, 13.7212, -443.1983" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13805,6 +14260,7 @@
                 <If Condition="GetQuestStep(66408) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66408" NpcId="1003958" ItemId="2000680" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13831,6 +14287,7 @@
                     </If>
                     <GetTo ZoneId="145" XYZ="-509.3614, -16.42, -7.522766" /> <!-- Marques -->
                     <TurnIn QuestId="66407" NpcId="1006672" ItemId="2394" XYZ="-509.3614, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13856,6 +14313,7 @@
                 <If Condition="GetQuestStep(66417) == 255">
                     <GetTo ZoneId="145" XYZ="-509.3614, -16.42, -7.522766" /> <!-- Marques -->
                     <TurnIn QuestId="66417" NpcId="1006672" ItemId="2000689" XYZ="-509.3614, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13907,6 +14365,7 @@
                 <If Condition="GetQuestStep(66412) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66412" NpcId="1003958" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13928,6 +14387,7 @@
                 <If Condition="GetQuestStep(66413) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66413" NpcId="1003958" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13949,6 +14409,7 @@
                 <If Condition="GetQuestStep(66414) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66414" NpcId="1003958" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13974,6 +14435,7 @@
                 <If Condition="GetQuestStep(66054) == 255">
                     <GetTo ZoneId="145" XYZ="-512.4742, -16.42, -7.522766" /> <!-- Iliud -->
                     <TurnIn QuestId="66054" NpcId="1006355" ItemId="2000850" XYZ="-512.4742, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14008,6 +14470,7 @@
                 <If Condition="GetQuestStep(66419) == 255">
                     <GetTo ZoneId="154" XYZ="-301.0452, -13.60442, 198.4435" /> <!-- Vortefaurt -->
                     <TurnIn QuestId="66419" NpcId="1006371" XYZ="-301.0452, -13.60442, 198.4435" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14029,6 +14492,7 @@
                 <If Condition="GetQuestStep(66421) == 255">
                     <GetTo ZoneId="154" XYZ="-296.6506, -13.63058, 197.3448" /> <!-- Idristan -->
                     <TurnIn QuestId="66421" NpcId="1006375" XYZ="-296.6506, -13.63058, 197.3448" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14062,6 +14526,7 @@
                 <If Condition="GetQuestStep(66747) == 255">
                     <GetTo ZoneId="139" XYZ="624.2312, -3.052744, 165.2704" /> <!-- Ealdwine -->
                     <TurnIn QuestId="66747" NpcId="1005528" ItemId="2001130,2001149" XYZ="624.2312, -3.052744, 165.2704" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14079,6 +14544,7 @@
                 <If Condition="GetQuestStep(66420) == 255">
                     <GetTo ZoneId="155" XYZ="171.5266, 222.6926, 355.4894" /> <!-- Ludovoix -->
                     <TurnIn QuestId="66420" NpcId="1006372" XYZ="171.5266, 222.6926, 355.4894" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14125,6 +14591,7 @@
                 <If Condition="GetQuestStep(66424) == 255">
                     <GetTo ZoneId="155" XYZ="172.9915, 222.0003, 314.3511" /> <!-- Maucolyn -->
                     <TurnIn QuestId="66424" NpcId="1006381" XYZ="172.9915, 222.0003, 314.3511" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14142,6 +14609,7 @@
                 <If Condition="GetQuestStep(66846) == 255">
                     <GetTo ZoneId="155" XYZ="241.5045, 222.2589, 325.4597" /> <!-- Portelaine -->
                     <TurnIn NpcId="1006385" QuestId="66846" XYZ="241.5045, 222.2589, 325.4597" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14163,6 +14631,7 @@
                 <If Condition="GetQuestStep(66427) == 255">
                     <GetTo ZoneId="155" XYZ="241.5045, 222.2589, 325.4597" /> <!-- Duvicauroix -->
                     <TurnIn NpcId="1006385" QuestId="66427" XYZ="241.5045, 222.2589, 325.4597" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14204,6 +14673,7 @@
                 <If Condition="GetQuestStep(66847) == 255">
                     <GetTo ZoneId="155" XYZ="241.5045, 222.2589, 325.4597" /> <!-- Portelaine -->
                     <TurnIn NpcId="1006385" QuestId="66847" XYZ="241.5045, 222.2589, 325.4597" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14236,6 +14706,7 @@
                 <If Condition="GetQuestStep(66428) == 255">
                     <GetTo ZoneId="155" XYZ="139.4521, 285.065, 176.8063" /> <!-- Stephannot -->
                     <TurnIn QuestId="66428" NpcId="1006386" ItemId="2000698" XYZ="139.4521, 285.065, 176.8063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14257,6 +14728,7 @@
                 <If Condition="GetQuestStep(66430) == 255">
                     <GetTo ZoneId="155" XYZ="139.4521, 285.065, 176.8063" /> <!-- Stephannot -->
                     <TurnIn QuestId="66430" NpcId="1006386" ItemId="2000701" XYZ="139.4521, 285.065, 176.8063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14274,6 +14746,7 @@
                 <If Condition="GetQuestStep(66431) == 255">
                     <GetTo ZoneId="155" XYZ="184.222, 319.0841, -238.3307" /> <!-- Theobalin -->
                     <TurnIn QuestId="66431" NpcId="1006392" ItemId="2000867" XYZ="184.222, 319.0841, -238.3307" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14302,6 +14775,7 @@
                 <If Condition="GetQuestStep(66429) == 255">
                     <GetTo ZoneId="155" XYZ="132.8602, 285.05, 178.8815" /> <!-- Sylvaintel -->
                     <TurnIn QuestId="66429" NpcId="1006387" XYZ="132.8602, 285.05, 178.8815" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14333,6 +14807,7 @@
                 <If Condition="GetQuestStep(66422) == 255">
                     <GetTo ZoneId="155" XYZ="190.2479, 293.33, 415.5793" /> <!-- Forlemort -->
                     <TurnIn QuestId="66422" NpcId="1006377" XYZ="200.9766, 293.33, 420.3707" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14358,6 +14833,7 @@
                 <If Condition="GetQuestStep(66423) == 255">
                     <GetTo ZoneId="155" XYZ="169.4819, 223.0354, 366.2623" /> <!-- Portelaine -->
                     <TurnIn QuestId="66423" NpcId="1006380" XYZ="169.4819, 223.0354, 366.2623" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14385,6 +14861,7 @@
                 <If Condition="GetQuestStep(66425) == 255">
                     <GetTo ZoneId="155" XYZ="169.4819, 223.0354, 366.2623" /> <!-- Portelaine -->
                     <TurnIn QuestId="66425" NpcId="1006380" ItemId="2000693,2000694,2000695" XYZ="169.4819, 223.0354, 366.2623" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14406,6 +14883,7 @@
                 <If Condition="GetQuestStep(66426) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66426" NpcId="1006384" ItemId="2000697" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14440,6 +14918,7 @@
                 <If Condition="GetQuestStep(66435) == 255">
                     <GetTo ZoneId="155" XYZ="263.8132, 303.1, -195.7885" /> <!-- Corentiaux -->
                     <TurnIn QuestId="66435" NpcId="1006400" ItemId="2000703" XYZ="263.8132, 303.1, -195.7885" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14461,6 +14940,7 @@
                 <If Condition="GetQuestStep(66436) == 255">
                     <GetTo ZoneId="155" XYZ="263.8132, 303.1, -195.7885" /> <!-- Corentiaux -->
                     <TurnIn QuestId="66436" NpcId="1006400" XYZ="263.8132, 303.1, -195.7885" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14490,6 +14970,7 @@
                 <If Condition="GetQuestStep(66438) == 255">
                     <GetTo ZoneId="155" XYZ="242.359, 325.3143, -151.4763" /> <!-- Arthurioux -->
                     <TurnIn QuestId="66438" NpcId="1006402" XYZ="242.359, 325.3143, -151.4763" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14513,6 +14994,7 @@
                 <If Condition="GetQuestStep(66439) == 255">
                     <GetTo ZoneId="155" XYZ="252.0027, 312, -261.738" /> <!-- Stephannot -->
                     <TurnIn QuestId="66439" NpcId="1006403" XYZ="252.0027, 312, -261.738" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14534,6 +15016,7 @@
                 <If Condition="GetQuestStep(66440) == 255">
                     <GetTo ZoneId="155" XYZ="252.0027, 312, -261.738" /> <!-- Belmont -->
                     <TurnIn QuestId="66440" NpcId="1006403" ItemId="2000707" XYZ="252.0027, 312, -261.738" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14551,6 +15034,7 @@
                 <If Condition="GetQuestStep(66441) == 255">
                     <GetTo ZoneId="154" XYZ="-32.76117, -40.70508, 179.2477" /> <!-- Isaudorel -->
                     <TurnIn QuestId="66441" NpcId="1006404" ItemId="2000708" XYZ="-32.76117, -40.70508, 179.2477" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14572,6 +15056,7 @@
                 <If Condition="GetQuestStep(66442) == 255">
                     <GetTo ZoneId="154" XYZ="-32.76117, -40.70508, 179.2477" /> <!-- Isaudorel -->
                     <TurnIn QuestId="66442" NpcId="1006404" XYZ="-32.76117, -40.70508, 179.2477" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14589,6 +15074,7 @@
                 <If Condition="GetQuestStep(66443) == 255">
                     <GetTo ZoneId="154" XYZ="63.15698, -13.3626, 140.917" /> <!-- Miah Molkot -->
                     <TurnIn QuestId="66443" NpcId="1006406" XYZ="63.15698, -13.3626, 140.917" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14610,6 +15096,7 @@
                 <If Condition="GetQuestStep(66444) == 255">
                     <GetTo ZoneId="154" XYZ="63.15698, -13.3626, 140.917" /> <!-- Miah Molkot -->
                     <TurnIn QuestId="66444" NpcId="1006406" XYZ="63.15698, -13.3626, 140.917" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14627,6 +15114,7 @@
                 <If Condition="GetQuestStep(66445) == 255">
                     <GetTo ZoneId="155" XYZ="252.0027, 312, -261.738" /> <!-- Belmont -->
                     <TurnIn QuestId="66445" NpcId="1006403" ItemId="2000710" XYZ="252.0027, 312, -261.738" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14648,6 +15136,7 @@
                 <If Condition="GetQuestStep(66451) == 255">
                     <GetTo ZoneId="155" XYZ="195.6969, 309.9871, -289.8757" /> <!-- Meduil -->
                     <TurnIn QuestId="66451" NpcId="1006432" ItemId="2000718" XYZ="195.6969, 309.9871, -289.8757" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14681,6 +15170,7 @@
                 <If Condition="GetQuestStep(66434) == 255">
                     <GetTo ZoneId="155" XYZ="205.0354, 310.015, -298.0544" /> <!-- Duchesnelt -->
                     <TurnIn QuestId="66434" NpcId="1006397" ItemId="2000702" XYZ="205.0354, 310.015, -298.0544" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14703,6 +15193,7 @@
                 <If Condition="GetQuestStep(66432) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66432" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14734,6 +15225,7 @@
                 <If Condition="GetQuestStep(66433) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66433" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14780,6 +15272,7 @@
                 <If Condition="GetQuestStep(66437) == 255">
                     <GetTo ZoneId="155" XYZ="257.8011, 303.1581, -204.4252" /> <!-- Yaelle -->
                     <TurnIn QuestId="66437" NpcId="1006401" XYZ="257.8011, 303.1581, -204.4252" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14802,6 +15295,7 @@
                 <If Condition="GetQuestStep(66452) == 255">
                     <GetTo ZoneId="155" XYZ="202.8076, 309.0734, -220.6913" /> <!-- Eugennoix -->
                     <TurnIn QuestId="66452" NpcId="1006433" ItemId="2000719" XYZ="202.8076, 309.0734, -220.6913" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14820,6 +15314,7 @@
                     <GetTo ZoneId="131" XYZ="138.3588, 4, -58.75545" /> <!-- Syntgoht -->
                     <RunCode Name="Wheres_My_Juice" />
                     <TurnIn QuestId="66454" NpcId="1001679" XYZ="140.4897, 4.009998, -59.80017" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14837,6 +15332,7 @@
                 <If Condition="GetQuestStep(66455) == 255">
                     <GetTo ZoneId="147" XYZ="-28.88544, 6.984501, 480.2776" /> <!-- Papawazu -->
                     <TurnIn QuestId="66455" NpcId="1006438" XYZ="-28.88544, 6.984501, 480.2776" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14872,6 +15368,7 @@
                 <If Condition="GetQuestStep(66456) == 255">
                     <GetTo ZoneId="147" XYZ="-28.88544, 6.984501, 480.2776" /> <!-- Papawazu -->
                     <TurnIn QuestId="66456" NpcId="1006438" XYZ="-28.88544, 6.984501, 480.2776" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14889,6 +15386,7 @@
                 <If Condition="GetQuestStep(66458) == 255">
                     <GetTo ZoneId="131" XYZ="138.3588, 4, -58.75545" /> <!-- Syntgoht -->
                     <TurnIn QuestId="66458" NpcId="1001679" XYZ="140.4897, 4.009998, -59.80017" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14910,6 +15408,7 @@
                 <If Condition="GetQuestStep(66457) == 255">
                     <GetTo ZoneId="141" XYZ="-282.887, -5.987557, -372.6406" /> <!-- Norman -->
                     <TurnIn QuestId="66457" NpcId="1007818" XYZ="-282.887, -5.987557, -372.6406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14927,6 +15426,7 @@
                 <If Condition="GetQuestStep(66459) == 255">
                     <GetTo ZoneId="155" XYZ="265.0948, 313.7561, -252.2469" /> <!-- Edwyn -->
                     <TurnIn QuestId="66459" NpcId="1006436" ItemId="2000852" XYZ="265.0948, 313.7561, -252.2469" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14959,6 +15459,7 @@
                 <If Condition="GetQuestStep(66446) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66446" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14998,6 +15499,7 @@
                 <If Condition="GetQuestStep(66447) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66447" NpcId="1006384" ItemId="2000711" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15040,6 +15542,7 @@
                 <If Condition="GetQuestStep(66448) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66448" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15061,6 +15564,7 @@
                 <If Condition="GetQuestStep(66449) == 255">
                     <GetTo ZoneId="155" XYZ="196.0936, 303.1, -285.0843" /> <!-- Medguistl -->
                     <TurnIn QuestId="66449" NpcId="1006429" ItemId="2000716" XYZ="196.0936, 303.1, -285.0843" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15095,6 +15599,7 @@
                 <If Condition="GetQuestStep(66450) == 255">
                     <GetTo ZoneId="155" XYZ="207.3242, 310.015, -297.3831" /> <!-- Juline -->
                     <TurnIn QuestId="66450" NpcId="1006430" ItemId="2000717" XYZ="207.3242, 310.015, -297.3831" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15132,6 +15637,7 @@
                 <If Condition="GetQuestStep(66453) == 255">
                     <GetTo ZoneId="155" XYZ="-478.2635, 211, -203.8148" /> <!-- Brunadier -->
                     <TurnIn QuestId="66453" NpcId="1006435" ItemId="2000721,2000722" XYZ="-478.2635, 211, -203.8148" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15174,6 +15680,7 @@
                 <If Condition="GetQuestStep(66460) == 255">
                     <GetTo ZoneId="155" XYZ="-439.604, 224.4, -194.886" /> <!-- Drillemont -->
                     <TurnIn QuestId="66460" NpcId="1006444" ItemId="2000856,2000858" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15195,6 +15702,7 @@
                 <If Condition="GetQuestStep(66469) == 255">
                     <GetTo ZoneId="155" XYZ="-432.2729, 224.4, -199.3591" /> <!-- Faucillien -->
                     <TurnIn QuestId="66469" NpcId="1006457" XYZ="-432.2729, 224.4, -199.3591" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15230,6 +15738,7 @@
                 <If Condition="GetQuestStep(66472) == 255">
                     <GetTo ZoneId="155" XYZ="-431.4794, 211, -194.873" /> <!-- Fousquenet -->
                     <TurnIn QuestId="66472" NpcId="1006460" XYZ="-431.4794, 211, -194.873" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15247,6 +15756,7 @@
                 <If Condition="GetQuestStep(66465) == 255">
                     <GetTo ZoneId="155" XYZ="-168.8411, 304.1538, -328.6641" /> <!-- Marcelain -->
                     <TurnIn QuestId="66465" NpcId="1006454" XYZ="-168.8411, 304.1538, -328.6641" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15272,6 +15782,7 @@
                 <If Condition="GetQuestStep(66471) == 255">
                     <GetTo ZoneId="155" XYZ="-409.3538, 224.9999, -297.0474" /> <!-- Charmine -->
                     <TurnIn QuestId="66471" NpcId="1006698" ItemId="2000731" XYZ="-409.3538, 224.9999, -297.0474" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15297,6 +15808,7 @@
                 <If Condition="GetQuestStep(66470) == 255">
                     <GetTo ZoneId="155" XYZ="-458.5184, 211.4575, -287.0985" /> <!-- Ferdillaix -->
                     <TurnIn QuestId="66470" NpcId="1006459" XYZ="-458.5184, 211.4575, -287.0985" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15318,6 +15830,7 @@
                 <If Condition="GetQuestStep(66464) == 255">
                     <GetTo ZoneId="155" XYZ="-128.1606, 304.1538, -298.024" /> <!-- Chaunollet -->
                     <TurnIn QuestId="66464" NpcId="1006456" ItemId="2000726" XYZ="-128.1606, 304.1538, -298.024" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15347,6 +15860,7 @@
                 <If Condition="GetQuestStep(66467) == 255">
                     <GetTo ZoneId="155" XYZ="-128.1606, 304.1538, -298.024" /> <!-- Chaunollet -->
                     <TurnIn QuestId="66467" NpcId="1006456" XYZ="-128.1606, 304.1538, -298.024" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15368,6 +15882,7 @@
                 <If Condition="GetQuestStep(66468) == 255">
                     <GetTo ZoneId="155" XYZ="-128.1606, 304.1538, -298.024" /> <!-- Chaunollet -->
                     <TurnIn QuestId="66468" NpcId="1006456" ItemId="2000728" XYZ="-128.1606, 304.1538, -298.024" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15389,6 +15904,7 @@
                 <If Condition="GetQuestStep(66466) == 255">
                     <GetTo ZoneId="155" XYZ="-137.9874, 304.1538, -288.2582" /> <!-- Loanne -->
                     <TurnIn QuestId="66466" NpcId="1006455" XYZ="-137.9874, 304.1538, -288.2582" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15414,6 +15930,7 @@
                 <If Condition="GetQuestStep(66462) == 255">
                     <GetTo ZoneId="155" XYZ="-439.292, 211, -210.7729" /> <!-- Nivie -->
                     <TurnIn QuestId="66462" NpcId="1006447" XYZ="-439.292, 211, -210.7729" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15450,6 +15967,7 @@
                 <If Condition="GetQuestStep(66463) == 255">
                     <GetTo ZoneId="155" XYZ="-411.6426, 225.0227, -304.036" /> <!-- Cenota -->
                     <TurnIn QuestId="66463" NpcId="1007567" ItemId="2000984" XYZ="-411.6426, 225.0227, -304.036" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15471,6 +15989,7 @@
                 <If Condition="GetQuestStep(66461) == 255">
                     <GetTo ZoneId="155" XYZ="-427.9088, 211, -199.7559" /> <!-- Clotairion -->
                     <TurnIn QuestId="66461" NpcId="1006446" XYZ="-427.9088, 211, -199.7559" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15492,6 +16011,7 @@
                 <If Condition="GetQuestStep(66473) == 255">
                     <GetTo ZoneId="155" XYZ="-415.9762, 225, -299.733" /> <!-- Cid -->
                     <TurnIn QuestId="66473" NpcId="1006461" ItemId="2000732" XYZ="-415.9762, 225, -299.733" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15562,6 +16082,7 @@
                 <If Condition="GetQuestStep(66474) == 255">
                     <GetTo ZoneId="155" XYZ="-437.9492, 211.17, -245.7771" /> <!-- Alphinaud -->
                     <TurnIn QuestId="66474" NpcId="1006467" XYZ="-437.9492, 211.17, -245.7771" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15588,6 +16109,7 @@
                 <If Condition="GetQuestStep(66475) == 255">
                     <GetTo ZoneId="155" XYZ="-437.9492, 211.17, -245.7771" /> <!-- Alphinaud -->
                     <TurnIn NpcId="1006467" ItemId="2000733" QuestId="66475" XYZ="-437.9492, 211.17, -245.7771" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15625,6 +16147,7 @@
                 <If Condition="GetQuestStep(66476) == 255">
                     <GetTo ZoneId="155" XYZ="-424.635, 233.4, -208.0638" /> <!-- Drillemont -->
                     <TurnIn QuestId="66476" NpcId="1006444" ItemId="2000866,2000945" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15656,6 +16179,7 @@
                 <If Condition="GetQuestStep(66477) == 255">
                     <GetTo ZoneId="155" XYZ="-437.9492, 211.17, -245.7771" /> <!-- Alphinaud -->
                     <TurnIn NpcId="1006467" QuestId="66477" XYZ="-437.9492, 211.17, -245.7771" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15681,6 +16205,7 @@
                 <If Condition="GetQuestStep(66480) == 255">
                     <GetTo ZoneId="155" XYZ="-405.417, 210.7882, -225.7267" /> <!-- Daimbert -->
                     <TurnIn QuestId="66480" NpcId="1006476" XYZ="-405.417, 210.7882, -225.7267" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15702,6 +16227,7 @@
                 <If Condition="GetQuestStep(66486) == 255">
                     <GetTo ZoneId="155" XYZ="-406.6377, 210.7882, -223.4379" /> <!-- Meurise -->
                     <TurnIn QuestId="66486" NpcId="1006484" XYZ="-406.6377, 210.7882, -223.4379" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15733,6 +16259,7 @@
                 <If Condition="GetQuestStep(66487) == 255">
                     <GetTo ZoneId="155" XYZ="-437.7966, 211, -223.4379" /> <!-- Briannaix -->
                     <TurnIn QuestId="66487" NpcId="1006488" XYZ="-437.7966, 211, -223.4379" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15762,6 +16289,7 @@
                 <If Condition="GetQuestStep(66478) == 255">
                     <GetTo ZoneId="155" XYZ="-422.5747, 265.0999, -205.822" /> <!-- Liautroix -->
                     <TurnIn QuestId="66478" NpcId="1006473" XYZ="-435.0805, 265.1, -208.5145" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15783,6 +16311,7 @@
                 <If Condition="GetQuestStep(66481) == 255">
                     <GetTo ZoneId="155" XYZ="-443.595, 217.9996, -284.0468" /> <!-- Berengeoit -->
                     <TurnIn QuestId="66481" NpcId="1006478" ItemId="2000933" XYZ="-443.595, 217.9996, -284.0468" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15800,6 +16329,7 @@
                 <If Condition="GetQuestStep(66482) == 255">
                     <GetTo ZoneId="155" XYZ="-763.8819, 222.9743, 55.71057" /> <!-- Ourdilic -->
                     <TurnIn QuestId="66482" NpcId="1006480" XYZ="-763.8819, 222.9743, 55.71057" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15821,6 +16351,7 @@
                 <If Condition="GetQuestStep(66483) == 255">
                     <GetTo ZoneId="155" XYZ="-763.8819, 222.9743, 55.71057" /> <!-- Ourdilic -->
                     <TurnIn QuestId="66483" NpcId="1006480" XYZ="-763.8819, 222.9743, 55.71057" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15855,6 +16386,7 @@
                 <If Condition="GetQuestStep(66479) == 255">
                     <GetTo ZoneId="155" XYZ="-417.9294, 225, -301.8998" /> <!-- Astidien -->
                     <TurnIn QuestId="66479" NpcId="1006442" XYZ="-417.9294, 225, -301.8998" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15882,6 +16414,7 @@
                 <If Condition="GetQuestStep(66485) == 255">
                     <GetTo ZoneId="155" XYZ="-763.8819, 222.9743, 55.71057" /> <!-- Ourdilic -->
                     <TurnIn QuestId="66485" NpcId="1006480" XYZ="-763.8819, 222.9743, 55.71057" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15944,6 +16477,7 @@
                 <If Condition="GetQuestStep(66484) == 255">
                     <GetTo ZoneId="155" XYZ="-764.4617, 222.9743, 53.57434" /> <!-- Lancefer -->
                     <TurnIn QuestId="66484" NpcId="1006481" ItemId="2000844" XYZ="-764.4617, 222.9743, 53.57434" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15992,6 +16526,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="7.248047, -21.97092, 119.7374" />
                     <TurnIn QuestId="66488" NpcId="1006491" XYZ="7.248047, -21.97092, 119.7374" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16015,6 +16550,7 @@
                 <If Condition="GetQuestStep(66489) == 255">
                     <GetTo ZoneId="145" XYZ="-437.6746, -55.6945, 100.8773" /> <!-- Lamberteint -->
                     <TurnIn QuestId="66489" NpcId="1006493" XYZ="-437.6746, -55.6945, 100.8773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16036,6 +16572,7 @@
                 <If Condition="GetQuestStep(66490) == 255">
                     <GetTo ZoneId="145" XYZ="-437.6746, -55.6945, 100.8773" /> <!-- Lamberteint -->
                     <TurnIn QuestId="66490" NpcId="1006493" ItemId="2000740" XYZ="-437.6746, -55.6945, 100.8773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16053,6 +16590,7 @@
                 <If Condition="GetQuestStep(66491) == 255">
                     <GetTo ZoneId="145" XYZ="-2.273621, -17.54423, 24.73486" /> <!-- Hahasako -->
                     <TurnIn QuestId="66491" NpcId="1006495" ItemId="2000741" XYZ="-2.273621, -17.54423, 24.73486" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16082,6 +16620,7 @@
                 <If Condition="GetQuestStep(66492) == 255">
                     <GetTo ZoneId="145" XYZ="-437.6746, -55.6945, 100.8773" /> <!-- Lamberteint -->
                     <TurnIn QuestId="66492" NpcId="1006493" ItemId="2000838" XYZ="-437.6746, -55.6945, 100.8773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16099,6 +16638,7 @@
                 <If Condition="GetQuestStep(66495) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66495" NpcId="1006497" ItemId="2000839" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16140,6 +16680,7 @@
                 <If Condition="GetQuestStep(66856) == 255">
                     <GetTo ZoneId="180" XYZ="-2.853455, 16.03717, -172.5033" /> <!-- 789th Order Pickman Gi Gu -->
                     <TurnIn QuestId="66856" NpcId="1005927" XYZ="-2.853455, 16.03717, -172.5033" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16180,6 +16721,7 @@
                 <If Condition="GetQuestStep(66857) == 255">
                     <GetTo ZoneId="180" XYZ="-2.853455, 16.03717, -172.5033" /> <!-- 789th Order Pickman Gi Gu -->
                     <TurnIn QuestId="66857" NpcId="1005927" XYZ="-2.853455, 16.03717, -172.5033" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16213,6 +16755,7 @@
                 <If Condition="GetQuestStep(67022) == 255">
                     <GetTo ZoneId="154" XYZ="149.4315, -18.1403, 99.22937" /> <!-- Sezul Totoloc -->
                     <TurnIn QuestId="67022" NpcId="1009199" ItemId="2001363" XYZ="149.4315, -18.1403, 99.22937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16238,6 +16781,7 @@
                 <If Condition="GetQuestStep(66493) == 255">
                     <GetTo ZoneId="145" XYZ="-67.27704, -20.29624, -3.006042" /> <!-- Helmhart -->
                     <TurnInPlus QuestId="66493" InteractDistance="3" NpcId="1006209" XYZ="-67.27704, -20.29624, -3.006042" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16259,6 +16803,7 @@
                 <If Condition="GetQuestStep(66494) == 255">
                     <GetTo ZoneId="145" XYZ="327.1381, 18.5358, 37.79651" /> <!-- Floating Stone -->
                     <TurnIn QuestId="66494" NpcId="1006496" ItemId="2000744" XYZ="327.1381, 18.5358, 37.79651" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16297,6 +16842,7 @@
                 <If Condition="GetQuestStep(66788) == 255">
                     <GetTo ZoneId="152" XYZ="48.20313, 6.07347, 247.7913" /> <!-- Olmxio -->
                     <TurnIn QuestId="66788" NpcId="1005564" XYZ="48.20313, 6.07347, 247.7913" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16326,6 +16872,7 @@
                 <If Condition="GetQuestStep(66789) == 255">
                     <GetTo ZoneId="152" XYZ="48.20313, 6.07347, 247.7913" /> <!-- Olmxio -->
                     <TurnIn QuestId="66789" NpcId="1005564" XYZ="48.20313, 6.07347, 247.7913" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16352,6 +16899,7 @@
                 <If Condition="GetQuestStep(66496) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66496" NpcId="1006497" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16381,6 +16929,7 @@
                 <If Condition="GetQuestStep(66497) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66497" NpcId="1006497" ItemId="2000843" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16412,6 +16961,7 @@
                 <If Condition="GetQuestStep(66498) == 255">
                     <GetTo ZoneId="138" XYZ="-266.5904, -40.04039, 461.7227" /> <!-- Davyd -->
                     <TurnIn QuestId="66498" NpcId="1006503" ItemId="2000840" XYZ="-266.5904, -40.04039, 461.7227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16433,6 +16983,7 @@
                 <If Condition="GetQuestStep(66500) == 255">
                     <GetTo ZoneId="138" XYZ="-254.5358, -37.89772, 485.191" /> <!-- Otan Yaratan -->
                     <TurnIn QuestId="66500" NpcId="1006504" XYZ="-254.5358, -37.89772, 485.191" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16454,6 +17005,7 @@
                 <If Condition="GetQuestStep(66501) == 255">
                     <GetTo ZoneId="138" XYZ="-200.3663, -40.3407, 503.1967" /> <!-- Ahlduwil -->
                     <TurnIn QuestId="66501" NpcId="1006505" ItemId="2000747" XYZ="-200.3663, -40.3407, 503.1967" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16475,6 +17027,7 @@
                 <If Condition="GetQuestStep(66502) == 255">
                     <GetTo ZoneId="138" XYZ="-198.4742, -40.4614, 499.9923" /> <!-- Erapi Taropi -->
                     <TurnIn QuestId="66502" NpcId="1006506" ItemId="2000748" XYZ="-198.4742, -40.4614, 499.9923" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16498,6 +17051,7 @@
                 <If Condition="GetQuestStep(66499) == 255">
                     <GetTo ZoneId="138" XYZ="-266.5904, -40.04039, 461.7227" /> <!-- Davyd -->
                     <TurnIn QuestId="66499" NpcId="1006503" XYZ="-266.5904, -40.04039, 461.7227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16547,6 +17101,7 @@
                 <If Condition="GetQuestStep(66503) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66503" NpcId="1006497" ItemId="2000841" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16585,6 +17140,7 @@
                 <If Condition="GetQuestStep(66753) == 255">
                     <GetTo ZoneId="146" XYZ="122.6062, 16.40265, -362.1119" /> <!-- Hamujj Gah -->
                     <TurnIn QuestId="66753" NpcId="1005553" XYZ="122.6062, 16.40265, -362.1119" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16614,6 +17170,7 @@
                 <If Condition="GetQuestStep(66754) == 255">
                     <GetTo ZoneId="146" XYZ="122.6062, 16.40265, -362.1119" /> <!-- Hamujj Gah -->
                     <TurnIn QuestId="66754" NpcId="1005553" XYZ="122.6062, 16.40265, -362.1119" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16631,6 +17188,7 @@
                 <If Condition="GetQuestStep(66505) == 255">
                     <GetTo ZoneId="152" XYZ="5.722107, -7.278625, 270.9545" /> <!-- Jeulerand -->
                     <TurnIn QuestId="66505" NpcId="1000617" ItemId="2000950" XYZ="5.722107, -7.278625, 270.9545" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16662,6 +17220,7 @@
                 <If Condition="GetQuestStep(66506) == 255">
                     <GetTo ZoneId="152" XYZ="-170.6722, 56.71352, -255.9701" /> <!-- Kain -->
                     <TurnIn QuestId="66506" NpcId="1006715" ItemId="2000750" XYZ="-170.6722, 56.71352, -255.9701" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16683,6 +17242,7 @@
                 <If Condition="GetQuestStep(66508) == 255">
                     <GetTo ZoneId="152" XYZ="-170.6722, 56.71352, -255.9701" /> <!-- Kain -->
                     <TurnIn QuestId="66508" NpcId="1006715" XYZ="-170.6722, 56.71352, -255.9701" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16704,6 +17264,7 @@
                 <If Condition="GetQuestStep(66509) == 255">
                     <GetTo ZoneId="152" XYZ="-236.2555, 51.49915, -193.1335" /> <!-- Elfleda -->
                     <TurnIn QuestId="66509" NpcId="1006717" ItemId="2000751" XYZ="-236.2555, 51.49915, -193.1335" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16725,6 +17286,7 @@
                 <If Condition="GetQuestStep(66504) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66504" NpcId="1000580" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16755,6 +17317,7 @@
                 <If Condition="GetQuestStep(66507) == 255">
                     <GetTo ZoneId="152" XYZ="-172.0455, 57.15228, -258.1064" /> <!-- Maerwynn -->
                     <TurnIn QuestId="66507" NpcId="1006716" XYZ="-172.0455, 57.15228, -258.1064" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16788,6 +17351,7 @@
                 <If Condition="GetQuestStep(66510) == 255">
                     <GetTo ZoneId="133" XYZ="-123.7355, 7.042648, -149.981" /> <!-- Hedyn -->
                     <TurnIn QuestId="66510" NpcId="1006710" ItemId="2000932" XYZ="-123.7355, 7.042648, -149.981" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16811,6 +17375,7 @@
                     </If>
                     <MoveTo Name="Cid" XYZ="7.339539, -21.97097, 121.9348" />
                     <TurnIn QuestId="66511" NpcId="1006492" ItemId="2000753" XYZ="7.339539, -21.97097, 121.9348" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16875,6 +17440,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-44.63269, 83.99996, -3.768982" />
                     <TurnIn QuestId="66055" NpcId="1006730" XYZ="-44.63269, 83.99996, -3.768982" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16910,6 +17476,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="22.81219, 0.9999986, 2.182007" />
                     <TurnIn QuestId="66056" NpcId="1007630" XYZ="22.81219, 0.9999986, 2.182007" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16936,6 +17503,7 @@
                 <If Condition="GetQuestStep(66514) == 255">
                     <GetTo ZoneId="155" XYZ="169.4819, 223.0354, 366.2623" /> <!-- Portelaine -->
                     <TurnIn QuestId="66514" NpcId="1006380" XYZ="169.4819, 223.0354, 366.2623" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16953,6 +17521,7 @@
                 <If Condition="GetQuestStep(66515) == 255">
                     <GetTo ZoneId="155" XYZ="-82.68872, 233.2374, 317.1892" /> <!-- Ophelie -->
                     <TurnIn QuestId="66515" NpcId="1006516" XYZ="-82.68872, 233.2374, 317.1892" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16974,6 +17543,7 @@
                 <If Condition="GetQuestStep(66516) == 255">
                     <GetTo ZoneId="155" XYZ="-354.8486, 214.7912, 687.5867" /> <!-- Portelaine -->
                     <TurnIn QuestId="66516" NpcId="1006518" XYZ="-354.8486, 214.7912, 687.5867" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17015,6 +17585,7 @@
                 <If Condition="GetQuestStep(66517) == 255">
                     <GetTo ZoneId="155" XYZ="-697.0474, 242.184, 380.6362" /> <!-- Abelie -->
                     <TurnIn QuestId="66517" NpcId="1006521" XYZ="-697.0474, 242.184, 380.6362" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17040,6 +17611,7 @@
                 <If Condition="GetQuestStep(66518) == 255">
                     <GetTo ZoneId="155" XYZ="-699.5193, 242.184, 373.495" /> <!-- Wedge -->
                     <TurnIn QuestId="66518" NpcId="1006520" XYZ="-699.5193, 242.184, 373.495" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17076,6 +17648,7 @@
                 <If Condition="GetQuestStep(66519) == 255">
                     <GetTo ZoneId="155" XYZ="-699.5193, 242.184, 373.495" /> <!-- Wedge -->
                     <TurnIn QuestId="66519" NpcId="1006520" XYZ="-699.5193, 242.184, 373.495" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17099,6 +17672,7 @@
                 <If Condition="GetQuestStep(66521) == 255">
                     <GetTo ZoneId="155" XYZ="-354.8486, 214.7912, 687.5867" /> <!-- Pierremons -->
                     <TurnIn QuestId="66521" NpcId="1006518" XYZ="-354.8486, 214.7912, 687.5867" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17120,6 +17694,7 @@
                 <If Condition="GetQuestStep(66520) == 255">
                     <GetTo ZoneId="156" XYZ="53.81848, 25.00952, -697.0779" /> <!-- Glaumunt -->
                     <TurnIn QuestId="66520" NpcId="1006531" XYZ="53.81848, 25.00952, -697.0779" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17149,6 +17724,7 @@
                 <If Condition="GetQuestStep(66522) == 255">
                     <GetTo ZoneId="156" XYZ="26.90161, 20.54392, -687.4037" /> <!-- Cid -->
                     <TurnIn QuestId="66522" NpcId="1006535" XYZ="26.90161, 20.54392, -687.4037" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17175,6 +17751,7 @@
                 <If Condition="GetQuestStep(66524) == 255">
                     <GetTo ZoneId="156" XYZ="29.58716, 26.3335, -703.6698" /> <!-- Npah Tayuun -->
                     <TurnIn QuestId="66524" NpcId="1006543" XYZ="29.58716, 26.3335, -703.6698" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17204,6 +17781,7 @@
                 <If Condition="GetQuestStep(66533) == 255">
                     <GetTo ZoneId="156" XYZ="30.62488, 21.25268, -643.5798" /> <!-- Aganbold -->
                     <TurnIn QuestId="66533" NpcId="1006542" XYZ="30.62488, 21.25268, -643.5798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17253,6 +17831,7 @@
                 <If Condition="GetQuestStep(66910) == 255">
                     <GetTo ZoneId="138" XYZ="-238.0255, -40.82826, 68.28406" /> <!-- Novv -->
                     <TurnIn QuestId="66910" NpcId="1005937" XYZ="-238.0255, -40.82826, 68.28406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17284,6 +17863,7 @@
                 <If Condition="GetQuestStep(66911) == 255">
                     <GetTo ZoneId="138" XYZ="-238.0255, -40.82826, 68.28406" /> <!-- Novv -->
                     <TurnIn QuestId="66911" NpcId="1005937" XYZ="-238.0255, -40.82826, 68.28406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17362,6 +17942,7 @@
                 <If Condition="GetQuestStep(66535) == 255">
                     <GetTo ZoneId="156" XYZ="30.62488, 21.25268, -643.5798" /> <!-- Aganbold -->
                     <TurnIn QuestId="66535" NpcId="1006542" ItemId="2000764" XYZ="30.62488, 21.25268, -643.5798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17397,6 +17978,7 @@
                 <If Condition="GetQuestStep(66523) == 255">
                     <GetTo ZoneId="156" XYZ="30.62488, 21.25268, -643.5798" /> <!-- Aganbold -->
                     <TurnIn QuestId="66523" NpcId="1006542" ItemId="2000756" XYZ="30.62488, 21.25268, -643.5798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17414,6 +17996,7 @@
                 <If Condition="GetQuestStep(66526) == 255">
                     <GetTo ZoneId="156" XYZ="446.7689, -4.808299, -464.6525" /> <!-- Nazyl Duzyl -->
                     <TurnIn QuestId="66526" NpcId="1006545" XYZ="446.7689, -4.808299, -464.6525" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17445,6 +18028,7 @@
                 <If Condition="GetQuestStep(66527) == 255">
                     <GetTo ZoneId="156" XYZ="446.7689, -4.808299, -464.6525" /> <!-- Nazyl Duzyl -->
                     <TurnIn QuestId="66527" NpcId="1006545" XYZ="446.7689, -4.808299, -464.6525" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17466,6 +18050,7 @@
                 <If Condition="GetQuestStep(66532) == 255">
                     <GetTo ZoneId="156" XYZ="29.89246, 21.25269, -644.5258" /> <!-- Kakamehi -->
                     <TurnIn QuestId="66532" NpcId="1006677" XYZ="29.89246, 21.25269, -644.5258" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17489,6 +18074,7 @@
                 <If Condition="GetQuestStep(66525) == 255">
                     <GetTo ZoneId="156" XYZ="24.09399, 28.99997, -750.0573" /> <!-- Guolgeim -->
                     <TurnIn QuestId="66525" NpcId="1006544" ItemId="2000758" XYZ="24.09399, 28.99997, -750.0573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17510,6 +18096,7 @@
                 <If Condition="GetQuestStep(66534) == 255">
                     <GetTo ZoneId="156" XYZ="24.09399, 28.99997, -750.0573" /> <!-- Guolgeim -->
                     <TurnIn QuestId="66534" NpcId="1006544" ItemId="2000763" XYZ="24.09399, 28.99997, -750.0573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17546,6 +18133,7 @@
                 <If Condition="GetQuestStep(66536) == 255">
                     <GetTo ZoneId="156" XYZ="24.09399, 28.99997, -750.0573" /> <!-- Guolgeim -->
                     <TurnIn QuestId="66536" NpcId="1006544" ItemId="2000765" XYZ="24.09399, 28.99997, -750.0573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17568,6 +18156,7 @@
                 <If Condition="GetQuestStep(66529) == 255">
                     <GetTo ZoneId="156" XYZ="448.6609, -3.509302, -442.7405" /> <!-- Wandering Breeze -->
                     <TurnIn QuestId="66529" NpcId="1006549" XYZ="448.6609, -3.509302, -442.7405" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17597,6 +18186,7 @@
                 <If Condition="GetQuestStep(66531) == 255">
                     <GetTo ZoneId="156" XYZ="448.6609, -3.509302, -442.7405" /> <!-- Wandering Breeze -->
                     <TurnIn QuestId="66531" NpcId="1006549" ItemId="2000853" XYZ="448.6609, -3.509302, -442.7405" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17618,6 +18208,7 @@
                 <If Condition="GetQuestStep(66528) == 255">
                     <GetTo ZoneId="156" XYZ="446.8298, -5.306207, -465.7206" /> <!-- Rammbroes -->
                     <TurnIn QuestId="66528" NpcId="1006725" XYZ="446.8298, -5.306207, -465.7206" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17640,6 +18231,7 @@
                 <If Condition="GetQuestStep(66530) == 255">
                     <GetTo ZoneId="156" XYZ="449.3323, -12.43682, -387.5639" /> <!-- Klynthota -->
                     <TurnIn QuestId="66530" NpcId="1006550" ItemId="2000934" XYZ="449.3323, -12.43682, -387.5639" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17675,6 +18267,7 @@
                 <If Condition="GetQuestStep(66538) == 255">
                     <GetTo ZoneId="156" XYZ="53.81848, 25.00952, -697.0779" /> <!-- Glaumunt -->
                     <TurnIn QuestId="66538" NpcId="1006531" XYZ="53.81848, 25.00952, -697.0779" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17716,6 +18309,7 @@
                 <If Condition="GetQuestStep(66539) == 255">
                     <GetTo ZoneId="156" XYZ="54.79517, 25.54827, -698.0544" /> <!-- Sark Malark -->
                     <TurnIn QuestId="66539" NpcId="1006552" ItemId="2000769,2000770" XYZ="54.79517, 25.54827, -698.0544" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17747,6 +18341,7 @@
                 <If Condition="GetQuestStep(66537) == 255">
                     <GetTo ZoneId="156" XYZ="26.90161, 20.54392, -687.4037" /> <!-- Cid -->
                     <TurnIn QuestId="66537" NpcId="1006535" ItemId="2000766" XYZ="26.90161, 20.54392, -687.4037" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17793,6 +18388,7 @@
                     </If>
                     <MoveTo Name="Cid" XYZ="-2.761902, -158.5813, -1.632751" />
                     <TurnIn QuestId="66540" NpcId="1006555" XYZ="-2.761902, -158.5813, -1.632751" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17910,6 +18506,7 @@
                     </If>
                     <MoveTo Name="Cid" XYZ="-2.761902, -158.5813, -1.632751" />
                     <TurnIn QuestId="66541" NpcId="1006555" XYZ="-2.761902, -158.5813, -1.632751" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17998,6 +18595,7 @@
                     </If>
                     <NoCombatMoveTo Name="Minfilia" XYZ="-43.7171, 84, 2.151489" />
                     <TurnIn QuestId="66057" NpcId="1006573" XYZ="-43.7171, 84, 2.151489" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18049,6 +18647,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.26135, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66058" NpcId="1006690" XYZ="39.26135, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18081,6 +18680,7 @@
                     </If>
 					<MoveTo Name="Lewin" XYZ="2.869185, 0.5000247, -3.373355" />
                     <TurnIn QuestId="66543" NpcId="1003061" XYZ="-0.01531982, 0.500025, -4.379395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18120,6 +18720,7 @@
                     </If>
                     <MoveTo Name="Lewin" XYZ="2.869185, 0.5000247, -3.373355" />
                     <TurnIn QuestId="66544" NpcId="1003061" XYZ="-0.01531982, 0.500025, -4.379395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18160,6 +18761,7 @@
                 <If Condition="GetQuestStep(66545) == 255">
                     <GetTo ZoneId="153" XYZ="209.3385, 18.12, -21.95776" /> <!-- Simmie -->
                     <TurnIn QuestId="66545" NpcId="1006585" XYZ="209.3385, 18.12, -21.95776" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18186,6 +18788,7 @@
                     </If>
                     <MoveTo Name="Urianger" XYZ="-2.822998, -3.000001, -56.22955" />
                     <TurnIn QuestId="66548" NpcId="1007478" ItemId="2000846" XYZ="-2.822998, -3.000001, -56.22955" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18211,6 +18814,7 @@
                 <If Condition="GetQuestStep(66547) == 255">
                     <GetTo ZoneId="153" XYZ="180.621, 9.909174, -78.78235" /> <!-- Kerrich -->
                     <TurnIn QuestId="66547" NpcId="1006587" ItemId="2000774" XYZ="180.621, 9.909174, -78.78235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18232,6 +18836,7 @@
                 <If Condition="GetQuestStep(66546) == 255">
                     <GetTo ZoneId="153" XYZ="199.2675, 10.38043, -85.40479" /> <!-- Isarmoix -->
                     <TurnIn QuestId="66546" NpcId="1006586" ItemId="2000845" XYZ="199.2675, 10.38043, -85.40479" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18262,6 +18867,7 @@
                 <If Condition="GetQuestStep(66550) == 255">
                     <GetTo ZoneId="155" XYZ="-354.1772, 214.6081, 692.6528" /> <!-- Willielmus -->
                     <TurnIn QuestId="66550" NpcId="1007625" XYZ="-354.1772, 214.6081, 692.6528" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18288,6 +18894,7 @@
                 <If Condition="GetQuestStep(66551) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Slafswys -->
                     <TurnIn QuestId="66551" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18312,6 +18919,7 @@
                 <If Condition="GetQuestStep(66553) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                     <TurnIn QuestId="66553" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18335,6 +18943,7 @@
                 <If Condition="GetQuestStep(66555) == 255">
                     <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                     <TurnIn QuestId="66555" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18365,6 +18974,7 @@
                     </If>
                     <MoveTo Name="Slafswys" XYZ="2.883911, -2.000001, -12.25305" />
                     <TurnIn QuestId="66556" NpcId="1007487" XYZ="2.883911, -2.000001, -12.25305" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18393,6 +19003,7 @@
                 <If Condition="GetQuestStep(66554) == 255">
                     <GetTo ZoneId="180" XYZ="-110.155, 64.49942, -238.819" /> <!-- F'majha -->
                     <TurnIn QuestId="66554" NpcId="1006594" ItemId="2000775" XYZ="-110.155, 64.49942, -238.819" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18419,6 +19030,7 @@
                 <If Condition="GetQuestStep(67089) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="67089" NpcId="1004917" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18444,6 +19056,7 @@
                 <If Condition="GetQuestStep(66557) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66557" NpcId="1004917" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18471,6 +19084,7 @@
                 <If Condition="GetQuestStep(66559) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66559" NpcId="1004917" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18509,6 +19123,7 @@
                     </If>
                     <MoveTo Name="Wigstan" XYZ="10.2998, -3.000002, -54.8562" />
                     <TurnIn QuestId="66560" NpcId="1011618" XYZ="10.2998, -3.000002, -54.8562" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18548,6 +19163,7 @@
                 <If Condition="GetQuestStep(66561) == 255">
                     <GetTo ZoneId="138" XYZ="65.87317, -3.118188, 61.41748" /> <!-- Falkbryda -->
                     <TurnIn QuestId="66561" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18601,6 +19217,7 @@
                 <If Condition="GetQuestStep(66562) == 255">
                     <GetTo ZoneId="138" XYZ="254.4746, -4.380904, 204.4861" /> <!-- Ururu Kogururu -->
                     <TurnIn QuestId="66562" NpcId="1006618" XYZ="254.4746, -4.380904, 204.4861" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18630,6 +19247,7 @@
                 <If Condition="GetQuestStep(66563) == 255">
                     <GetTo ZoneId="138" XYZ="65.87317, -3.118188, 61.41748" /> <!-- Falkbryda -->
                     <TurnIn QuestId="66563" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18666,6 +19284,7 @@
                     </If>
                     <NoCombatMoveTo Name="Radolf" XYZ="-1.205505, -2.00001, -28.00031" />
                     <TurnIn QuestId="66571" NpcId="1007488" XYZ="-1.205505, -2.00001, -28.00031" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18687,6 +19306,7 @@
                 <If Condition="GetQuestStep(66565) == 255">
                     <GetTo ZoneId="138" XYZ="69.96252, -3.11823, 52.65881" /> <!-- Ahtzatrach -->
                     <TurnIn QuestId="66565" NpcId="1006615" XYZ="69.96252, -3.11823, 52.65881" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18708,6 +19328,7 @@
                 <If Condition="GetQuestStep(66566) == 255">
                     <GetTo ZoneId="138" XYZ="64.37781, -3.118241, 48.50842" /> <!-- Eilis -->
                     <TurnIn QuestId="66566" NpcId="1006617" XYZ="64.37781, -3.118241, 48.50842" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18730,6 +19351,7 @@
                 <If Condition="GetQuestStep(66564) == 255">
                     <GetTo ZoneId="138" XYZ="56.80933, -3.110172, 53.78796" /> <!-- U'jughal -->
                     <TurnIn QuestId="66564" NpcId="1006616" XYZ="56.80933, -3.110172, 53.78796" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18752,6 +19374,7 @@
                 <If Condition="GetQuestStep(66567) == 255">
                     <GetTo ZoneId="138" XYZ="64.37781, -3.118241, 48.50842" /> <!-- Eilis -->
                     <TurnIn QuestId="66567" NpcId="1006617" XYZ="64.37781, -3.118241, 48.50842" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18777,6 +19400,7 @@
                 <If Condition="GetQuestStep(66568) == 255">
                     <GetTo ZoneId="138" XYZ="64.37781, -3.118241, 48.50842" /> <!-- Eilis -->
                     <TurnIn QuestId="66568" NpcId="1006617" XYZ="64.37781, -3.118241, 48.50842" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18794,6 +19418,7 @@
                 <If Condition="GetQuestStep(66570) == 255">
                     <GetTo ZoneId="138" XYZ="-97.0932, -25.00205, 66.72766" /> <!-- Sthalrhet -->
                     <TurnIn QuestId="66570" NpcId="1006627" ItemId="2000848" XYZ="-97.0932, -25.00205, 66.72766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18815,6 +19440,7 @@
                 <If Condition="GetQuestStep(66569) == 255">
                     <GetTo ZoneId="138" XYZ="26.56592, -10.28117, -83.39056" /> <!-- Nortmoen -->
                     <TurnIn QuestId="66569" NpcId="1006626" ItemId="2000784" XYZ="26.56592, -10.28117, -83.39056" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18876,6 +19502,7 @@
                 <If Condition="GetQuestStep(66572) == 255">
                     <GetTo ZoneId="140" XYZ="-467.277, 22.99698, -475.2117" /> <!-- Allied Communications Officer -->
                     <TurnIn QuestId="66572" NpcId="1006578" XYZ="-467.277, 22.99698, -475.2117" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18893,6 +19520,7 @@
                 <If Condition="GetQuestStep(66573) == 255">
                     <GetTo ZoneId="147" XYZ="37.97961, 4.051331, 420.2792" /> <!-- Cracked Fist -->
                     <TurnIn QuestId="66573" NpcId="1006638" XYZ="37.97961, 4.051331, 420.2792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18932,6 +19560,7 @@
                 <If Condition="GetQuestStep(66575) == 255">
                     <GetTo ZoneId="147" XYZ="37.97961, 4.051331, 420.2792" /> <!-- Cracked Fist -->
                     <TurnIn QuestId="66575" NpcId="1006638" XYZ="37.97961, 4.051331, 420.2792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18959,6 +19588,7 @@
                 <If Condition="GetQuestStep(66578) == 255">
                     <GetTo ZoneId="147" XYZ="-29.95355, 46.99734, 32.5474" /> <!-- Edelstein -->
                     <TurnIn QuestId="66578" NpcId="1006646" XYZ="-29.95355, 46.99734, 32.54749" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18991,6 +19621,7 @@
                     <GetTo ZoneId="147" XYZ="-29.95355, 46.99734, 32.5474" /> <!-- Edelstein -->
                     <Dismount/>
                     <TurnInPlus QuestId="66579" NpcId="1006646" XYZ="-29.95355, 46.99734, 32.54749" />
+                    <WaitTimer WaitTime="2"/>
                 </While>
             </If>
         </If>
@@ -19018,6 +19649,7 @@
                 <If Condition="GetQuestStep(66582) == 255">
                     <GetTo ZoneId="147" XYZ="-294.8196, 88, -225.1774" /> <!-- Raubahn -->
                     <TurnIn QuestId="66582" NpcId="1006657" XYZ="-294.8196, 88, -225.1774" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19046,6 +19678,7 @@
                 <If Condition="GetQuestStep(66574) == 255">
                     <GetTo ZoneId="147" XYZ="39.59705, 4.107583, 421.1947" /> <!-- Rafold -->
                     <TurnIn QuestId="66574" NpcId="1006637" XYZ="39.59705, 4.107583, 421.1947" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19067,6 +19700,7 @@
                 <If Condition="GetQuestStep(66577) == 255">
                     <GetTo ZoneId="147" XYZ="22.04926, 48.6382, -15.82361" /> <!-- Memezofu -->
                     <TurnIn QuestId="66577" NpcId="1006643" ItemId="2000788" XYZ="22.04926, 48.6382, -15.82361" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19095,6 +19729,7 @@
                 <If Condition="GetQuestStep(66580) == 255">
                     <GetTo ZoneId="147" XYZ="22.04926, 48.6382, -15.82361" /> <!-- Memezofu -->
                     <TurnIn QuestId="66580" NpcId="1006643" XYZ="22.04926, 48.6382, -15.82361" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19116,6 +19751,7 @@
                 <If Condition="GetQuestStep(66581) == 255">
                     <GetTo ZoneId="147" XYZ="22.04926, 48.6382, -15.82361" /> <!-- Memezofu -->
                     <TurnIn QuestId="66581" NpcId="1006643" ItemId="2000790" XYZ="22.04926, 48.6382, -15.82361" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19137,6 +19773,7 @@
                 <If Condition="GetQuestStep(66576) == 255">
                     <GetTo ZoneId="147" XYZ="57.1145, 4.086993, 422.6597" /> <!-- Spiraling Path -->
                     <TurnIn QuestId="66576" NpcId="1007604" XYZ="57.1145, 4.086993, 422.6597" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19204,6 +19841,7 @@
                 <If Condition="GetQuestStep(66672) == 255">
                     <GetTo ZoneId="147" XYZ="-294.8196, 88, -225.1774" /> <!-- Raubahn -->
                     <TurnIn QuestId="66672" NpcId="1006657" XYZ="-294.8196, 88, -225.1774" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19238,6 +19876,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.26135, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66060" NpcId="1006692" XYZ="39.26135, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19255,6 +19894,7 @@
                 <If Condition="GetQuestStep(66642) == 255">
                     <GetTo ZoneId="250" XYZ="0.01519775, 3.583684, -30.38074" /> <!-- Berkoeya Loetahlsyn -->
                     <TurnInPlus QuestId="66642" NpcId="1005184" XYZ="0.01519775, 3.583684, -30.38074" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19284,6 +19924,7 @@
                 <If Condition="GetQuestStep(66925) == 255">
                     <GetTo ZoneId="153" XYZ="-360.0062, 1.264418, 459.8306" /> <!-- Alphene -->
                     <TurnIn QuestId="66925" NpcId="1008543" XYZ="-360.0062, 1.264418, 459.8306" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -19301,6 +19942,7 @@
                 <If Condition="GetQuestStep(66406) == 255">
                     <GetTo ZoneId="139" XYZ="208.5145, -2.048988, 78.50769" /> <!-- Abazi Charazi -->
                     <TurnIn QuestId="66406" NpcId="1006356" XYZ="208.5145, -2.048988, 78.50769" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] A Realm Reborn (Patch 2.1).xml
+++ b/Questing/[O] A Realm Reborn (Patch 2.1).xml
@@ -149,10 +149,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66711" NpcId="1007722" XYZ="2.487183, 5.215406E-07, 4.592957" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66711" NpcId="1007722" XYZ="2.487183, 5.215406E-07, 4.592957" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -207,10 +209,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66712" NpcId="1006355" XYZ="-512.4742, -16.42, -7.522766" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66712" NpcId="1006355" XYZ="-512.4742, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -285,6 +289,7 @@
                     </If>
                     <NoCombatMoveTo Name="Alphinaud" XYZ="-35.11102, 70.34484, 4.043579" />
                     <TurnIn QuestId="66713" NpcId="1007752" XYZ="-35.11102, 70.34484, 4.043579" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -364,10 +369,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66714" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66714" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -448,10 +455,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66715" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66715" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -485,10 +494,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66716" NpcId="1006530" ItemId="2001077" XYZ="21.92719, 20.74698, -682.063" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66716" NpcId="1006530" ItemId="2001077" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -542,10 +553,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66717" NpcId="1006544" XYZ="24.09399, 28.99997, -750.0573" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66717" NpcId="1006544" XYZ="24.09399, 28.99997, -750.0573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -577,10 +590,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66719" NpcId="1006552" XYZ="54.79517, 25.54827, -698.0544" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66719" NpcId="1006552" XYZ="54.79517, 25.54827, -698.0544" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -613,10 +628,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66718" NpcId="1006530" ItemId="2001078" XYZ="21.92719, 20.74698, -682.063" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66718" NpcId="1006530" ItemId="2001078" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -636,6 +653,7 @@
                 <If Condition="GetQuestStep(67097) == 255">
                     <GetTo ZoneId="156" XYZ="21.92719, 20.74698, -682.063" /> <!-- Slafborn -->
                     <TurnIn QuestId="67097" NpcId="1006530" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -655,6 +673,7 @@
                 <If Condition="GetQuestStep(67098) == 255">
                     <GetTo ZoneId="156" XYZ="21.92719, 20.74698, -682.063" /> <!-- Slafborn -->
                     <TurnIn QuestId="67098" NpcId="1006530" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -724,10 +743,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66722" NpcId="1003785" ItemId="2001080" XYZ="-489.8299, 21.48999, -381.9791" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66722" NpcId="1003785" ItemId="2001080" XYZ="-489.8299, 21.48999, -381.9791" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -772,10 +793,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66723" NpcId="1003785" ItemId="2001081" XYZ="-489.8299, 21.48999, -381.9791" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66723" NpcId="1003785" ItemId="2001081" XYZ="-489.8299, 21.48999, -381.9791" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -813,10 +836,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66724" NpcId="1000168" XYZ="-75.48645, -0.5013741, -5.081299" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnInPlus QuestId="66724" NpcId="1000168" XYZ="-75.48645, -0.5013741, -5.081299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -857,10 +882,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66725" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66725" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -941,10 +968,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66726" NpcId="1007862" XYZ="-140.032, 8.647763, 280.8728" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66726" NpcId="1007862" XYZ="-140.032, 8.647763, 280.8728" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -997,10 +1026,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66727" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66727" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1081,6 +1112,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66728" NpcId="1006693" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1131,6 +1163,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="1.022339, -1.995725, -45.79236" />
                     <TurnIn QuestId="66729" NpcId="1007724" XYZ="1.022339, -1.995725, -45.79236" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] A Realm Reborn (Patch 2.2).xml
+++ b/Questing/[O] A Realm Reborn (Patch 2.2).xml
@@ -116,6 +116,7 @@
                 <If Condition="GetQuestStep(66881) == 255">
                     <GetTo ZoneId="140" XYZ="57.66382, 45, -220.9354" /> <!-- Thancred -->
                     <TurnIn QuestId="66881" NpcId="1008597" XYZ="57.66382, 45, -220.9354" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -143,6 +144,7 @@
                 <If Condition="GetQuestStep(66882) == 255">
                     <GetTo ZoneId="140" XYZ="59.61694, 45.14532, -215.9" /> <!-- Fufulupa -->
                     <TurnIn QuestId="66882" NpcId="1002058" XYZ="59.61694, 45.14532, -215.9" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -205,10 +207,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66883" NpcId="1008616" XYZ="-18.26508, 36.0139, 57.93848" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66883" NpcId="1008616" XYZ="-18.26508, 36.0139, 57.93848" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -270,10 +274,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66884" NpcId="1008623" XYZ="24.88745, 6.999997, -80.03363" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66884" NpcId="1008623" XYZ="24.88745, 6.999997, -80.03363" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -320,10 +326,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66885" NpcId="1008626" ItemId="2001207" XYZ="-417.4106, 23.16707, -350.5455" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66885" NpcId="1008626" ItemId="2001207" XYZ="-417.4106, 23.16707, -350.5455" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -349,6 +357,7 @@
                 <If Condition="GetQuestStep(66886) == 255">
                     <GetTo ZoneId="140" XYZ="-417.4106, 23.16707, -350.5455" /> <!-- Hozan -->
                     <TurnIn QuestId="66886" NpcId="1008626" ItemId="2001207" XYZ="-417.4106, 23.16707, -350.5455" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -393,10 +402,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66887" NpcId="1008639" XYZ="-497.9477, 19.05133, -354.757" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66887" NpcId="1008639" XYZ="-497.9477, 19.05133, -354.757" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -424,6 +435,7 @@
                 <If Condition="GetQuestStep(66888) == 255">
                     <GetTo ZoneId="130" XYZ="24.88745, 6.999997, -80.03363" /> <!-- Alphinaud -->
                     <TurnIn QuestId="66888" NpcId="1008623" XYZ="24.88745, 6.999997, -80.03363" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -464,11 +476,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66889" NpcId="1008547" XYZ="0.7781982, -1.995725, -45.48718" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.7781982, -1.995725, -45.48718" />
                     <TurnIn QuestId="66889" NpcId="1008547" XYZ="0.7781982, -1.995725, -45.48718" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -544,10 +558,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66884" NpcId="1008623" XYZ="24.88745, 6.999997, -80.03363" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66890" NpcId="1008663" ItemIds="2001210,2001211" XYZ="87.38831, 31.40296, -729.0913" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -597,11 +613,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66891" NpcId="1008565" XYZ="1.632629, -1.995725, -41.91656" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="1.632629, -1.995725, -41.91656" />
                     <TurnIn QuestId="66891" NpcId="1008565" XYZ="1.632629, -1.995725, -41.91656" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -644,10 +662,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66892" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66892" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -688,10 +708,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66893" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66893" NpcId="1006614" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -727,10 +749,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66894" NpcId="1006614" ItemId="2001215" XYZ="65.87317, -3.118188, 61.41748" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66894" NpcId="1006614" ItemId="2001215" XYZ="65.87317, -3.118188, 61.41748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -771,10 +795,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66884" NpcId="1008623" XYZ="24.88745, 6.999997, -80.03363" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66895" NpcId="1008803" XYZ="-418.9059, -35.7011, -400.5035" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -823,10 +849,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66896" NpcId="1008693" XYZ="155.4741, 8.973627, 584.1306" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66896" NpcId="1008693" XYZ="155.4741, 8.973627, 584.1306" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -861,11 +889,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66897" NpcId="1002694" XYZ="-0.04577637, 1.600142, -7.003906" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Merlwyb" XYZ="-0.04577637, 1.600142, -7.003906" />
                     <TurnIn QuestId="66897" NpcId="1002694" XYZ="-0.04577637, 1.600142, -7.003906" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -891,10 +921,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66898" NpcId="1008694" ItemId="2001216" XYZ="-117.2656, 9.999866, 154.7417" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66898" NpcId="1008694" ItemId="2001216" XYZ="-117.2656, 9.999866, 154.7417" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -927,11 +959,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66899" NpcId="1008579" XYZ="1.022339, -1.995725, -45.73132" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="1.022339, -1.995725, -45.73132" />
                     <TurnIn QuestId="66899" NpcId="1008579" XYZ="1.022339, -1.995725, -45.73132" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] A Realm Reborn (Patch 2.3).xml
+++ b/Questing/[O] A Realm Reborn (Patch 2.3).xml
@@ -114,6 +114,7 @@
                 <If Condition="GetQuestStep(66978) == 255">
                     <GetTo ZoneId="130" XYZ="24.88745, 6.999997, -80.03363" /> <!-- Alphinaud -->
                     <TurnIn QuestId="66978" NpcId="1008623" XYZ="24.88745, 6.999997, -80.03363" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -150,6 +151,7 @@
                 <If Condition="GetQuestStep(66979) == 255">
                     <GetTo ZoneId="141" XYZ="187.5486, -1, -302.9374" /> <!-- Terrified Refugee -->
                     <TurnInPlus QuestId="66979" NpcId="1009049" XYZ="187.5486, -1, -302.9374" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -191,10 +193,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66980" NpcId="1004576" XYZ="-141.6495, 4.1, -114.6716" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66980" NpcId="1004576" XYZ="-141.6495, 4.1, -114.6716" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -230,10 +234,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66981" NpcId="1004576" XYZ="-141.6495, 4.1, -114.6716" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66981" NpcId="1004576" XYZ="-141.6495, 4.1, -114.6716" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -258,10 +264,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66982" NpcId="1001821" XYZ="-24.12457, 38, 85.31323" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66982" NpcId="1001821" XYZ="-24.12457, 38, 85.31323" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -293,11 +301,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66983" NpcId="1008579" XYZ="1.022339, -1.995725, -45.73132" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="1.022339, -1.995725, -45.73132" />
                     <TurnIn QuestId="66983" NpcId="1008579" XYZ="1.022339, -1.995725, -45.73132" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -345,10 +355,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66984" NpcId="1009097" XYZ="22.87323, -3.774938, 211.1696" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66984" NpcId="1009097" XYZ="22.87323, -3.774938, 211.1696" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -402,10 +414,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66985" NpcId="1009100" XYZ="269.6421, -11.65452, -107.4083" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66985" NpcId="1009100" XYZ="269.6421, -11.65452, -107.4083" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -461,10 +475,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66986" NpcId="1009414" XYZ="258.1368, -23.38493, -526.8788" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66986" NpcId="1009414" XYZ="258.1368, -23.38493, -526.8788" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -508,10 +524,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66987" NpcId="1009119" XYZ="106.8589, -27.48706, -366.3844" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66987" NpcId="1009119" XYZ="106.8589, -27.48706, -366.3844" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -536,6 +554,7 @@
                 <If Condition="GetQuestStep(66988) == 255">
                     <GetTo ZoneId="152" XYZ="22.87323, -3.774938, 211.1696" /> <!-- Serpent Lieutenant -->
                     <TurnIn QuestId="66988" NpcId="1009097" XYZ="22.87323, -3.774938, 211.1696" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -574,6 +593,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="0.9917603, -1.995725, -45.70081" />
                     <TurnIn QuestId="66989" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -623,10 +643,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66990" NpcId="1006530" XYZ="21.92719, 20.74698, -682.063" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66990" NpcId="1006530" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -711,6 +733,7 @@
                     </If>
                     <MoveTo Name="Tataru" XYZ="-3.768982, 0.01804011, -7.156494" />
                     <TurnIn QuestId="66991" NpcId="1009058" XYZ="-3.768982, 0.01804011, -7.156494" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -786,11 +809,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66992" NpcId="1009021" XYZ="2.914429, -1.995725, -42.13019" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Alphinaud" XYZ="2.914429, -1.995725, -42.13019" />
                     <TurnIn QuestId="66992" NpcId="1009021" XYZ="2.914429, -1.995725, -42.13019" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -877,6 +902,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="2.914429, -1.995725, -42.13019" />
                     <TurnIn QuestId="66993" NpcId="1009021" XYZ="2.914429, -1.995725, -42.13019" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -905,6 +931,7 @@
                 <If Condition="GetQuestStep(66994) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66994" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -957,10 +984,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66995" NpcId="1006530" XYZ="21.92719, 20.74698, -682.063" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="66995" NpcId="1006530" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1039,11 +1068,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="66996" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.9917603, -1.995725, -45.70081" />
                     <TurnIn QuestId="66996" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] A Realm Reborn (Patch 2.4).xml
+++ b/Questing/[O] A Realm Reborn (Patch 2.4).xml
@@ -135,10 +135,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65588" NpcId="1008700" XYZ="-132.5247, 4.1, -111.9249" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65588" NpcId="1008700" XYZ="-132.5247, 4.1, -111.9249" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -216,11 +218,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65589" NpcId="1010078" XYZ="31.54041, -1, -0.8087769" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Alphinaud" XYZ="31.54041, -1, -0.8087769" />
                     <TurnIn QuestId="65589" NpcId="1010078" XYZ="31.54041, -1, -0.8087769" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -271,6 +275,7 @@
                     -->
 
                     <TurnInPlus QuestId="65590" NpcId="1007603" XYZ="264.9119, 302.2624, -223.7126" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -307,10 +312,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65593" NpcId="1009977" XYZ="261.0055, 303.1, -198.5962" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65593" NpcId="1009977" XYZ="261.0055, 303.1, -198.5962" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -335,10 +342,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65598" NpcId="1006444" XYZ="-432.9748, 233.4727, -199.6643" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65598" NpcId="1006444" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -379,10 +388,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65605" NpcId="1006444" XYZ="-432.9748, 233.4727, -199.6643" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65605" NpcId="1006444" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -406,6 +417,7 @@
                 <If Condition="GetQuestStep(65610) == 255">
                     <GetTo ZoneId="155" XYZ="-432.9748, 233.4727, -199.6643" /> <!-- Drillemont -->
                     <TurnIn QuestId="65610" ItemId="2001470" NpcId="1006444" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -437,6 +449,7 @@
                 <If Condition="GetQuestStep(65611) == 255">
                     <GetTo ZoneId="155" XYZ="-902.6169, 229.2524, -9.689575" /> <!-- Alphinaud -->
                     <TurnIn QuestId="65611" NpcId="1009996" XYZ="-902.6169, 229.2524, -9.689575" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -480,6 +493,7 @@
                 <If Condition="GetQuestStep(65613) == 255">
                     <GetTo ZoneId="155" XYZ="229.4498, 222, 347.3105" /> <!-- Alphinaud -->
                     <TurnIn QuestId="65613" NpcId="1010191" XYZ="229.4498, 222, 347.3105" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -525,10 +539,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65614" NpcId="1010010" XYZ="-50.94995, -3.440948, 20.58435" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65614" NpcId="1010010" XYZ="-50.94995, -3.440948, 20.58435" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -581,10 +597,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65615" NpcId="1010017" XYZ="22.17133, 1.2, 28.85474" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65615" NpcId="1010017" XYZ="22.17133, 1.2, 28.85474" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -612,6 +630,7 @@
                 <If Condition="GetQuestStep(65616) == 255">
                     <GetTo ZoneId="153" XYZ="90.74536, 21.96121, 178.8204" /> <!-- Shinobi -->
                     <TurnIn QuestId="65616" NpcId="1010034" XYZ="90.74536, 21.96121, 178.8204" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -656,11 +675,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65617" NpcId="1010147" XYZ="0.8086548, -1.995725, -45.67035" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.8086548, -1.995725, -45.67035" />
                     <TurnIn QuestId="65617" NpcId="1010147" XYZ="0.8086548, -1.995725, -45.67035" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -719,11 +740,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65618" NpcId="1010147" XYZ="0.8086548, -1.995725, -45.67035" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.8086548, -1.995725, -45.67035" />
                     <TurnIn QuestId="65618" NpcId="1010147" XYZ="0.8086548, -1.995725, -45.67035" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -764,6 +787,7 @@
                 <If Condition="GetQuestStep(65620) == 255">
                     <GetTo ZoneId="155" XYZ="-905.7603, 229.2982, -10.14728" /> <!-- Moenbryda -->
                     <TurnIn QuestId="65620" NpcId="1010042" XYZ="-905.7603, 229.2982, -10.14728" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -797,6 +821,7 @@
                     -->
 
                     <TurnInPlus QuestId="65622" NpcId="1007603" XYZ="264.9119, 302.2624, -223.7126" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -830,11 +855,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65623" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.9917603, -1.995725, -45.70081" />
                     <TurnIn QuestId="65623" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -905,10 +932,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65624" NpcId="1010063" XYZ="-207.5685, 71.61736, -132.5247" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65624" NpcId="1010063" XYZ="-207.5685, 71.61736, -132.5247" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -933,6 +962,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="0.9917603, -1.995725, -45.70081" />
                     <TurnIn QuestId="65625" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] A Realm Reborn (Patch 2.5).xml
+++ b/Questing/[O] A Realm Reborn (Patch 2.5).xml
@@ -109,6 +109,7 @@
                     </If>
 					<MoveTo Name="Urianger" XYZ="-2.822998, -3.000001, -56.22955" />
 					<TurnIn QuestId="66583" NpcId="1007478" XYZ="-2.822998, -3.000001, -56.22955" />
+					<WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -141,6 +142,7 @@
 					<Dismount/>
 					<MoveTo Name="Zahar'ak Aetheryte" XYZ="692.6243, 5.513888, -80.3129" UseMesh="False" />
 					<TurnInPlus InteractDistance="5.0" QuestId="66584" NpcId="2002581" XYZ="693.1846, 5.784381, -80.087" />
+					<WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -176,6 +178,7 @@
 					<Dismount/>
 					<MoveTo Name="Natalan Aetheryte" XYZ="649.7748, 292.4391, 175.3414" />
 					<TurnInPlus QuestId="66693" NpcId="2002582" XYZ="649.7748, 292.4391, 175.3414" />
+					<WaitTimer WaitTime="2"/>
 				</If>
             </If>
         </If>
@@ -211,6 +214,7 @@
 					<Dismount/>
 					<MoveTo Name="U'Ghamaro Aetheryte" XYZ="144.4336, 27.1674, -622.5881" />
 					<TurnInPlus QuestId="66694" NpcId="2002583" XYZ="144.4336, 27.1674, -622.5881" />
+					<WaitTimer WaitTime="2"/>
 				</If>
             </If>
         </If>
@@ -252,6 +256,7 @@
                 <If Condition="GetQuestStep(65899) == 255">
                     <GetTo ZoneId="145" XYZ="-17.22742, -10.01511, -18.50922" /> <!-- Ilberd -->
                     <TurnIn QuestId="65899" NpcId="1010845" XYZ="-17.22742, -10.01511, -18.50922" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -280,6 +285,7 @@
                 <If Condition="GetQuestStep(65900) == 255">
                     <GetTo ZoneId="145" XYZ="192.401, -27.4872, 199.3286" /> <!-- Ilberd -->
                     <TurnIn QuestId="65900" NpcId="1010849" XYZ="192.401, -27.4872, 199.3286" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -316,6 +322,7 @@
                     </If>
                     <MoveTo Name="Tataru" XYZ="-3.677429, 0.01804011, -7.034485" />
                     <TurnIn QuestId="65901" NpcId="1010891" XYZ="-3.677429, 0.01804011, -7.034485" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -396,6 +403,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-1.907471, 7.450581E-09, -3.128174" />
                     <TurnIn QuestId="65902" NpcId="1010858" XYZ="-1.907471, 7.450581E-09, -3.128174" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -490,6 +498,7 @@
                 <If Condition="GetQuestStep(65903) == 255">
                     <GetTo ZoneId="147" XYZ="-29.95355, 46.99734, 32.54749" /> <!-- Edelstein -->
                     <TurnIn QuestId="65903" NpcId="1006646" ItemId="2001548" XYZ="-29.95355, 46.99734, 32.54749" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -525,6 +534,7 @@
                 <If Condition="GetQuestStep(65904) == 255">
                     <GetTo ZoneId="147" XYZ="-29.95355, 46.99734, 32.54749" /> <!-- Edelstein -->
                     <TurnIn QuestId="65904" NpcId="1006646" XYZ="-29.95355, 46.99734, 32.54749" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -577,11 +587,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65905" NpcId="1011000" XYZ="-0.07635498, -1.995725, -42.25226" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="-0.07635498, -1.995725, -42.25226" />
                     <TurnIn QuestId="65905" NpcId="1011000" XYZ="-0.07635498, -1.995725, -42.25226" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -628,6 +640,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="0.9613037, -1.995725, -45.60925" />
                     <TurnIn QuestId="65965" NpcId="1010897" XYZ="0.9613037, -1.995725, -45.60925" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -691,6 +704,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-1.266479, -1.995725, -42.06915" />
                     <TurnIn QuestId="65906" NpcId="1010930" XYZ="-1.266479, -1.995725, -42.06915" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -726,6 +740,7 @@
                 <If Condition="GetQuestStep(65907) == 255">
                     <GetTo ZoneId="155" XYZ="-144.1825, 304.154, -300.7401" /> <!-- Alphinaud -->
                     <TurnIn QuestId="65907" NpcId="1010951" XYZ="-144.1825, 304.154, -300.7401" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -761,6 +776,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-2.792419, 0.01498272, -0.7477417" />
                     <TurnIn QuestId="65908" NpcId="1010953" XYZ="-2.792419, 0.01498272, -0.7477417" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -791,6 +807,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="0.503479, -1.995725, -42.61847" />
                     <TurnIn QuestId="65909" NpcId="1010896" XYZ="0.503479, -1.995725, -42.61847" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -852,6 +869,7 @@
                 <If Condition="GetQuestStep(65927) == 255">
                     <GetTo ZoneId="156" XYZ="33.27991, 20.495, -655.2072" /> <!-- Tataru -->
                     <TurnIn QuestId="65927" NpcId="1010961" XYZ="33.27991, 20.495, -655.2072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -887,6 +905,7 @@
                 <If Condition="GetQuestStep(65954) == 255">
                     <GetTo ZoneId="155" XYZ="-168.8411, 304.1538, -328.6641" /> <!-- Marcelain -->
                     <TurnIn QuestId="65954" NpcId="1006454" ItemId="2001548" XYZ="-168.8411, 304.1538, -328.6641" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -926,11 +945,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65955" NpcId="1010897" XYZ="0.9613037, -1.995725, -45.60925" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.9613037, -1.995725, -45.60925" />
                     <TurnIn QuestId="65955" NpcId="1010897" XYZ="0.9613037, -1.995725, -45.60925" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1003,6 +1024,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="0.9917603, -1.995725, -45.70081" />
                     <TurnIn QuestId="65956" NpcId="1008969" XYZ="0.9917603, -1.995725, -45.70081" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1043,6 +1065,7 @@
                 <If Condition="GetQuestStep(65957) == 255">
                     <GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
                     <TurnIn QuestId="65957" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1083,6 +1106,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="0.9917603, -1.995725, -45.70081" />
                     <TurnIn QuestId="65958" NpcId="1010897" XYZ="0.9917603, -1.995725, -45.70081" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1160,6 +1184,7 @@
                 <If Condition="GetQuestStep(65959) == 255">
                     <GetTo ZoneId="153" XYZ="-207.4464, 20.86788, 360.067" /> <!-- Unsettled Scholar -->
                     <TurnIn QuestId="65959" NpcId="1010984" XYZ="-207.4464, 20.86788, 360.067" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1199,11 +1224,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65960" NpcId="1010897" XYZ="0.9613037, -1.995725, -45.60925" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Minfilia" XYZ="0.9613037, -1.995725, -45.60925" />
                     <TurnIn QuestId="65960" NpcId="1010897" XYZ="0.9613037, -1.995725, -45.60925" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1228,6 +1255,7 @@
                 <If Condition="GetQuestStep(65961) == 255">
                     <GetTo ZoneId="131" XYZ="-6.149414, 29.99998, 19.15009" /> <!-- Minfilia -->
                     <TurnIn QuestId="65961" NpcId="1010992" XYZ="-6.149414, 29.99998, 19.15009" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1259,6 +1287,7 @@
                 <If Condition="GetQuestStep(65962) == 255">
                     <GetTo ZoneId="130" XYZ="21.07263, 7.45, -78.78235" /> <!-- Momodi -->
                     <TurnIn QuestId="65962" NpcId="1001353" ItemId="2001545" XYZ="21.07263, 7.45, -78.78235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1282,6 +1311,7 @@
                 <If Condition="GetQuestStep(65963) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="65963" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1297,6 +1327,7 @@
                 <If Condition="GetQuestStep(65964) == 255">
                     <GetTo ZoneId="155" XYZ="264.9119, 302.2624, -223.7126" /> <!-- House Fortemps Guard -->
                     <TurnInPlus QuestId="65964" NpcId="1007603" XYZ="264.9119, 302.2624, -223.7126" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] Class and Job Quests.xml
+++ b/Questing/[O] Class and Job Quests.xml
@@ -4020,10 +4020,10 @@
 						</If>
 						<If Condition="GetQuestStep(67549) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67549" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67549" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4036,11 +4036,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 34">
 					<If Condition="not HasQuest(67550)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67550)">
-							 <PickupQuest NpcId="1012222" QuestId="67550" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67550" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67550)">
@@ -4081,10 +4081,10 @@
 						</If>
 						<If Condition="GetQuestStep(67550) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67550" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67550" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4097,11 +4097,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 39">
 					<If Condition="not HasQuest(67551)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67551)">
-							 <PickupQuest NpcId="1012222" QuestId="67551" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67551" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67551)">
@@ -4133,10 +4133,10 @@
 					<If Condition="HasQuest(67552)">
 						<If Condition="GetQuestStep(67552) == 1">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Leveva" XYZ="202.3804, -5.399966, -58.9151" />
-							<TalkTo NpcId="1012222" QuestId="67552" StepId="1" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Leveva" XYZ="198.9282, -5.399965, -59.27039" />
+							<TalkTo NpcId="1012222" QuestId="67552" StepId="1" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 						<If Condition="GetQuestStep(67552) == 2">
 							<If Condition="not IsOnMap(129)">
@@ -4202,10 +4202,10 @@
 						</If>
 						<If Condition="GetQuestStep(67552) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67552" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67552" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4218,11 +4218,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 44">
 					<If Condition="not HasQuest(67553)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67553)">
-							<PickupQuest NpcId="1012222" QuestId="67553" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67553" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67553)">
@@ -4235,10 +4235,10 @@
 						</If>
 						<If Condition="GetQuestStep(67553) == 2">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<HandOver ItemIds="2001819" QuestId="67553" StepId="2" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<HandOver ItemIds="2001819" QuestId="67553" StepId="2" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 						<If Condition="GetQuestStep(67553) == 3">
 							<If Condition="not IsOnMap(156)">
@@ -4265,10 +4265,10 @@
 						</If>
 						<If Condition="GetQuestStep(67553) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67553" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67553" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4281,11 +4281,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 49">
 					<If Condition="not HasQuest(67554)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67554)">
-							<PickupQuest NpcId="1012222" QuestId="67554" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67554" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67554)">
@@ -4317,10 +4317,10 @@
 					<If Condition="HasQuest(67555)">
 						<If Condition="GetQuestStep(67555) == 1">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TalkTo NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" QuestId="67555" StepId="1" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TalkTo NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" QuestId="67555" StepId="1" />
 						</If>
 						<If Condition="GetQuestStep(67555) == 2">
 							<If Condition="not IsOnMap(155)">
@@ -4410,10 +4410,10 @@
 						</While>
 						<If Condition="GetQuestStep(67556) == 2">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TalkTo NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" QuestId="67556" StepId="2" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TalkTo NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" QuestId="67556" StepId="2" />
 						</If>
 						<If Condition="GetQuestStep(67556) == 3">
 							<If Condition="not IsOnMap(419)">
@@ -4438,10 +4438,10 @@
 						</If>
 						<If Condition="GetQuestStep(67556) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67556" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67556" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4454,11 +4454,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 51">
 					<If Condition="not HasQuest(67557)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67557)">
-							 <PickupQuest NpcId="1012222" QuestId="67557" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67557" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67557)">
@@ -4520,10 +4520,10 @@
 						</If>
 						<If Condition="GetQuestStep(67557) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67557" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67557" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4536,11 +4536,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 53">
 					<If Condition="not HasQuest(67558)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67558)">
-							 <PickupQuest NpcId="1012222" QuestId="67558" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67558" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67558)">
@@ -4579,10 +4579,10 @@
 						</If>
 						<If Condition="GetQuestStep(67558) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67558" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67558" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4595,11 +4595,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 55">
 					<If Condition="not HasQuest(67559)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67559)">
-							 <PickupQuest NpcId="1012222" QuestId="67559" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67559" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67559)">
@@ -4647,10 +4647,10 @@
 						</If>
 						<If Condition="GetQuestStep(67559) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67559" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67559" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4666,11 +4666,11 @@
 				<!-- <If Condition="Core.Player.ClassLevel &gt; 57">
 					<If Condition="not HasQuest(67560)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67560)">
-							 <PickupQuest NpcId="1012222" QuestId="67560" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67560" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67560)">
@@ -4732,10 +4732,10 @@
 						</If>
 						<If Condition="GetQuestStep(67560) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67560" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67560" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4748,11 +4748,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 59">
 					<If Condition="not HasQuest(67561)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67561)">
-							 <PickupQuest NpcId="1012222" QuestId="67561" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67561" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67561)">
@@ -4802,10 +4802,10 @@
 						</If>
 						<If Condition="GetQuestStep(67561) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67561" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67561" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4819,7 +4819,7 @@
 					<If Condition="not HasQuest(67945)">
 						<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
 						<If Condition="IsQuestAcceptQualified(67945)">
-							<PickupQuest NpcId="1012222" QuestId="67945" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67945" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67945)">
@@ -4865,7 +4865,7 @@
 						</If>
 						<If Condition="GetQuestStep(67946) == 255">
 							<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
-							<TurnIn QuestId="67946" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<TurnIn QuestId="67946" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4879,7 +4879,7 @@
 					<If Condition="not HasQuest(67947)">
 						<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
 						<If Condition="IsQuestAcceptQualified(67947)">
-							<PickupQuest NpcId="1012222" QuestId="67947" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67947" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67947)">

--- a/Questing/[O] Class and Job Quests.xml
+++ b/Questing/[O] Class and Job Quests.xml
@@ -62,6 +62,7 @@
 						<If Condition="GetQuestStep(65990) == 255">
 							<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 							<TurnIn QuestId="65990" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -102,6 +103,7 @@
 							<If Condition="GetQuestStep(65991) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim-->
 								<TurnIn QuestId="65991" NpcId="1000909" ItemId="2000796" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -155,6 +157,7 @@
 							<If Condition="GetQuestStep(65992) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65992" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -208,6 +211,7 @@
 							<If Condition="GetQuestStep(65993) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65993" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -234,6 +238,7 @@
 							<If Condition="GetQuestStep(66639) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="66639" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -282,6 +287,7 @@
 							<If Condition="GetQuestStep(65994) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65994" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -337,6 +343,7 @@
 							<If Condition="GetQuestStep(65995) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65995" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -465,6 +472,7 @@
 								</If>
 								<MoveTo Name="Thubyrgeim" XYZ="-326.3752, 12.89966, 9.994568" />
 								<TurnIn QuestId="65996" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -580,6 +588,7 @@
 								</If>
 								<MoveTo Name="Thubyrgeim" XYZ="-326.3752, 12.89966, 9.994568" />
 								<TurnIn QuestId="65997" NpcId="1000909" ItemId="2000889" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -648,6 +657,7 @@
 								</If>
 								<MoveTo Name="Alka Zolka" XYZ="-4.470947, 44.99989, -250.5685" />
 								<TurnIn QuestId="66633" NpcId="1006757" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -707,6 +717,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66627" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -773,6 +784,7 @@
 								</If>
 								<MoveTo Name="Alka Zolka" XYZ="-4.470947, 44.99989, -250.5685" />
 								<TurnIn NpcId="1006757" QuestId="66634" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -826,6 +838,7 @@
 								</If>
 								<MoveTo Name="Alka Zolka" XYZ="-4.470947, 44.99989, -250.5685" />
 								<TurnIn NpcId="1006757" QuestId="66635" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -895,6 +908,7 @@
 								<BotSettings AutoEquip="0" />
 								<RunCode Name="In_the_Image_of_the_Ancients" />
 								<TurnIn NpcId="1006757" QuestId="66636" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 								<BotSettings AutoEquip="1" />
 							</While>
 						</If>
@@ -956,6 +970,7 @@
 							<If Condition="GetQuestStep(66637) == 255">
 								<GetTo ZoneId="128" XYZ="-4.470947, 44.99989, -250.5685" /> <!-- Alka Zolka -->
 								<TurnIn NpcId="1006757" QuestId="66637" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1027,6 +1042,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="231.7997, 5.184731, 61.14282" />
 								<TurnIn QuestId="66638" NpcId="1007849" XYZ="231.7997, 5.184731, 61.14282" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1079,6 +1095,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67207" ItemId="2001585" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1147,6 +1164,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67208" ItemId="2001586" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1217,6 +1235,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67209" ItemId="2001587" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1290,6 +1309,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="404.1962, -2.608213, 212.1156" />
 								<TurnIn QuestId="67210" NpcId="1013138" XYZ="404.1962, -2.608213, 212.1156" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1352,6 +1372,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67211" ItemId="2001588" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -1443,6 +1464,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="491.4778, 16.49544, 69.16907" />
 								<TurnIn QuestId="67212" NpcId="1013199" XYZ="491.4778, 16.49544, 69.16907" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1474,6 +1496,7 @@
 							<If Condition="GetQuestStep(68459) == 255">
 								<GetTo ZoneId="139" XYZ="206.0426, -3.111818, 41.94702" /> <!-- Surito Carito -->
 								<TurnIn QuestId="68459" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1521,6 +1544,7 @@
 							<If Condition="GetQuestStep(68460) == 255">
 								<GetTo ZoneId="153" XYZ="-220.8439, 21.26176, 363.3936" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68460" NpcId="1021911" XYZ="-220.8439, 21.26176, 363.3936" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1574,6 +1598,7 @@
 							<If Condition="GetQuestStep(68461) == 255">
 								<GetTo ZoneId="153" XYZ="-220.8439, 21.26176, 363.3936" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68461" NpcId="1021911" XYZ="-220.8439, 21.26176, 363.3936" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1613,6 +1638,7 @@
 							<If Condition="GetQuestStep(68462) == 255">
 								<GetTo ZoneId="153" XYZ="-220.8439, 21.26176, 363.3936" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68462" NpcId="1021911" XYZ="-220.8439, 21.26176, 363.3936" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1681,6 +1707,7 @@
 							<If Condition="GetQuestStep(68463) == 255">
 								<GetTo ZoneId="139" XYZ="206.8054, -3.065021, 43.83911" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68463" NpcId="1021918" XYZ="206.8054, -3.065021, 43.83911" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1748,6 +1775,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66628" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1780,6 +1808,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66629" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1864,6 +1893,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66630" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1913,6 +1943,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66631" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1977,6 +2008,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66632" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2016,6 +2048,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="67636" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2071,6 +2104,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67637" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2123,6 +2157,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67638" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2176,6 +2211,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67639" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2237,6 +2273,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67640" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2286,6 +2323,7 @@
 								</If>
 								<NoCombatMoveTo Name="Y'mhitra" XYZ="264.515, 232.541, 728.8472" />
 								<TurnIn QuestId="67641" NpcId="1014044" XYZ="264.515, 232.541, 728.8472" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2322,6 +2360,7 @@
 							<If Condition="GetQuestStep(68161) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68161" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2364,6 +2403,7 @@
 							<If Condition="GetQuestStep(68162) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68162" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2422,6 +2462,7 @@
 							<If Condition="GetQuestStep(68163) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68163" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2457,6 +2498,7 @@
 							<If Condition="GetQuestStep(68164) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68164" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2528,6 +2570,7 @@
 							<If Condition="GetQuestStep(68165) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> --> <!-- Y'mhitra -->
 								<!-- <TurnIn QuestId="68165" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+ <WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -2572,6 +2615,7 @@
 						<If Condition="GetQuestStep(65755) == 255">
 							<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 							<TurnIn QuestId="65755" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -2619,6 +2663,7 @@
 							<If Condition="GetQuestStep(65582) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65582" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2673,6 +2718,7 @@
 							<If Condition="GetQuestStep(65603) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65603" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2730,6 +2776,7 @@
 							<If Condition="GetQuestStep(65670) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65670" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2791,6 +2838,7 @@
 							<If Condition="GetQuestStep(65604) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65604" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2867,6 +2915,7 @@
 								</If>
 								<MoveTo Name="Luciane" XYZ="209.5521, 0.9999819, 35.01941" />
 								<TurnIn QuestId="65606" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2928,6 +2977,7 @@
 								</If>
 								<MoveTo Name="Luciane" XYZ="209.5521, 0.9999819, 35.01941" />
 								<TurnIn QuestId="65607" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2988,6 +3038,7 @@
 								</If>
 								<MoveTo Name="Luciane" XYZ="209.5521, 0.9999819, 35.01941" />
 								<TurnIn QuestId="65612" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3045,6 +3096,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66621" NpcId="1006750" ItemId="2000813" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3096,6 +3148,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66622" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3128,6 +3181,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66623" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3171,6 +3225,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66624" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3231,6 +3286,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66625" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3275,6 +3331,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="70.17627, 226.7221, 381.3076" />
 								<TurnIn QuestId="66626" NpcId="1007891" XYZ="70.17627, 226.7221, 381.3076" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3356,6 +3413,7 @@
 								</If>
 								<MoveTo Name="Sanson" XYZ="-52.5368, 8.059148, 31.72351" />
 								<TurnIn QuestId="67249" NpcId="1014208" XYZ="-52.5368, 8.059148, 31.72351" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3409,6 +3467,7 @@
 								</If>
 								<NoCombatMoveTo Name="Sanson" XYZ="445.365, 212.5398, 699.7938" />
 								<TurnIn QuestId="67250" NpcId="1014216" XYZ="445.365, 212.5398, 699.7938" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3483,6 +3542,7 @@
 								</If>
 								<NoCombatMoveTo Name="Sanson" XYZ="544.976, -51.27571, 65.38477" />
 								<TurnIn QuestId="67251" NpcId="1014232" XYZ="544.976, -51.27571, 65.38477" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3532,6 +3592,7 @@
 								</If>
 								<NoCombatMoveTo Name="Sanson" XYZ="544.976, -51.27571, 65.38477" />
 								<TurnIn QuestId="67252" NpcId="1014231" XYZ="544.976, -51.27571, 65.38477" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3620,6 +3681,7 @@
 								</If>
 								<NoCombatMoveTo Name="Moglin" XYZ="381.7043, -66.84979, 700.8619" />
 								<TurnIn QuestId="67253" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3701,6 +3763,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="67254" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -3732,6 +3795,7 @@
 							<If Condition="GetQuestStep(68426) == 255">
 								<GetTo ZoneId="612" XYZ="-653.132, 130, -523.827" /> <!-- Nourval -->
 								<TurnIn QuestId="68426" NpcId="1022511" XYZ="-653.132, 130, -523.827" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3763,6 +3827,7 @@
 							<If Condition="GetQuestStep(68427) == 255">
 								<GetTo ZoneId="612" XYZ="-650.9041, 130, -520.8667" /> <!-- Guydelot -->
 								<TurnIn QuestId="68427" NpcId="1022513" XYZ="-650.9041, 130, -520.8667" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3806,6 +3871,7 @@
 							<If Condition="GetQuestStep(68428) == 255">
 								<GetTo ZoneId="612" XYZ="-653.0403, 130, -522.179" /> <!-- Sanson -->
 								<TurnIn QuestId="68428" NpcId="1022523" XYZ="-653.0403, 130, -522.179" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3841,6 +3907,7 @@
 							<If Condition="GetQuestStep(68429) == 255">
 								<GetTo ZoneId="132" XYZ="-52.35376, -3.326972, 20.58435" /> <!-- Guydelot -->
 								<TurnIn QuestId="68429" NpcId="1022528" XYZ="-52.35376, -3.326972, 20.58435" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3900,6 +3967,7 @@
 							<If Condition="GetQuestStep(68430) == 255">
 								<GetTo ZoneId="153" XYZ="16.46442, 6.750492, -7.339661" /> <!-- Jehantel -->
 								<TurnIn QuestId="68430" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3956,6 +4024,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67549" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4016,6 +4085,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67550" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4041,6 +4111,7 @@
 							</If>
 							<MoveTo Name="Leveva" XYZ="199.9388, -0.899981, -48.72211" />
 							<TurnIn QuestId="67551" NpcId="1014944" XYZ="199.9388, -0.899981, -48.72211" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4135,6 +4206,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67552" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4197,6 +4269,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67553" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4222,6 +4295,7 @@
 							</If>
 							<MoveTo Name="Leveva" XYZ="199.9388, -0.899981, -48.72211" />
 							<TurnIn QuestId="67554" NpcId="1014944" XYZ="199.9388, -0.899981, -48.72211" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4306,6 +4380,7 @@
 							</If>
 							<NoCombatMoveTo Name="Destination" XYZ="205.9204, 307.8507, 412.2529" />
 							<TurnIn QuestId="67555" NpcId="2006367" XYZ="205.9204, 307.8507, 412.2529" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4367,6 +4442,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67556" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4448,6 +4524,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67557" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4506,6 +4583,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67558" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4573,6 +4651,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67559" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4657,6 +4736,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67560" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If> -->
@@ -4726,6 +4806,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67561" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4753,6 +4834,7 @@
 						<If Condition="GetQuestStep(67945) == 255">
 							<GetTo ZoneId="419" XYZ="195.1781, -5.399962, -67.06348" /> <!-- Leveva -->
 							<TurnIn QuestId="67945" NpcId="1021191" XYZ="195.1781, -5.399962, -67.06348" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4784,6 +4866,7 @@
 						<If Condition="GetQuestStep(67946) == 255">
 							<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
 							<TurnIn QuestId="67946" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4849,6 +4932,7 @@
 						<If Condition="GetQuestStep(67947) == 255">
 							<GetTo ZoneId="628" XYZ="98.10022, 4.000001, 87.44946" /> <!-- Kyokuho -->
 							<TurnIn QuestId="67947" NpcId="1021262" XYZ="98.10022, 4.000001, 87.44946" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4884,6 +4968,7 @@
 						<If Condition="GetQuestStep(67948) == 255">
 							<GetTo ZoneId="628" XYZ="98.10022, 4.000001, 87.44946" /> <!-- Kyokuho -->
 							<TurnIn QuestId="67948" NpcId="1021262" XYZ="98.10022, 4.000001, 87.44946" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4938,6 +5023,7 @@
 						<If Condition="GetQuestStep(67949) == 255">
 							<GetTo ZoneId="628" XYZ="-47.50134, 16.62471, 9.719971" /> <!-- Kyokuho -->
 							<TurnIn QuestId="67949" NpcId="1021309" XYZ="-47.50134, 16.62471, 9.719971" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4980,6 +5066,7 @@
 						<If Condition="GetQuestStep(65747) == 255">
 							<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 							<TurnIn QuestId="65747" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -5010,6 +5097,7 @@
 							<If Condition="GetQuestStep(65584) == 255">
 								<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65584" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5058,6 +5146,7 @@
 							<If Condition="GetQuestStep(65627) == 255">
 								<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65627" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5106,6 +5195,7 @@
 							<If Condition="GetQuestStep(65683) == 255">
 								<MoveTo XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65683" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5161,6 +5251,7 @@
 							<If Condition="GetQuestStep(65628) == 255">
 								<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65628" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5228,6 +5319,7 @@
 								</If>
 								<MoveTo Name="E-Sumi-Yan" XYZ="-258.8083, -5.773526, -27.26788" />
 								<TurnIn QuestId="65629" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5293,6 +5385,7 @@
 								</If>
 								<MoveTo Name="E-Sumi-Yan" XYZ="-258.8083, -5.773526, -27.26788" />
 								<TurnIn QuestId="65976" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5376,6 +5469,7 @@
 								</If>
 								<MoveTo Name="E-Sumi-Yan" XYZ="-258.8083, -5.773526, -27.26788" />
 								<TurnIn QuestId="65977" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5419,6 +5513,7 @@
 								</If>
 								<MoveTo Name="Braya" XYZ="-243.1525, -4.000004, -7.950012" />
 								<TurnIn QuestId="65730" NpcId="1000705" XYZ="-243.1525, -4.000004, -7.950012" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5478,6 +5573,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="66615" NpcId="1006751" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5533,6 +5629,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66616" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5580,6 +5677,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66617" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5672,6 +5770,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66618" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5735,6 +5834,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="66619" NpcId="1006751" ItemId="2000944" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5797,6 +5897,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66620" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5870,6 +5971,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="-45.02942, -40.95, 174.3037" />
 								<TurnIn QuestId="67255" NpcId="1013609" XYZ="-45.02942, -40.95, 174.3037" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5935,6 +6037,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="209.2164, 302, -204.8524" />
 								<TurnIn QuestId="67256" NpcId="1013610" XYZ="209.2164, 302, -204.8524" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6003,6 +6106,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="463.5232, 200.2377, 651.911" />
 								<TurnIn QuestId="67257" NpcId="1013614" XYZ="463.5232, 200.2377, 651.911" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6049,6 +6153,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="486.9305, -51.1414, 25.98608" />
 								<TurnIn QuestId="67258" NpcId="1013623" XYZ="486.9305, -51.1414, 25.98608" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6102,6 +6207,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="-679.9573, -100.524, 775.1736" />
 								<TurnIn QuestId="67259" NpcId="1013625" XYZ="-679.9573, -100.524, 775.1736" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6131,6 +6237,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="67260" NpcId="1006751" ItemId="2001688" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6227,6 +6334,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="67261" NpcId="1006751" ItemId="2001688" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6269,6 +6377,7 @@
 							<If Condition="GetQuestStep(67950) == 255">
 								<GetTo ZoneId="612" XYZ="-622.5834, 130.265, -473.7469" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="67950" NpcId="1018752" XYZ="-622.5834, 130.265, -473.7469" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6300,6 +6409,7 @@
 							<If Condition="GetQuestStep(67951) == 255">
 								<GetTo ZoneId="612" XYZ="-623.621, 130.2421, -474.7234" /> <!-- Sylphie -->
 								<TurnIn QuestId="67951" NpcId="1018753" XYZ="-623.621, 130.2421, -474.7234" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6348,6 +6458,7 @@
 							<If Condition="GetQuestStep(67952) == 255">
 								<GetTo ZoneId="612" XYZ="-623.621, 130.2421, -474.7234" /> <!-- Sylphie -->
 								<TurnIn QuestId="67952" NpcId="1018753" XYZ="-623.621, 130.2421, -474.7234" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6379,6 +6490,7 @@
 							<If Condition="GetQuestStep(67953) == 255">
 								<GetTo ZoneId="612" XYZ="-655.024, 40.43195, 375.967" /> <!-- Sylphie -->
 								<TurnIn QuestId="67953" NpcId="1019132" XYZ="-655.024, 40.43195, 375.967" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6437,6 +6549,7 @@
 							<If Condition="GetQuestStep(67954) == 255">
 								<GetTo ZoneId="612" XYZ="-382.7115, 40.27582, 484.3669" /> <!-- Gatty -->
 								<TurnIn QuestId="67954" NpcId="1019588" XYZ="-382.7115, 40.27582, 484.3669" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6528,6 +6641,7 @@
 							</If>
 							<MoveTo Name="Fray" XYZ="43.38135, 16.0801, -86.04565" />
 							<TurnIn QuestId="67590" NpcId="1014889" XYZ="43.38135, 16.0801, -86.04565" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6602,6 +6716,7 @@
 							</If>
 							<NoCombatMoveTo Name="Fray" XYZ="-215.7168, 16.84427, -270.6493" />
 							<TurnIn QuestId="67591" NpcId="1014893" XYZ="-215.7168, 16.84427, -270.6493" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6693,6 +6808,7 @@
 							</If>
 							<NoCombatMoveTo Name="Fray" XYZ="-367.1473, -55.99894, 107.103" />
 							<TurnIn QuestId="67592" NpcId="1014895" XYZ="-367.1473, -55.99894, 107.103" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6762,6 +6878,7 @@
 							</If>
 							<NoCombatMoveTo Name="Fray" XYZ="235.6755, 7.999999, 698.207" />
 							<TurnIn QuestId="67593" NpcId="1014901" XYZ="235.6755, 7.999999, 698.207" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6834,6 +6951,7 @@
 							</If>
 							<NoCombatMoveTo Name="Untiring Knight" XYZ="-431.2657, 211, -251.2093" />
 							<TurnIn QuestId="67594" NpcId="1014908" XYZ="-431.2657, 211, -251.2093" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6874,6 +6992,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67595" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6941,6 +7060,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67596" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7025,6 +7145,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67597" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7085,6 +7206,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67598" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7172,6 +7294,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67599" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7223,6 +7346,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67600" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7274,6 +7398,7 @@
 						<If Condition="GetQuestStep(68451) == 255">
 							<GetTo ZoneId="397" XYZ="482.0782, 203.4332, 680.7506" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68451" NpcId="1022866" XYZ="482.0782, 203.4332, 680.7506" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7318,6 +7443,7 @@
 						<If Condition="GetQuestStep(68452) == 255">
 							<GetTo ZoneId="398" XYZ="461.4175, -51.1414, 43.4729" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68452" NpcId="1022885" XYZ="461.4175, -51.1414, 43.4729" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7386,6 +7512,7 @@
 						<If Condition="GetQuestStep(68453) == 255">
 							<GetTo ZoneId="400" XYZ="253.0708, -43.13636, 626.8864" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68453" NpcId="1022953" XYZ="253.0708, -43.13636, 626.8864" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7441,6 +7568,7 @@
 						<If Condition="GetQuestStep(68454) == 255">
 							<GetTo ZoneId="418" XYZ="104.2344, 14.99999, 40.78735" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68454" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7514,6 +7642,7 @@
 						<If Condition="GetQuestStep(68455) == 255">
 							<GetTo ZoneId="419" XYZ="2.670288, 11.94781, 36.97253" /> <!-- Where It All Began -->
 							<TurnIn QuestId="68455" NpcId="2008885" XYZ="2.670288, 11.94781, 36.97253" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7556,6 +7685,7 @@
 						<If Condition="GetQuestStep(65822) == 255">
 							<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 							<TurnIn QuestId="65822" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7610,6 +7740,7 @@
 							<If Condition="GetQuestStep(65792) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65792" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7658,6 +7789,7 @@
 							<If Condition="GetQuestStep(65797) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65797" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7706,6 +7838,7 @@
 							<If Condition="GetQuestStep(65824) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65824" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7751,6 +7884,7 @@
 							<If Condition="GetQuestStep(65798) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65798" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7836,6 +7970,7 @@
 								</If>
 								<MoveTo Name="Mylla" XYZ="-94.52972, 6.500001, 39.81079" />
 								<TurnIn QuestId="65799" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7904,6 +8039,7 @@
 								</If>
 								<MoveTo Name="Mylla" XYZ="-94.52972, 6.500001, 39.81079" />
 								<TurnIn QuestId="65800" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7986,6 +8122,7 @@
 								</If>
 								<MoveTo Name="Mylla" XYZ="-94.52972, 6.500001, 39.81079" />
 								<TurnIn QuestId="65801" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8043,6 +8180,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66591" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8089,6 +8227,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66592" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8121,6 +8260,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66593" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8163,6 +8303,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66594" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8204,6 +8345,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66595" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8259,6 +8401,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66596" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8319,6 +8462,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jenlyns" XYZ="75.33374, 2.135708, 316.3347" />
 								<TurnIn QuestId="67568" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8367,6 +8511,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67569" NpcId="1014054" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8468,6 +8613,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67570" NpcId="1014065" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8514,6 +8660,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="51.13293, 124.9563, 178.6984" />
 								<TurnIn QuestId="67571" NpcId="1014068" XYZ="51.13293, 124.9563, 178.6984" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8595,6 +8742,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67572" NpcId="1015055" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8672,6 +8820,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67573" NpcId="1014103" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8703,6 +8852,7 @@
 							<If Condition="GetQuestStep(68107) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68107" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8756,6 +8906,7 @@
 							<If Condition="GetQuestStep(68108) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68108" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8797,6 +8948,7 @@
 							<If Condition="GetQuestStep(68109) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68109" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8847,6 +8999,7 @@
 							<If Condition="GetQuestStep(68110) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68110" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8886,6 +9039,7 @@
 							<If Condition="GetQuestStep(68111) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68111" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8930,6 +9084,7 @@
 						<If Condition="GetQuestStep(65754) == 255">
 							<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 							<TurnIn QuestId="65754" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -8977,6 +9132,7 @@
 							<If Condition="GetQuestStep(65583) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65583" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9004,6 +9160,7 @@
 							<If Condition="GetQuestStep(65571) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65571" NpcId="1000254" ItemId="2000102" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9031,6 +9188,7 @@
 							<If Condition="GetQuestStep(65679) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65679" NpcId="1000254" ItemId="2000122" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9074,6 +9232,7 @@
 							<If Condition="GetQuestStep(65591) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65591" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9153,6 +9312,7 @@
 								</If>
 								<NoCombatMoveTo Name="Ywain" XYZ="157.7019, 15.90038, -270.3442" />
 								<TurnIn QuestId="65592" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9248,6 +9408,7 @@
 								</If>
 								<NoCombatMoveTo Name="Ywain" XYZ="157.7019, 15.90038, -270.3442" />
 								<TurnIn QuestId="65974" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9303,6 +9464,7 @@
 								</If>
 								<NoCombatMoveTo Name="Ywain" XYZ="157.7019, 15.90038, -270.3442" />
 								<TurnIn QuestId="65975" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9369,6 +9531,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66603" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9431,6 +9594,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66604" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9471,6 +9635,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66605" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9569,6 +9734,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66606" NpcId="1006748" ItemIds="2000814,2000815" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9601,6 +9767,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66607" NpcId="1006748" ItemId="2000824" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9641,6 +9808,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66608" NpcId="1006748" ItemId="2000824" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9673,6 +9841,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67225" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9721,6 +9890,7 @@
 								</If>
 								<NoCombatMoveTo Name="Heustienne" XYZ="202.1973, 183.6595, -96.11658" />
 								<TurnIn QuestId="67226" NpcId="1013445" XYZ="202.1973, 183.6595, -96.11658" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9753,6 +9923,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67227" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9815,6 +9986,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67228" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9861,6 +10033,7 @@
 								</If>
 								<NoCombatMoveTo Name="Montorgains" XYZ="218.0056, 222, 346.4561" />
 								<TurnIn QuestId="67229" NpcId="1013470" XYZ="218.0056, 222, 346.4561" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9915,6 +10088,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67230" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9985,6 +10159,7 @@
 								</If>
 								<NoCombatMoveTo Name="Heustienne" XYZ="-505.3026, 120.6116, -311.3909" />
 								<TurnIn QuestId="67231" NpcId="1013494" XYZ="-505.3026, 120.6116, -311.3909" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10008,6 +10183,7 @@
 							<If Condition="GetQuestStep(68446) == 255">
 								<GetTo ZoneId="155" XYZ="217.8835, 222, 345.3269" /> <!-- Alberic -->
 								<TurnIn QuestId="68446" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10043,6 +10219,7 @@
 							<If Condition="GetQuestStep(68447) == 255">
 								<GetTo ZoneId="155" XYZ="217.8835, 222, 345.3269" /> <!-- Alberic -->
 								<TurnIn QuestId="68447" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10087,6 +10264,7 @@
 							<If Condition="GetQuestStep(68448) == 255">
 								<GetTo ZoneId="628" XYZ="-92.60706, 18.9999, -194.4152" /> <!-- Orn Khai -->
 								<TurnIn QuestId="68448" NpcId="1022553" XYZ="-92.60706, 18.9999, -194.4152" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10150,6 +10328,7 @@
 							<If Condition="GetQuestStep(68449) == 255">
 								<GetTo ZoneId="622" XYZ="528.4656, -19.45055, 273.3348" /> <!-- Orn Khai -->
 								<TurnIn QuestId="68449" NpcId="1022560" XYZ="528.4656, -19.45055, 273.3348" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10191,6 +10370,7 @@
 							<If Condition="GetQuestStep(68450) == 255">
 								<GetTo ZoneId="622" XYZ="-494.3466, 71.27808, -509.514" /> <!-- Orn Khai -->
 								<TurnIn QuestId="68450" NpcId="1022562" XYZ="-494.3466, 71.27808, -509.514" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10247,6 +10427,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67233" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10335,6 +10516,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67234" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10360,6 +10542,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67235" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10441,6 +10624,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67236" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10466,6 +10650,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67237" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10531,6 +10716,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67238" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10595,6 +10781,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67239" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10659,6 +10846,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67240" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10698,6 +10886,7 @@
 							</If>
 							<MoveTo Name="Count Baurendouin De Haillenarte" XYZ="-152.8802, 17, -52.90308" />
 							<TurnIn QuestId="67241" NpcId="1014796" XYZ="-152.8802, 17, -52.90308" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10766,6 +10955,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67242" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10835,6 +11025,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67243" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10903,6 +11094,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67244" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10953,6 +11145,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67246" NpcId="1014577" ItemId="2001818" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10992,6 +11185,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67247" NpcId="1014577" ItemId="2001818" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11062,6 +11256,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67248" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11095,6 +11290,7 @@
 						<If Condition="GetQuestStep(68441) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68441" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11134,6 +11330,7 @@
 						<If Condition="GetQuestStep(68442) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68442" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11174,6 +11371,7 @@
 						<If Condition="GetQuestStep(68443) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68443" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11214,6 +11412,7 @@
 						<If Condition="GetQuestStep(68444) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68444" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11253,6 +11452,7 @@
 						<If Condition="GetQuestStep(68445) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68445" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11295,6 +11495,7 @@
 						<If Condition="GetQuestStep(65848) == 255">
 							<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 							<TurnIn QuestId="65848" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11367,6 +11568,7 @@
 							<If Condition="GetQuestStep(65849) == 255">
 								<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65849" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11398,6 +11600,7 @@
 							<If Condition="GetQuestStep(65850) == 255">
 								<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65850" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11429,6 +11632,7 @@
 							<If Condition="GetQuestStep(65851) == 255">
 								<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65851" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11500,6 +11704,7 @@
 								</If>
 								<MoveTo XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65852" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11586,6 +11791,7 @@
 								</If>
 								<MoveTo Name="Wyrnzoen" XYZ="-1.205505, 44.99989, -255.8786" />
 								<TurnIn QuestId="65853" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11636,6 +11842,7 @@
 								</If>
 								<MoveTo Name="Wyrnzoen" XYZ="-1.205505, 44.99989, -255.8786" />
 								<TurnIn QuestId="65854" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11734,6 +11941,7 @@
 								</If>
 								<MoveTo Name="Wyrnzoen" XYZ="-1.205505, 44.99989, -255.8786" />
 								<TurnIn QuestId="65855" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11807,6 +12015,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66585" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11868,6 +12077,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66586" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11939,6 +12149,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66587" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12032,6 +12243,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66588" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12072,6 +12284,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66589" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12132,6 +12345,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66590" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12197,6 +12411,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66121" NpcId="1013279" ItemId="2001589" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12245,6 +12460,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66122" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12301,6 +12517,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66124" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>						
 						</If>
 					</If>
@@ -12410,6 +12627,7 @@
 								</If>
 								<NoCombatMoveTo Name="Storm Captain" XYZ="304.1886, -36.40591, 332.6923" />
 								<TurnIn QuestId="66132" NpcId="1013282" ItemId="2001662" XYZ="304.1886, -36.40591, 332.6923" />
+								<WaitTimer WaitTime="2"/>
 							</If> 
 						</If>
 					</If>
@@ -12458,6 +12676,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="67213" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12560,6 +12779,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66134" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12644,6 +12864,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="-109.9718, -24.72433, 63.55383" />
 								<TurnIn QuestId="66137" NpcId="1013329" ItemId="2001886" XYZ="-109.9718, -24.72433, 63.55383" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12681,6 +12902,7 @@
 							<If Condition="GetQuestStep(68436) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68436" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12718,6 +12940,7 @@
 							<If Condition="GetQuestStep(68436) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68436" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12753,6 +12976,7 @@
 							<If Condition="GetQuestStep(68437) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68437" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12796,6 +13020,7 @@
 							<If Condition="GetQuestStep(68438) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68438" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12833,6 +13058,7 @@
 							<If Condition="GetQuestStep(68439) == 255">
 								<GetTo ZoneId="622" XYZ="525.1088, -19.50681, 403.3722" /> <!-- Curious Gorge -->
 								<TurnIn QuestId="68439" NpcId="1022836" XYZ="525.1088, -19.50681, 403.3722" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12896,6 +13122,7 @@
 							<If Condition="GetQuestStep(68440) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68440" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12940,6 +13167,7 @@
 						<If Condition="GetQuestStep(66089) == 255">
 							<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 							<TurnIn QuestId="66089" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -12986,6 +13214,7 @@
 							<If Condition="GetQuestStep(66090) == 255">
 								<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 								<TurnIn QuestId="66090" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13021,6 +13250,7 @@
 							<If Condition="GetQuestStep(66091) == 255">
 								<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 								<TurnIn QuestId="66091" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13056,6 +13286,7 @@
 							<If Condition="GetQuestStep(66234) == 255">
 								<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 								<TurnIn QuestId="66234" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13110,6 +13341,7 @@
 							<If Condition="GetQuestStep(66094) == 255">
 								<GetTo ZoneId="130" XYZ="-65.65961, 0.9482077, -51.98755" /> <!-- Chuchuto -->
 								<TurnIn QuestId="66094" NpcId="1003827" XYZ="-65.65961, 0.9482077, -51.98755" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13175,6 +13407,7 @@
 								</If>
 								<MoveTo Name="Hamon" XYZ="-74.57086, 2.000005, -42.40485" />
 								<TurnIn QuestId="66098" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13246,6 +13479,7 @@
 								</If>
 								<MoveTo Name="Hamon" XYZ="-74.57086, 2.000005, -42.40485" />
 								<TurnIn QuestId="66102" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13318,6 +13552,7 @@
 								</If>
 								<MoveTo Name="Hamon" XYZ="-74.57086, 2.000005, -42.40485" />
 								<TurnIn QuestId="66103" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13378,6 +13613,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66597" NpcId="1006749" ItemId="2001061" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13437,6 +13673,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66598" NpcId="1006749" ItemId="2001062" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13483,6 +13720,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66599" NpcId="1006749" ItemId="2001063" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13522,6 +13760,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66600" NpcId="1006749" ItemId="2001064" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13607,6 +13846,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66601" NpcId="1006749" ItemId="2001064" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13653,6 +13893,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="104.7227, -4.938011, -533.5317" />
 								<TurnIn QuestId="66602" NpcId="1007899" XYZ="104.7227, -4.938011, -533.5317" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13729,6 +13970,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67562" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13810,6 +14052,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67563" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13857,6 +14100,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67564" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13903,6 +14147,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67565" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13966,6 +14211,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67566" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -14014,6 +14260,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="-149.3401, 12.68588, -260.9141" />
 								<TurnIn QuestId="67567" NpcId="1014112" XYZ="-149.3401, 12.68588, -260.9141" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14045,6 +14292,7 @@
 							<If Condition="GetQuestStep(67962) == 255">
 								<GetTo ZoneId="156" XYZ="15.85406, 28.62082, -682.765" /> <!-- Widargelt -->
 								<TurnIn QuestId="67962" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14088,6 +14336,7 @@
 							<If Condition="GetQuestStep(67963) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67963" NpcId="1022390" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14131,6 +14380,7 @@
 							<If Condition="GetQuestStep(67964) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67964" NpcId="1023728" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14185,6 +14435,7 @@
 							<If Condition="GetQuestStep(67965) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67965" NpcId="1022390" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14240,6 +14491,7 @@
 							<If Condition="GetQuestStep(67966) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67966" NpcId="1022390" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14297,6 +14549,7 @@
 						<If Condition="GetQuestStep(68113) == 255">
 							<GetTo ZoneId="145" XYZ="-496.7575, -17.41137, 28.0918" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68113" NpcId="1021447" XYZ="-496.7575, -17.41137, 28.0918" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14348,6 +14601,7 @@
 						<If Condition="GetQuestStep(68114) == 255">
 							<GetTo ZoneId="140" XYZ="-476.402, 23.2289, -430.7164" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68114" ItemId="2002181" NpcId="1021457" XYZ="-476.402, 23.2289, -430.7164" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14397,6 +14651,7 @@
 						<If Condition="GetQuestStep(68115) == 255">
 							<GetTo ZoneId="138" XYZ="307.3624, -36.40299, 309.9871" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68115" NpcId="1021462" XYZ="307.3624, -36.40299, 309.9871" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14458,6 +14713,7 @@
 						<If Condition="GetQuestStep(68116) == 255">
 							<GetTo ZoneId="138" XYZ="311.3907, -25.00225, 230.8231" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68116" NpcId="1021473" XYZ="311.3907, -25.00225, 230.8231" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14497,6 +14753,7 @@
 						<If Condition="GetQuestStep(68117) == 255">
 							<GetTo ZoneId="147" XYZ="-94.92645, 48.01958, -31.57098" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68117" NpcId="1021482" XYZ="-94.92645, 48.01958, -31.57098" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14561,6 +14818,7 @@
 						<If Condition="GetQuestStep(68118) == 255">
 							<GetTo ZoneId="156" XYZ="55.55798, 20.48517, -672.5719" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68118" NpcId="1021493" XYZ="55.55798, 20.48517, -672.5719" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14600,6 +14858,7 @@
 						<If Condition="GetQuestStep(68119) == 255">
 							<GetTo ZoneId="478" XYZ="-5.44751, 211, -39.6582" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68119" NpcId="1021779" XYZ="-5.44751, 211, -39.6582" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14655,6 +14914,7 @@
 						<If Condition="GetQuestStep(68120) == 255">
 							<GetTo ZoneId="478" XYZ="-4.135254, 211, -39.84137" /> <!-- Arya -->
 							<TurnIn QuestId="68120" NpcId="1021778" XYZ="-4.135254, 211, -39.84137" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14718,6 +14978,7 @@
 						<If Condition="GetQuestStep(68121) == 255">
 							<GetTo ZoneId="478" XYZ="-5.44751, 211, -39.6582" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68121" NpcId="1021779" XYZ="-5.44751, 211, -39.6582" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14771,6 +15032,7 @@
 						<If Condition="GetQuestStep(68122) == 255">
 							<GetTo ZoneId="419" XYZ="-19.63837, 15.96505, -37.24731" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68122" NpcId="1021795" XYZ="-19.63837, 15.96505, -37.24731" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14834,6 +15096,7 @@
 						<If Condition="GetQuestStep(68123) == 255">
 							<GetTo ZoneId="156" XYZ="55.55798, 20.41107, -675.5627" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68123" NpcId="1021800" XYZ="55.55798, 20.41107, -675.5627" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14899,6 +15162,7 @@
 							</If>
 							<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 							<TurnIn QuestId="65640" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14982,6 +15246,7 @@
 								</If>
 								<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 								<TurnIn QuestId="65646" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15088,6 +15353,7 @@
 								</If>
 								<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 								<TurnIn QuestId="65662" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15161,6 +15427,7 @@
 							<If Condition="GetQuestStep(65680) == 255">
 								<GetTo ZoneId="138" XYZ="319.4476, -36.35382, 346.7612" /> <!-- Jacke -->
 								<TurnIn QuestId="65680" NpcId="1010218" XYZ="319.4476, -36.35382, 346.7612" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15203,6 +15470,7 @@
 								</If>
 								<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 								<TurnIn QuestId="65681" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15310,6 +15578,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65682" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15398,6 +15667,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65684" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15466,6 +15736,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65690" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15534,6 +15805,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65691" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15632,6 +15904,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65748" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15722,6 +15995,7 @@
 								</If>
 								<NoCombatMoveTo Name="Oboro" XYZ="-4.348877, 39.53194, 247.6387" />
 								<TurnIn QuestId="65749" NpcId="1010616" XYZ="-4.348877, 39.53194, 247.6387" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15756,6 +16030,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65750" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15868,6 +16143,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65751" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15902,6 +16178,7 @@
 								</If>
 								<NoCombatMoveTo Name="Oboro" XYZ="473.1364, 16.49299, 67.33801" />
 								<TurnIn QuestId="65752" NpcId="1010619" XYZ="473.1364, 16.49299, 67.33801" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16009,6 +16286,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65753" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16127,6 +16405,7 @@
 								</If>
 								<NoCombatMoveTo Name="Destination" XYZ="-182.8184, 30.5332, -684.9318" />
 								<TurnIn QuestId="65768" NpcId="2004932" XYZ="-182.8184, 30.5332, -684.9318" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16198,6 +16477,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65769" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16293,6 +16573,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65770" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16375,6 +16656,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65771" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16448,6 +16730,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="67220" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16550,6 +16833,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="67221" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16621,6 +16905,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="67222" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16700,6 +16985,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="67223" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16806,6 +17092,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="67224" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16873,6 +17160,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="68484" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16939,6 +17227,7 @@
 							<If Condition="GetQuestStep(68485) == 255">
 								<GetTo ZoneId="628" XYZ="116.8077, 11.97827, -38.34595" /> <!-- Destination -->
 								<TurnIn QuestId="68485" NpcId="2008937" XYZ="116.8077, 11.97827, -38.34595" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16999,6 +17288,7 @@
 							<If Condition="GetQuestStep(68486) == 255">
 								<GetTo ZoneId="614" XYZ="412.1614, 68.02851, -96.75751" /> <!-- Oboro -->
 								<TurnIn QuestId="68486" NpcId="1023570" XYZ="412.1614, 68.02851, -96.75751" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17058,6 +17348,7 @@
 							<If Condition="GetQuestStep(68487) == 255">
 								<GetTo ZoneId="614" XYZ="412.1614, 68.02851, -96.75751" /> <!-- Oboro -->
 								<TurnIn QuestId="68487" NpcId="1023570" XYZ="412.1614, 68.02851, -96.75751" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17098,6 +17389,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="68488" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17144,6 +17436,7 @@
 						<If Condition="GetQuestStep(68096) == 255">
 							<GetTo ZoneId="130" XYZ="35.66028, 6.999999, -82.99384" /> <!-- Musosai -->
 							<TurnIn QuestId="68096" NpcId="1021835" XYZ="35.66028, 6.999999, -82.99384" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17189,6 +17482,7 @@
 						<If Condition="GetQuestStep(68097) == 255">
 							<GetTo ZoneId="128" XYZ="9.536865, 40.00023, -15.21332" /> <!-- Musosai -->
 							<TurnIn QuestId="68097" NpcId="1021858" XYZ="9.536865, 40.00023, -15.21332" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17242,6 +17536,7 @@
 						<If Condition="GetQuestStep(68098) == 255">
 							<GetTo ZoneId="132" XYZ="43.25928, -8, 99.19885" /> <!-- Musosai -->
 							<TurnIn QuestId="68098" NpcId="1021869" XYZ="43.25928, -8, 99.19885" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17291,6 +17586,7 @@
 						<If Condition="GetQuestStep(68099) == 255">
 							<GetTo ZoneId="418" XYZ="112.4132, 3.629973, 62.30261" /> <!-- Musosai -->
 							<TurnIn QuestId="68099" NpcId="1021878" XYZ="112.4132, 3.629973, 62.30261" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17336,6 +17632,7 @@
 						<If Condition="GetQuestStep(68100) == 255">
 							<GetTo ZoneId="418" XYZ="112.5048, 3.629974, 60.83765" /> <!-- Momozigo -->
 							<TurnIn QuestId="68100" NpcId="1021879" XYZ="112.5048, 3.629974, 60.83765" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17384,6 +17681,7 @@
 						<If Condition="GetQuestStep(68101) == 255">
 							<GetTo ZoneId="130" XYZ="36.85046, 6.999999, -83.78735" /> <!-- Momozigo -->
 							<TurnIn QuestId="68101" NpcId="1021836" XYZ="36.85046, 6.999999, -83.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17419,6 +17717,7 @@
 						<If Condition="GetQuestStep(68102) == 255">
 							<GetTo ZoneId="130" XYZ="36.85046, 6.999999, -83.78735" /> <!-- Momozigo -->
 							<TurnIn QuestId="68102" NpcId="1021836" XYZ="36.85046, 6.999999, -83.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17450,6 +17749,7 @@
 						<If Condition="GetQuestStep(68103) == 255">
 							<GetTo ZoneId="628" XYZ="128.6183, 15, -158.0378" /> <!-- Soft-spoken Sekiseigumi -->
 							<TurnInPlus QuestId="68103" NpcId="1022190" XYZ="128.6183, 15, -158.0378" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17510,6 +17810,7 @@
 						<If Condition="GetQuestStep(68104) == 255">
 							<GetTo ZoneId="628" XYZ="128.5573, 15, -158.0988" /> <!-- Kongo -->
 							<TurnIn QuestId="68104" NpcId="1022203" XYZ="128.5573, 15, -158.0988" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17553,6 +17854,7 @@
 						<If Condition="GetQuestStep(68105) == 255">
 							<GetTo ZoneId="628" XYZ="129.7169, 15, -157.6105" /> <!-- Makoto -->
 							<TurnIn QuestId="68105" NpcId="1022184" XYZ="129.7169, 15, -157.6105" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17605,6 +17907,7 @@
 						<If Condition="GetQuestStep(68106) == 255">
 							<GetTo ZoneId="628" XYZ="129.7169, 15, -157.6105" /> <!-- Makoto -->
 							<TurnIn QuestId="68106" NpcId="1022184" XYZ="129.7169, 15, -157.6105" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17649,6 +17952,7 @@
 						<If Condition="GetQuestStep(65882) == 255">
 							<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 							<TurnIn QuestId="65882" NpcId="1001708" ItemId="2001545" XYZ="-250.3548, 18, 80.88806" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17683,6 +17987,7 @@
 							<If Condition="GetQuestStep(65883) == 255">
 								<GetTo ZoneId="130" XYZ="-240.4975, 18.7, 85.58777" /> <!-- Cocobygo -->
 								<TurnIn QuestId="65883" NpcId="1001709" XYZ="-240.4975, 18.7, 85.58777" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17726,6 +18031,7 @@
 							<If Condition="GetQuestStep(65884) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65884" NpcId="1001708" ItemIds="2000418,2000419" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17765,6 +18071,7 @@
 							<If Condition="GetQuestStep(65885) == 255">
 								<GetTo ZoneId="130" XYZ="-240.2533, 18.8, 86.90002" /> <!-- Cocobani -->
 								<TurnIn QuestId="65885" NpcId="1001710" ItemIds="2000418,2000419" XYZ="-240.2533, 18.8, 86.90002" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17822,6 +18129,7 @@
 							<If Condition="GetQuestStep(65886) == 255">
 								<GetTo ZoneId="130" XYZ="-241.6266, 18.8, 83.32947" /> <!-- Cocobezi -->
 								<TurnIn QuestId="65886" NpcId="1001711" ItemId="2001545" XYZ="-241.6266, 18.8, 83.32947" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17890,6 +18198,7 @@
 							<If Condition="GetQuestStep(65887) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65887" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17940,6 +18249,7 @@
 							<If Condition="GetQuestStep(65888) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65888" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17999,6 +18309,7 @@
 							<If Condition="GetQuestStep(65889) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65889" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18035,6 +18346,7 @@
 							<If Condition="GetQuestStep(66609) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="66609" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18076,6 +18388,7 @@
 							<If Condition="GetQuestStep(66610) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="66610" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18135,6 +18448,7 @@
 							<If Condition="GetQuestStep(66611) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66611" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18176,6 +18490,7 @@
 							<If Condition="GetQuestStep(66612) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66612" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18221,6 +18536,7 @@
 							<If Condition="GetQuestStep(66613) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66613" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18266,6 +18582,7 @@
 							<If Condition="GetQuestStep(66614) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66614" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18293,6 +18610,7 @@
 							<If Condition="GetQuestStep(67214) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67214" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18324,6 +18642,7 @@
 							<If Condition="GetQuestStep(67215) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67215" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18383,6 +18702,7 @@
 							<If Condition="GetQuestStep(67216) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67216" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18410,6 +18730,7 @@
 							<If Condition="GetQuestStep(67217) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67217" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 								<WaitWhile Condition="Managers.QuestLogManager.InCutscene" />
 							</If>
 						</If>
@@ -18472,6 +18793,7 @@
 							<If Condition="GetQuestStep(67218) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67218" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18532,6 +18854,7 @@
 							<If Condition="GetQuestStep(67219) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67219" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18566,6 +18889,7 @@
 							<If Condition="GetQuestStep(68124) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68124" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18602,6 +18926,7 @@
 							<If Condition="GetQuestStep(68125) == 255">
 								<GetTo ZoneId="131" XYZ="87.47986, 18, 113.6949" /> <!-- Shatotto -->
 								<TurnIn QuestId="68125" NpcId="1020966" XYZ="87.47986, 18, 113.6949" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18641,6 +18966,7 @@
 							<If Condition="GetQuestStep(68126) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68126" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18680,6 +19006,7 @@
 							<If Condition="GetQuestStep(68127) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68127" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18728,6 +19055,7 @@
 							<If Condition="GetQuestStep(68128) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68128" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>

--- a/Questing/[O] Heavensward (Patch 3.1).xml
+++ b/Questing/[O] Heavensward (Patch 3.1).xml
@@ -111,6 +111,7 @@
             <If Condition="GetQuestStep(67692) == 255">
                 <GetTo ZoneId="418" XYZ="111.2839, 24.38816, -4.379395" /> <!-- Lucia -->
                 <TurnIn QuestId="67692" NpcId="1015978" XYZ="111.2839, 24.38816, -4.379395" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -134,6 +135,7 @@
             <If Condition="GetQuestStep(67693) == 255">
                 <GetTo ZoneId="398" XYZ="-297.7493, 39.04307, 37.06409" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67693" NpcId="1015983" XYZ="-297.7493, 39.04307, 37.06409" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -158,6 +160,7 @@
             <If Condition="GetQuestStep(67694) == 255">
                 <GetTo ZoneId="399" XYZ="-478.1415, 137.4297, 700.8926" /> <!-- Krile -->
                 <TurnIn QuestId="67694" NpcId="1015992" XYZ="-478.1415, 137.4297, 700.8926" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -234,6 +237,7 @@
             <If Condition="GetQuestStep(67696) == 255">
                 <GetTo ZoneId="398" XYZ="225.1163, -116.6398, 504.7227" /> <!-- Thancred -->
                 <TurnIn QuestId="67696" NpcId="1016002" XYZ="225.1163, -116.6398, 504.7227" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -257,6 +261,7 @@
             <If Condition="GetQuestStep(67697) == 255">
                 <GetTo ZoneId="418" XYZ="125.9326, 24.45884, -5.539063" /> <!-- Lucia -->
                 <TurnIn QuestId="67697" NpcId="1016008" XYZ="125.9326, 24.45884, -5.539063" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -300,6 +305,7 @@
             <If Condition="GetQuestStep(67698) == 255">
                 <GetTo ZoneId="418" XYZ="125.9326, 24.45884, -5.539063" /> <!-- Lucia -->
                 <TurnIn QuestId="67698" NpcId="1016008" XYZ="125.9326, 24.45884, -5.539063" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -361,6 +367,7 @@
                 </If>
                 <MoveTo Name="Alphinaud" XYZ="0.7476196, 0.02225424, 4.623413" />
                 <TurnIn QuestId="67699" NpcId="1016050" XYZ="0.7476196, 0.02225424, 4.623413" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>

--- a/Questing/[O] Heavensward (Patch 3.2).xml
+++ b/Questing/[O] Heavensward (Patch 3.2).xml
@@ -125,6 +125,7 @@
                 </If>
                 <MoveTo Name="Tataru" XYZ="-2.67041, 7.450581E-09, -5.264404" />
                 <TurnIn QuestId="67767" NpcId="1016535" XYZ="-2.67041, 7.450581E-09, -5.264404" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -177,6 +178,7 @@
                 </If>
                 <MoveTo Name="Alphinaud" XYZ="19.48578, 38.4364, 6.973328" />
                 <TurnIn QuestId="67768" NpcId="1016560" XYZ="19.48578, 38.4364, 6.973328" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -204,6 +206,7 @@
             <If Condition="GetQuestStep(67769) == 255">
                 <GetTo ZoneId="397" XYZ="481.4069, 225.0023, 793.0876" /> <!-- Lucia -->
                 <TurnIn QuestId="67769" NpcId="1016564" XYZ="481.4069, 225.0023, 793.0876" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -225,6 +228,7 @@
             <If Condition="GetQuestStep(67770) == 255">
                 <GetTo ZoneId="397" XYZ="503.3494, 217.9515, 760.4639" /> <!-- Artoirel -->
                 <TurnIn QuestId="67770" NpcId="1016565" XYZ="503.3494, 217.9515, 760.4639" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -257,6 +261,7 @@
             <If Condition="GetQuestStep(67771) == 255">
                 <GetTo ZoneId="397" XYZ="515.5565, 217.9515, 763.7291" /> <!-- Emmanellain -->
                 <TurnIn QuestId="67771" NpcId="1016566" XYZ="515.5565, 217.9515, 763.7291" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -282,6 +287,7 @@
             <If Condition="GetQuestStep(67772) == 255">
                 <GetTo ZoneId="397" XYZ="416.5254, 217.9514, 754.2076" /> <!-- Thancred -->
                 <TurnIn QuestId="67772" NpcId="1016580" XYZ="416.5254, 217.9514, 754.2076" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -305,6 +311,7 @@
             <If Condition="GetQuestStep(67773) == 255">
                 <GetTo ZoneId="397" XYZ="507.1641, 217.9515, 769.9243" /> <!-- Thancred -->
                 <TurnIn QuestId="67773" NpcId="1016579" XYZ="507.1641, 217.9515, 769.9243" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -350,6 +357,7 @@
             <If Condition="GetQuestStep(67774) == 255">
                 <GetTo ZoneId="418" XYZ="112.5352, 24.39169, -2.914551" /> <!-- Thancred -->
                 <TurnIn QuestId="67774" NpcId="1016583" XYZ="112.5352, 24.39169, -2.914551" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -405,6 +413,7 @@
             <If Condition="GetQuestStep(67775) == 255">
                 <GetTo ZoneId="155" XYZ="-136.6445, 304.1538, -308.3696" /> <!-- Thancred -->
                 <TurnIn QuestId="67775" NpcId="1016588" XYZ="-136.6445, 304.1538, -308.3696" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -428,6 +437,7 @@
             <If Condition="GetQuestStep(67776) == 255">
                 <GetTo ZoneId="397" XYZ="501.976, 217.9515, 762.7222" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67776" NpcId="1016590" XYZ="501.976, 217.9515, 762.7222" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -463,6 +473,7 @@
             <If Condition="GetQuestStep(67777) == 255">
                 <GetTo ZoneId="419" XYZ="14.8775, 16.00967, -4.196289" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67777" NpcId="1013227" XYZ="14.8775, 16.00967, -4.196289" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>

--- a/Questing/[O] Heavensward (Patch 3.3).xml
+++ b/Questing/[O] Heavensward (Patch 3.3).xml
@@ -106,6 +106,7 @@
             <If Condition="GetQuestStep(67778) == 255">
                 <GetTo ZoneId="418" XYZ="109.7275, 24.38438, -4.715088" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67778" NpcId="1016818" XYZ="109.7275, 24.38438, -4.715088" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -125,6 +126,7 @@
             <If Condition="GetQuestStep(67779) == 255">
                 <GetTo ZoneId="398" XYZ="-285.6337, 39.04305, 53.72693" /> <!-- Vidofnir -->
                 <TurnIn QuestId="67779" NpcId="1011935" XYZ="-285.6337, 39.04305, 53.72693" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -160,6 +162,7 @@
             <If Condition="GetQuestStep(67780) == 255">
                 <GetTo ZoneId="400" XYZ="-758.3887, 123.7287, 210.7728" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67780" NpcId="1017011" XYZ="-758.3887, 123.7287, 210.7728" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -179,6 +182,7 @@
             <If Condition="GetQuestStep(67781) == 255">
                 <GetTo ZoneId="418" XYZ="7.400574, 1.279123, 104.3563" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67781" NpcId="1016589" XYZ="7.400574, 1.279123, 104.3563" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -213,6 +217,7 @@
                 </If>
                 <GetTo ZoneId="418" XYZ="124.4678, 24.45884, 0.4729614" /> <!-- Aymeric -->
                 <TurnIn QuestId="67782" NpcId="1012380" XYZ="124.4678, 24.45884, 0.4729614" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -243,6 +248,7 @@
                 </If>
                 <MoveTo Name="Alphinaud" XYZ="0.7476196, 0.02225424, 4.623413" />
                 <TurnIn QuestId="67783" NpcId="1012857" XYZ="0.7476196, 0.02225424, 4.623413" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>

--- a/Questing/[O] Heavensward (Patch 3.4).xml
+++ b/Questing/[O] Heavensward (Patch 3.4).xml
@@ -112,6 +112,7 @@
                 </If>
                 <MoveTo Name="Alphinaud" XYZ="2.059875, 0.02225424, -1.327576" />
                 <TurnIn QuestId="67877" NpcId="1017721" XYZ="2.059875, 0.02225424, -1.327576" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -153,6 +154,7 @@
             <If Condition="GetQuestStep(67878) == 255">
                 <GetTo ZoneId="155" XYZ="601.9531, 331.8172, -308.8579" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67878" NpcId="1017724" XYZ="601.9531, 331.8172, -308.8579" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -188,6 +190,7 @@
             <If Condition="GetQuestStep(67879) == 255">
                 <GetTo ZoneId="180" XYZ="-141.558, 64.59769, -212.2683" /> <!-- Bloeidin -->
                 <TurnIn QuestId="67879" NpcId="1006325" XYZ="-141.558, 64.59769, -212.2683" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -226,6 +229,7 @@
             <If Condition="GetQuestStep(67880) == 255">
                 <GetTo ZoneId="180" XYZ="-42.00812, 64.50034, -228.4734" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67880" NpcId="1017736" XYZ="-42.00812, 64.50034, -228.4734" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -273,6 +277,7 @@
             <If Condition="GetQuestStep(67881) == 255">
                 <GetTo ZoneId="180" XYZ="-48.29486, 64.43991, -235.5841" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67881" NpcId="1017744" XYZ="-48.29486, 64.43991, -235.5841" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -325,6 +330,7 @@
             <If Condition="GetQuestStep(67882) == 255">
                 <GetTo ZoneId="146" XYZ="-169.3599, 27.48653, -397.1161" /> <!-- Alisaie -->
                 <TurnIn QuestId="67882" NpcId="1017751" XYZ="-169.3599, 27.48653, -397.1161" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -358,6 +364,7 @@
             <If Condition="GetQuestStep(67883) == 255">
                 <GetTo ZoneId="146" XYZ="179.797, 13.12442, -443.1678" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67883" NpcId="1017757" XYZ="179.797, 13.12442, -443.1678" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -388,6 +395,7 @@
             <If Condition="GetQuestStep(67884) == 255">
                 <GetTo ZoneId="146" XYZ="-106.9505, 21.88423, -478.9044" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67884" NpcId="1017762" XYZ="-106.9505, 21.88423, -478.9044" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -432,6 +440,7 @@
             <If Condition="GetQuestStep(67885) == 255">
                 <GetTo ZoneId="146" XYZ="1.327454, 0.9078357, -3.463867" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67885" NpcId="1017767" XYZ="1.327454, 0.9078357, -3.463867" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -477,6 +486,7 @@
                 </If>
                 <MoveTo Name="Alphinaud" XYZ="-3.585876, 0.01804011, -6.912354" />
                 <TurnIn QuestId="67886" NpcId="1017776" XYZ="-3.585876, 0.01804011, -6.912354" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>

--- a/Questing/[O] Heavensward (Patch 3.5).xml
+++ b/Questing/[O] Heavensward (Patch 3.5).xml
@@ -106,6 +106,7 @@
             <If Condition="GetQuestStep(67887) == 255">
                 <GetTo ZoneId="418" XYZ="125.6885, 24.45884, 2.456604" /> <!-- Lucia -->
                 <TurnIn QuestId="67887" NpcId="1013167" XYZ="125.6885, 24.45884, 2.456604" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -129,6 +130,7 @@
             <If Condition="GetQuestStep(67888) == 255">
                 <GetTo ZoneId="132" XYZ="8.407715, -1.509768, 13.93146" /> <!-- Aymeric -->
                 <TurnIn QuestId="67888" NpcId="1018015" XYZ="8.407715, -1.509768, 13.93146" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -152,6 +154,7 @@
             <If Condition="GetQuestStep(67889) == 255">
                 <GetTo ZoneId="156" XYZ="34.1344, 20.495, -655.5734" /> <!-- Alisaie -->
                 <TurnIn QuestId="67889" NpcId="1018020" XYZ="34.1344, 20.495, -655.5734" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -208,6 +211,7 @@
             <If Condition="GetQuestStep(67890) == 255">
                 <GetTo ZoneId="152" XYZ="39.59705, 6.826768, 489.8602" /> <!-- Yda -->
                 <TurnIn QuestId="67890" NpcId="1018026" XYZ="39.59705, 6.826768, 489.8602" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -232,6 +236,7 @@
                 </If>
                 <MoveTo Name="Alisaie" XYZ="-3.708008, 0.01804012, -6.881897" />
                 <TurnIn QuestId="67891" NpcId="1018033" XYZ="-3.708008, 0.01804012, -6.881897" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -265,6 +270,7 @@
             <If Condition="GetQuestStep(67892) == 255">
                 <GetTo ZoneId="133" XYZ="-154.1009, 4, -15.45746" /> <!-- Alphinaud -->
                 <TurnIn QuestId="67892" NpcId="1012395" XYZ="-154.1009, 4, -15.45746" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -301,6 +307,7 @@
                 </If>
                 <MoveTo Name="Nero tol Scaeva" XYZ="13.19904, -3.72529E-09, -8.590881" />
                 <TurnIn QuestId="67893" NpcId="1018041" XYZ="13.19904, -3.72529E-09, -8.590881" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -359,6 +366,7 @@
             <If Condition="GetQuestStep(67894) == 255">
                 <GetTo ZoneId="132" XYZ="40.60425, -19.00001, 92.36279" /> <!-- Cid -->
                 <TurnIn QuestId="67894" NpcId="1018046" XYZ="40.60425, -19.00001, 92.36279" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -407,6 +415,7 @@
                 </If>
                 <MoveTo Name="Alisaie" XYZ="-2.639893, 7.450581E-09, -7.400635" />
                 <TurnIn QuestId="67895" NpcId="1018331" XYZ="-2.639893, 7.450581E-09, -7.400635" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>

--- a/Questing/[O] Heavensward.xml
+++ b/Questing/[O] Heavensward.xml
@@ -144,6 +144,7 @@
                     </If>
                     <GetTo ZoneId="419" XYZ="15.60992, 16.00967, -6.515625" /> <!-- Haurchefant -->
                     <TurnIn QuestId="67116" NpcId="1012313" XYZ="15.60992, 16.00967, -6.515625" />
+                    <WaitTimer WaitTime="2"/>
                     <WaitWhile Condition="not IsOnMap(433)" />
                 </If>
             </If>
@@ -197,10 +198,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67117" NpcId="1012323" XYZ="-50.21753, 8.05915, 15.45734" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67117" NpcId="1012323" XYZ="-50.21753, 8.05915, 15.45734" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -253,11 +256,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67118" NpcId="1013036" XYZ="-0.2289429, 0, 7.339539" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Alphinaud" XYZ="-0.2289429, 0, 7.339539" />
                     <TurnIn QuestId="67118" NpcId="1013036" XYZ="-0.2289429, 0, 7.339539" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -371,6 +376,7 @@
                 <If Condition="GetQuestStep(67267) == 255">
                     <GetTo ZoneId="419" XYZ="25.92505, 15.86507, 19.39423" /> <!-- Torsefers -->
                     <TurnIn QuestId="67267" NpcId="1012217" XYZ="25.92505, 15.86507, 19.39423" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -467,6 +473,7 @@
                 <If Condition="GetQuestStep(67266) == 255">
                     <GetTo ZoneId="418" XYZ="102.9221, 3.629973, 65.56799" /> <!-- Brictt -->
                     <TurnIn QuestId="67266" NpcId="1012170" XYZ="102.9221, 3.629973, 65.56799" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -495,6 +502,7 @@
                     </If>
                     <MoveTo Name="Cevilia" XYZ="-164.6907, 2.170003, 27.573" />
                     <TurnIn QuestId="67265" NpcId="1012176" XYZ="-164.6907, 2.170003, 27.573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -524,10 +532,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67262" NpcId="1012213" XYZ="-166.3997, 14.95313, -175.7077" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67262" NpcId="1012213" XYZ="-166.3997, 14.95313, -175.7077" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -549,6 +559,7 @@
                 <If Condition="GetQuestStep(67263) == 255">
                     <GetTo ZoneId="419" XYZ="151.9341, -14.52896, 16.18976" /> <!-- Cliaux -->
                     <TurnIn QuestId="67263" NpcId="1012220" XYZ="151.9341, -14.52896, 16.18976" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -558,6 +569,7 @@
                 <If Condition="GetQuestStep(67264) == 255">
                     <GetTo ZoneId="419" XYZ="75.31892, 10.0549, -101.4088" /> <!-- Title-stripped Noble's Son -->
                     <TurnIn QuestId="67264" NpcId="1014709" XYZ="74.50977, 10.0549, -100.3586" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -587,7 +599,8 @@
 
                     -->
 
-                    <!-- <TurnIn QuestId="67631" NpcId="1013395" ItemId="2001784" XYZ="45.60925, 31.19533, -732.9061" /> -->
+                    <!-- <TurnIn QuestId="67631" NpcId="1013395" ItemId="2001784" XYZ="45.60925, 31.19533, -732.9061" />
+ <WaitTimer WaitTime="2"/> -->
 
                     <!-- TO DO -->
 
@@ -720,6 +733,7 @@
                     </If>
                     <NoCombatMoveTo Name="Redwald" XYZ="503.1051, 217.9515, 790.2189" />
                     <TurnIn QuestId="67119" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -789,10 +803,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67120" NpcId="1011236" XYZ="446.0059, 217.9514, 764.0649" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67120" NpcId="1011236" XYZ="446.0059, 217.9514, 764.0649" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -855,10 +871,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67121" NpcId="1011241" ItemId="2001572" XYZ="501.7318, 164.194, 301.1367" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67121" NpcId="1011241" ItemId="2001572" XYZ="501.7318, 164.194, 301.1367" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -889,10 +907,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67268" NpcId="1011238" ItemId="2001594" XYZ="536.2478, 217.9083, 779.6901" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67268" NpcId="1011238" ItemId="2001594" XYZ="536.2478, 217.9083, 779.6901" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -902,6 +922,7 @@
                 <If Condition="GetQuestStep(67269) == 255">
                     <GetTo ZoneId="397" XYZ="402.7618, 199.3566, 689.4482" /> <!-- Sigan -->
                     <TurnIn QuestId="67269" NpcId="1014123" ItemId="2001735" XYZ="402.7618, 199.3566, 689.4482" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -936,6 +957,7 @@
                 <If Condition="GetQuestStep(67270) == 255">
                     <GetTo ZoneId="397" XYZ="402.7618, 199.3566, 689.4482" /> <!-- Sigan -->
                     <TurnIn QuestId="67270" NpcId="1014123" ItemId="2001736" XYZ="402.7618, 199.3566, 689.4482" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -974,10 +996,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67122" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67122" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1073,10 +1097,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67123" NpcId="1012340" XYZ="81.80359, 117.1982, 152.3002" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67123" NpcId="1012340" XYZ="81.80359, 117.1982, 152.3002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1135,6 +1161,7 @@
                 <If Condition="GetQuestStep(67124) == 255">
                     <GetTo ZoneId="397" XYZ="465.0186, 162.5833, -522.9115" /> <!-- Artoirel -->
                     <TurnIn QuestId="67124" NpcId="1012348" XYZ="465.0186, 162.5833, -522.9115" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1175,6 +1202,7 @@
                 <If Condition="GetQuestStep(67273) == 255">
                     <GetTo ZoneId="397" XYZ="426.8099, 169.3901, -566.0945" /> <!-- Hot-tempered Knight -->
                     <TurnIn QuestId="67273" NpcId="1013344" ItemId="2001596" XYZ="426.8099, 169.3901, -566.0945" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1187,6 +1215,7 @@
                 <If Condition="GetQuestStep(67271) == 255">
                     <GetTo ZoneId="397" XYZ="197.1312, 189.4263, 270.6188" /> <!-- Ysaudore -->
                     <TurnIn QuestId="67271" NpcId="1011903" XYZ="197.1312, 189.4263, 270.6188" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1196,6 +1225,7 @@
                 <If Condition="GetQuestStep(67272) == 255">
                     <GetTo ZoneId="397" XYZ="493.1563, 200.2377, 663.0197" /> <!-- Ingaret -->
                     <TurnIn QuestId="67272" NpcId="1011240" ItemId="2001595" XYZ="493.1563, 200.2377, 663.0197" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1229,11 +1259,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67125" NpcId="1012328" XYZ="1.754761, 0.003450237, -9.750549" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <NoCombatMoveTo Name="Artoirel" XYZ="1.754761, 0.003450237, -9.750549" />
                     <TurnIn QuestId="67125" NpcId="1012328" XYZ="1.754761, 0.003450237, -9.750549" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1268,6 +1300,7 @@
                     </If>
                     <NoCombatMoveTo Name="Laniaitte" XYZ="-277.6379, -184.5974, 741.6038" />
                     <TurnIn QuestId="67126" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1349,10 +1382,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67127" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67127" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1417,10 +1452,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67128" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67128" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1445,6 +1482,7 @@
                 <If Condition="GetQuestStep(67276) == 255">
                     <GetTo ZoneId="401" XYZ="-344.9608, -164.6414, 836.3317" /> <!-- Gildon -->
                     <TurnIn QuestId="67276" NpcId="1012059" ItemId="2001765" XYZ="-344.9608, -164.6414, 836.3317" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1490,10 +1528,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67129" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67129" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1567,10 +1607,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67275" NpcId="1013345" XYZ="-249.4392, -183.3127, 745.4489" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67275" NpcId="1013345" XYZ="-249.4392, -183.3127, 745.4489" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1583,6 +1625,7 @@
                 <If Condition="GetQuestStep(67274) == 255">
                     <GetTo ZoneId="401" XYZ="-658.8998, -127.7836, 622.98" /> <!-- Caribault -->
                     <TurnIn QuestId="67274" NpcId="1012056" ItemId="2001597" XYZ="-658.8998, -127.7836, 622.98" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1620,10 +1663,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67277" NpcId="1012059" XYZ="-344.9608, -164.6414, 836.3317" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67277" NpcId="1012059" XYZ="-344.9608, -164.6414, 836.3317" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1653,10 +1698,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67130" NpcId="1012364" ItemId="2001574" XYZ="64.10315, -144.9241, 527.3669" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67130" NpcId="1012364" ItemId="2001574" XYZ="64.10315, -144.9241, 527.3669" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1702,6 +1749,7 @@
                 <If Condition="GetQuestStep(67131) == 255">
                     <GetTo ZoneId="401" XYZ="-678.2483, -110.6741, 481.7731" /> <!-- Cid -->
                     <TurnIn QuestId="67131" NpcId="1012367" XYZ="-678.2483, -110.6741, 481.7731" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1748,11 +1796,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67132" NpcId="1012329" XYZ="-7.309082, 0.003586963, -0.5036011" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Emmanellain" XYZ="-7.309082, 0.003586963, -0.5036011" />
                     <TurnIn QuestId="67132" NpcId="1012329" XYZ="-7.309082, 0.003586963, -0.5036011" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1821,6 +1871,7 @@
                     -->
 
                     <TurnIn QuestId="67133" NpcId="1012381" XYZ="120.6531, 14.95313, -156.6339" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1882,6 +1933,7 @@
 
                     <MoveTo Name="Alphinaud" XYZ="0.6866455, 0.02225424, 4.623413" />
                     <TurnIn QuestId="67134" NpcId="1012387" XYZ="0.6866455, 0.02225424, 4.623413" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1913,6 +1965,7 @@
                 <If Condition="GetQuestStep(67278) == 255">
                     <GetTo ZoneId="397" XYZ="518.9136, 217.9515, 769.9243" /> <!-- Emerissel -->
                     <TurnIn QuestId="67278" NpcId="1011233" ItemId="2001805" XYZ="518.9136, 217.9515, 769.9243" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1975,6 +2028,7 @@
                 <If Condition="GetQuestStep(67281) == 255">
                     <GetTo ZoneId="397" XYZ="503.1051, 217.9515, 790.2189" /> <!-- Redwald -->
                     <TurnIn QuestId="67281" NpcId="1011231" ItemId="2001738" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2032,6 +2086,7 @@
                     -->
 
                     <TurnIn QuestId="67280" NpcId="1011240" XYZ="493.1563, 200.2377, 663.0197" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2041,6 +2096,7 @@
                 <If Condition="GetQuestStep(67282) == 255">
                     <GetTo ZoneId="397" XYZ="503.1051, 217.9515, 790.2189" /> <!-- Redwald -->
                     <TurnIn QuestId="67282" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2097,10 +2153,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67283" NpcId="1014123" ItemId="2001743" XYZ="402.7618, 199.3566, 689.4482" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67283" NpcId="1014123" ItemId="2001743" XYZ="402.7618, 199.3566, 689.4482" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2122,6 +2180,7 @@
                 <If Condition="GetQuestStep(67279) == 255">
                     <GetTo ZoneId="401" XYZ="-277.6379, -184.5974, 741.6038" /> <!-- Laniaitte -->
                     <TurnIn QuestId="67279" NpcId="1011952" ItemId="2001806" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2192,6 +2251,7 @@
                     -->
 
                     <TurnIn QuestId="67284" NpcId="1011952" ItemId="2001599" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2210,10 +2270,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67285" NpcId="1012059" ItemId="2001744" XYZ="-344.9608, -164.6414, 836.3317" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67285" NpcId="1012059" ItemId="2001744" XYZ="-344.9608, -164.6414, 836.3317" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2262,6 +2324,7 @@
                 <If Condition="GetQuestStep(67135) == 255">
                     <GetTo ZoneId="156" XYZ="30.07544, 50.99997, -819.7299" /> <!-- Higiri -->
                     <TurnIn QuestId="67135" NpcId="1013018" XYZ="30.07544, 50.99997, -819.7299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2290,6 +2353,7 @@
                 <If Condition="GetQuestStep(67136) == 255">
                     <GetTo ZoneId="145" XYZ="-380.8805, -23.06451, 388.632" /> <!-- Hozan -->
                     <TurnIn QuestId="67136" NpcId="1013028" XYZ="-380.8805, -23.06451, 388.632" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2390,11 +2454,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67137" NpcId="1013038" XYZ="1.998901, 1.147389E-06, -2.517761" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Alphinaud" XYZ="1.998901, 1.147389E-06, -2.517761" />
                     <TurnIn QuestId="67137" NpcId="1013038" XYZ="1.998901, 1.147389E-06, -2.517761" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2447,6 +2513,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="1.113892, 0.02225424, -4.409851" />
                     <TurnIn QuestId="67138" NpcId="1012579" XYZ="1.113892, 0.02225424, -4.409851" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2493,6 +2560,7 @@
                 <If Condition="GetQuestStep(67139) == 255">
                     <GetTo ZoneId="418" XYZ="107.6829, 24.3786, -6.698792" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67139" NpcId="1012588" XYZ="107.6829, 24.3786, -6.698792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2584,6 +2652,7 @@
                 <If Condition="GetQuestStep(67286) == 255">
                     <GetTo ZoneId="397" XYZ="522.5452, 228.3512, 723.5675" /> <!-- Josseloux -->
                     <TurnIn QuestId="67286" NpcId="1011235" XYZ="522.5452, 228.3512, 723.5675" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2614,6 +2683,7 @@
                     -->
 
                     <TurnIn QuestId="67140" NpcId="1012592" XYZ="459.1592, 162.512, -524.651" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2657,10 +2727,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67141" NpcId="1012601" ItemId="2001578" XYZ="452.4147, 157.4083, -542.8397" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67141" NpcId="1012601" ItemId="2001578" XYZ="452.4147, 157.4083, -542.8397" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2721,6 +2793,7 @@
                 <If Condition="GetQuestStep(67288) == 255">
                     <GetTo ZoneId="397" XYZ="540.3677, 217.9083, 772.8236" /> <!-- Well-mannered Widow -->
                     <TurnIn QuestId="67288" NpcId="1013346" XYZ="540.3677, 217.9083, 772.8236" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2733,6 +2806,7 @@
                 <If Condition="GetQuestStep(67142) == 255">
                     <GetTo ZoneId="397" XYZ="-288.8686, 127.0664, 13.19904" /> <!-- Jantellot -->
                     <TurnIn QuestId="67142" NpcId="1011907" XYZ="-288.8686, 127.0664, 13.19904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2807,6 +2881,7 @@
                 <If Condition="GetQuestStep(67143) == 255">
                     <GetTo ZoneId="397" XYZ="-311.1467, 126.5033, -6.729248" /> <!-- Pierriquet -->
                     <TurnIn QuestId="67143" NpcId="1012283" XYZ="-311.1467, 126.5033, -6.729248" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2876,6 +2951,7 @@
                 <If Condition="GetQuestStep(67298) == 255">
                     <GetTo ZoneId="397" XYZ="-294.6975, 126.8487, 4.53186" /> <!-- Dominiac -->
                     <TurnIn QuestId="67298" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2896,10 +2972,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67295" NpcId="1011910" XYZ="-298.2681, 126.6705, -1.419189" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67295" NpcId="1011910" XYZ="-298.2681, 126.6705, -1.419189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3005,6 +3083,7 @@
                 <If Condition="GetQuestStep(67289) == 255">
                     <GetTo ZoneId="397" XYZ="-46.49432, 88.28323, -606.2257" /> <!-- Spiteful Knight -->
                     <TurnIn QuestId="67289" NpcId="1013347" XYZ="-46.49432, 88.28323, -606.2257" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3029,6 +3108,7 @@
                 <If Condition="GetQuestStep(67299) == 255">
                     <GetTo ZoneId="397" XYZ="-298.2681, 126.6705, -1.419189" /> <!-- Luciae -->
                     <TurnIn QuestId="67299" NpcId="1011910" ItemId="2001602" XYZ="-298.2681, 126.6705, -1.419189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3038,6 +3118,7 @@
                 <If Condition="GetQuestStep(67300) == 255">
                     <GetTo ZoneId="397" XYZ="-294.6975, 126.8487, 4.53186" /> <!-- Dominiac -->
                     <TurnIn QuestId="67300" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3054,6 +3135,7 @@
                     -->
 
                     <TurnIn QuestId="67296" NpcId="1011907" XYZ="-288.8686, 127.0664, 13.19904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3107,6 +3189,7 @@
                 <If Condition="GetQuestStep(67304) == 255">
                     <GetTo ZoneId="397" XYZ="-300.3434, 126.6752, -1.571716" /> <!-- Messenger Knight -->
                     <TurnIn QuestId="67304" NpcId="1013359" ItemId="2001605" XYZ="-300.3434, 126.6752, -1.571716" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3150,6 +3233,7 @@
                 <If Condition="GetQuestStep(67301) == 255">
                     <GetTo ZoneId="397" XYZ="-294.6975, 126.8487, 4.53186" /> <!-- Dominiac -->
                     <TurnIn QuestId="67301" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3159,6 +3243,7 @@
                 <If Condition="GetQuestStep(67297) == 255">
                     <GetTo ZoneId="397" XYZ="-288.8686, 127.0664, 13.19904" /> <!-- Jantellot -->
                     <TurnIn QuestId="67297" NpcId="1011907" XYZ="-288.8686, 127.0664, 13.19904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3237,6 +3322,7 @@
                 <If Condition="GetQuestStep(67302) == 255">
                     <GetTo ZoneId="397" XYZ="-294.6975, 126.8487, 4.53186" /> <!-- Dominiac -->
                     <TurnIn QuestId="67302" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3255,10 +3341,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67303" NpcId="1011907" ItemId="2001604" XYZ="-288.8686, 127.0664, 13.19904" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67303" NpcId="1011907" ItemId="2001604" XYZ="-288.8686, 127.0664, 13.19904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3325,6 +3413,7 @@
                 <If Condition="GetQuestStep(67305) == 255">
                     <GetTo ZoneId="397" XYZ="-294.6975, 126.8487, 4.53186" /> <!-- Dominiac -->
                     <TurnIn QuestId="67305" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3341,6 +3430,7 @@
                     -->
 
                     <TurnIn QuestId="67144" NpcId="1012670" ItemId="2001584" XYZ="-631.9219, 142.1073, -322.7131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3360,6 +3450,7 @@
                 <If Condition="GetQuestStep(67287) == 255">
                     <GetTo ZoneId="401" XYZ="-358.6633, -157.9937, 761.0131" /> <!-- Marielle -->
                     <TurnIn QuestId="67287" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3438,10 +3529,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67292" NpcId="1012054" XYZ="-640.1007, -119.5621, 469.5963" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67292" NpcId="1012054" XYZ="-640.1007, -119.5621, 469.5963" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3458,6 +3551,7 @@
                 <If Condition="GetQuestStep(67291) == 255">
                     <GetTo ZoneId="401" XYZ="769.8939, -94.98, 86.35071" /> <!-- Terremiaux -->
                     <TurnIn QuestId="67291" NpcId="1013349" XYZ="769.8939, -94.98, 86.35071" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3488,6 +3582,7 @@
                 <If Condition="GetQuestStep(67293) == 255">
                     <GetTo ZoneId="401" XYZ="769.8939, -94.98, 86.35071" /> <!-- Terremiaux -->
                     <TurnIn QuestId="67293" NpcId="1013349" XYZ="769.8939, -94.98, 86.35071" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3526,6 +3621,7 @@
                 <If Condition="GetQuestStep(67294) == 255">
                     <GetTo ZoneId="401" XYZ="-277.6379, -184.5974, 741.6038" /> <!-- Laniaitte -->
                     <TurnIn QuestId="67294" NpcId="1011952" ItemId="2001601" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3650,6 +3746,7 @@
                 <!-- <If Condition="GetQuestStep(67290) == 255">
                     <GetTo ZoneId="397" XYZ="543.2668, 228.377, 734.4929" /> --> <!-- Nonplussed Noblewoman -->
                     <!-- <TurnIn QuestId="67290" NpcId="1013360" ItemId="2001606" XYZ="543.2668, 228.377, 734.4929" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -3676,6 +3773,7 @@
                     -->
 
                     <TurnIn QuestId="67647" NpcId="1011911" ItemId="2001883" XYZ="-279.5605, 127.0813, 13.59576" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3788,11 +3886,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67145" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <NoCombatMoveTo Name="Marcechamp" XYZ="470.0236, -49.89133, 20.37079" />
                     <TurnIn QuestId="67145" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3925,6 +4025,7 @@
                 <If Condition="GetQuestStep(67311) == 255">
                     <GetTo ZoneId="398" XYZ="535.3016, -51.34064, 65.29333" /> <!-- Loupard -->
                     <TurnIn QuestId="67311" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3934,6 +4035,7 @@
                 <If Condition="GetQuestStep(67306) == 255">
                     <GetTo ZoneId="398" XYZ="483.2379, -51.1414, 25.28406" /> <!-- Virgeaume -->
                     <TurnIn QuestId="67306" NpcId="1011918" XYZ="483.2379, -51.1414, 25.28406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3950,6 +4052,7 @@
                     -->
 
                     <TurnIn QuestId="67307" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4006,10 +4109,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67308" NpcId="1011923" XYZ="711.1161, -36.39083, 198.1079" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67308" NpcId="1011923" XYZ="711.1161, -36.39083, 198.1079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4051,10 +4156,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67309" NpcId="1011924" XYZ="849.0576, -37.66994, -39.56665" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67309" NpcId="1011924" XYZ="849.0576, -37.66994, -39.56665" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4088,6 +4195,7 @@
                     <RunCode Name="MoveForwardStart" />
                     <NoCombatMoveTo Name="Aimebert" XYZ="685.9692, -24.38285, -269.0624" />
                     <TurnIn QuestId="67310" NpcId="1011932" XYZ="685.9692, -24.38285, -269.0624" />
+                    <WaitTimer WaitTime="2"/>
                     <NoCombatMoveTo Name="Jump Spot" XYZ="693.4866, -24.62367, -244.3382" />
                     <RunCode Name="MoveForwardStart" />
                 </If>
@@ -4136,10 +4244,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67312" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67312" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4165,10 +4275,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67146" NpcId="2005489" XYZ="169.604, -63.24872, -11.82581" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67146" NpcId="2005489" XYZ="169.604, -63.24872, -11.82581" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4208,6 +4320,7 @@
                     <If Condition="GetQuestStep(65698) == 255">
                         <GetTo ZoneId="133" XYZ="-24.24664, 10.04002, -262.7451" /> --> <!-- Millith Ironheart -->
                         <!-- <TurnIn QuestId="65698" NpcId="1009297" XYZ="-24.24664, 10.04002, -262.7451" />
+ <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
             </If> -->
@@ -4274,11 +4387,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67147" NpcId="1012625" XYZ="-212.726, -37.57478, 185.1682" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <NoCombatMoveTo Name="Ysayle" XYZ="-212.726, -37.57478, 185.1682" />
                     <TurnIn QuestId="67147" NpcId="1012625" XYZ="-212.726, -37.57478, 185.1682" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4377,10 +4492,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67313" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67313" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4431,10 +4548,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67317" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67317" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4510,10 +4629,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67318" NpcId="1014494" XYZ="479.7893, -50.83053, -5.722229" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67318" NpcId="1014494" XYZ="479.7893, -50.83053, -5.722229" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4572,6 +4693,7 @@
                 <If Condition="GetQuestStep(67319) == 255">
                     <GetTo ZoneId="398" XYZ="535.3016, -51.34064, 65.29333" /> <!-- Loupard -->
                     <TurnIn QuestId="67319" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4590,10 +4712,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67148" NpcId="1012629" ItemId="2001580" XYZ="200, -55.46249, -233.4478" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67148" NpcId="1012629" ItemId="2001580" XYZ="200, -55.46249, -233.4478" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4678,6 +4802,7 @@
                 <If Condition="GetQuestStep(67314) == 255">
                     <GetTo ZoneId="398" XYZ="483.2379, -51.1414, 25.28406" /> <!-- Virgeaume -->
                     <TurnIn QuestId="67314" NpcId="1011918" XYZ="483.2379, -51.1414, 25.28406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4687,6 +4812,7 @@
                 <If Condition="GetQuestStep(67315) == 255">
                     <GetTo ZoneId="398" XYZ="470.0236, -49.89133, 20.37079" /> <!-- Marceshamp -->
                     <TurnIn QuestId="67315" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4715,6 +4841,7 @@
                 <If Condition="GetQuestStep(67316) == 255">
                     <GetTo ZoneId="398" XYZ="344.9302, -30.12832, -419.2111" /> <!-- Tailfeather Hunter -->
                     <TurnIn QuestId="67316" NpcId="1013364" XYZ="344.9302, -30.12832, -419.2111" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4740,6 +4867,7 @@
                 <If Condition="GetQuestStep(67320) == 255">
                     <GetTo ZoneId="398" XYZ="517.3571, -24.31757, -541.0392" /> <!-- Harrowed Hunter -->
                     <TurnIn QuestId="67320" NpcId="1013365" ItemId="2001610" XYZ="517.3571, -24.31757, -541.0392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4779,10 +4907,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67321" NpcId="1011919" XYZ="497.8256, -49.79028, 11.82568" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67321" NpcId="1011919" XYZ="497.8256, -49.79028, 11.82568" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4813,10 +4943,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67149" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67149" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4922,6 +5054,7 @@
                 <If Condition="GetQuestStep(67322) == 255">
                     <GetTo ZoneId="398" XYZ="81.49841, -49.2125, -150.042" /> <!-- Cibleroit -->
                     <TurnIn QuestId="67322" NpcId="1011930" ItemId="2001611" XYZ="81.49841, -49.2125, -150.042" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4931,6 +5064,7 @@
                 <If Condition="GetQuestStep(67323) == 255">
                     <GetTo ZoneId="398" XYZ="82.04773, -49.18927, -152.1478" /> <!-- The Hungerer -->
                     <TurnIn QuestId="67323" NpcId="1012282" ItemId="2001612" XYZ="82.04773, -49.18927, -152.1478" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4940,6 +5074,7 @@
                 <If Condition="GetQuestStep(67326) == 255">
                     <GetTo ZoneId="398" XYZ="70.81714, -49.2083, -141.558" /> <!-- Vath Fleetfoot -->
                     <TurnIn QuestId="67326" NpcId="1011929" ItemId="2001614" XYZ="70.81714, -49.2083, -141.558" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4949,6 +5084,7 @@
                 <If Condition="GetQuestStep(67327) == 255">
                     <GetTo ZoneId="398" XYZ="56.83984, -49.92323, -135.9121" /> <!-- Voracious Vath -->
                     <TurnIn QuestId="67327" NpcId="1011931" ItemId="2001615" XYZ="56.83984, -49.92323, -135.9121" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5037,10 +5173,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67324" NpcId="1011930" ItemId="2001613" XYZ="81.49841, -49.2125, -150.042" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67324" NpcId="1011930" ItemId="2001613" XYZ="81.49841, -49.2125, -150.042" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5059,10 +5197,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67325" NpcId="1012282" XYZ="82.04773, -49.18927, -152.1478" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67325" NpcId="1012282" XYZ="82.04773, -49.18927, -152.1478" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5079,6 +5219,7 @@
                     -->
 
                     <TurnIn QuestId="67328" NpcId="1011928" ItemId="2001616" XYZ="73.19751, -49.19563, -139.0555" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5142,6 +5283,7 @@
                     -->
 
                     <TurnIn QuestId="67653" NpcId="1011921" XYZ="453.3607, -51.1414, 58.57935" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5205,6 +5347,7 @@
                 <If Condition="GetQuestStep(67150) == 255">
                     <GetTo ZoneId="398" XYZ="59.22021, -50.88858, -130.2358" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67150" NpcId="1013582" XYZ="59.22021, -50.88858, -130.2358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5287,6 +5430,7 @@
                 <If Condition="GetQuestStep(67333) == 255">
                     <GetTo ZoneId="398" XYZ="470.0236, -49.89133, 20.37079" /> <!-- Marcechamp -->
                     <TurnIn QuestId="67333" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5328,6 +5472,7 @@
                     -->
 
                     <TurnIn QuestId="67334" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5356,6 +5501,7 @@
                 <If Condition="GetQuestStep(67151) == 255">
                     <GetTo ZoneId="398" XYZ="394.3694, -93.98035, 731.8073" /> <!-- Destination -->
                     <TurnIn QuestId="67151" NpcId="2006423" XYZ="394.3694, -93.98035, 731.8073" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5466,6 +5612,7 @@
                 <If Condition="GetQuestStep(67332) == 255">
                     <GetTo ZoneId="398" XYZ="73.19751, -49.19563, -139.0555" /> <!-- Vath Storyteller -->
                     <TurnIn QuestId="67332" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5485,10 +5632,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67331" NpcId="1011929" ItemId="2001622" XYZ="70.81714, -49.2083, -141.558" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67331" NpcId="1011929" ItemId="2001622" XYZ="70.81714, -49.2083, -141.558" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5498,6 +5647,7 @@
                 <If Condition="GetQuestStep(67329) == 255">
                     <GetTo ZoneId="398" XYZ="56.83984, -49.92323, -135.9121" /> <!-- Voracious Vath -->
                     <TurnIn QuestId="67329" NpcId="1011931" ItemId="2001620" XYZ="56.83984, -49.92323, -135.9121" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5507,6 +5657,7 @@
                 <If Condition="GetQuestStep(67330) == 255">
                     <GetTo ZoneId="398" XYZ="75.63892, -49.12486, -161.4863" /> <!-- Vath Strongarm -->
                     <TurnIn QuestId="67330" NpcId="1013398" ItemId="2001621" XYZ="75.63892, -49.12486, -161.4863" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5577,10 +5728,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67343" NpcId="1011929" XYZ="70.81714, -49.2083, -141.558" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67343" NpcId="1011929" XYZ="70.81714, -49.2083, -141.558" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5622,6 +5775,7 @@
                 <If Condition="GetQuestStep(67344) == 255">
                     <GetTo ZoneId="398" XYZ="70.81714, -49.2083, -141.558" /> <!-- Vath Fleetfoot -->
                     <TurnIn QuestId="67344" NpcId="1011929" XYZ="70.81714, -49.2083, -141.558" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5634,6 +5788,7 @@
                 <If Condition="GetQuestStep(67340) == 255">
                     <GetTo ZoneId="398" XYZ="424.0394, -97.70425, 770.5809" /> <!-- Nonmind Drone -->
                     <TurnIn QuestId="67340" NpcId="1013409" XYZ="462.5466, -100.2958, 804.3792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5704,10 +5859,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67341" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67341" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5728,6 +5885,7 @@
                 <If Condition="GetQuestStep(67342) == 255">
                     <GetTo ZoneId="398" XYZ="70.05408, -50.9607, -120.2259" /> <!-- Astute Vath -->
                     <TurnIn QuestId="67342" NpcId="1013411" XYZ="70.05408, -50.9607, -120.2259" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5798,6 +5956,7 @@
                 <If Condition="GetQuestStep(67350) == 255">
                     <GetTo ZoneId="398" XYZ="-213.5195, -36.5583, 177.5692" /> <!-- Kal Myhk -->
                     <TurnIn QuestId="67350" NpcId="1014160" XYZ="-213.5195, -36.5583, 177.5692" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5900,6 +6059,7 @@
                 <If Condition="GetQuestStep(67335) == 255">
                     <GetTo ZoneId="398" XYZ="-225.7267, -30.06788, 104.0206" /> <!-- Toh Y Thrah -->
                     <TurnIn QuestId="67335" NpcId="1011940" ItemId="2001623" XYZ="-225.7267, -30.06788, 104.0206" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5916,6 +6076,7 @@
                     -->
 
                     <TurnIn QuestId="67338" NpcId="1011937" XYZ="-305.562, 39.04307, 22.9953" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5925,6 +6086,7 @@
                 <If Condition="GetQuestStep(67339) == 255">
                     <GetTo ZoneId="398" XYZ="-310.5364, 96.0603, 41.76392" /> <!-- Gullinkambi -->
                     <TurnIn QuestId="67339" NpcId="1011938" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5934,6 +6096,7 @@
                 <If Condition="GetQuestStep(67351) == 255">
                     <GetTo ZoneId="398" XYZ="-310.5364, 96.0603, 41.76392" /> <!-- Gullinkambi -->
                     <TurnIn QuestId="67351" NpcId="1011938" ItemId="2001753" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5989,10 +6152,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67348" NpcId="1011937" ItemId="2001630" XYZ="-305.562, 39.04307, 22.9953" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67348" NpcId="1011937" ItemId="2001630" XYZ="-305.562, 39.04307, 22.9953" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6020,6 +6185,7 @@
                 <If Condition="GetQuestStep(67336) == 255">
                     <GetTo ZoneId="398" XYZ="-225.7267, -30.06788, 104.0206" /> <!-- Toh Y Thrah -->
                     <TurnIn QuestId="67336" NpcId="1011940" ItemId="2001624" XYZ="-225.7267, -30.06788, 104.0206" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6069,10 +6235,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67337" NpcId="1011940" ItemId="2001626" XYZ="-225.7267, -30.06788, 104.0206" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67337" NpcId="1011940" ItemId="2001626" XYZ="-225.7267, -30.06788, 104.0206" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6096,6 +6264,7 @@
                 <If Condition="GetQuestStep(67152) == 255">
                     <GetTo ZoneId="398" XYZ="56.35156, -50.57729, -142.5041" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67152" NpcId="1014544" XYZ="56.35156, -50.57729, -142.5041" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6207,6 +6376,7 @@
                 <If Condition="GetQuestStep(67345) == 255">
                     <GetTo ZoneId="398" XYZ="-310.5364, 96.0603, 41.76392" /> <!-- Gullinkambi -->
                     <TurnIn QuestId="67345" NpcId="1011938" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6231,6 +6401,7 @@
                 <If Condition="GetQuestStep(67352) == 255">
                     <GetTo ZoneId="398" XYZ="-213.5195, -36.5583, 177.5692" /> <!-- Kal Myhk -->
                     <TurnIn QuestId="67352" NpcId="1014160" XYZ="-213.5195, -36.5583, 177.5692" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6302,6 +6473,7 @@
                 <If Condition="GetQuestStep(67353) == 255">
                     <GetTo ZoneId="398" XYZ="-310.5364, 96.0603, 41.76392" /> <!-- Gullinkambi -->
                     <TurnIn QuestId="67353" NpcId="1011938" ItemId="2001755" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6360,6 +6532,7 @@
                 <If Condition="GetQuestStep(67346) == 255">
                     <GetTo ZoneId="398" XYZ="-310.5364, 96.0603, 41.76392" /> <!-- Gullinkambi -->
                     <TurnIn QuestId="67346" NpcId="1011938" ItemId="2001629" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6400,10 +6573,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67354" NpcId="1011938" ItemId="2001759" XYZ="-310.5364, 96.0603, 41.76392" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67354" NpcId="1011938" ItemId="2001759" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6434,6 +6609,7 @@
                 <If Condition="GetQuestStep(67347) == 255">
                     <GetTo ZoneId="398" XYZ="-346.7918, 30.97619, -34.28705" /> <!-- Indomitable Wyvern -->
                     <TurnIn QuestId="67347" NpcId="1013417" XYZ="-346.7918, 30.97619, -34.28705" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6443,6 +6619,7 @@
                 <If Condition="GetQuestStep(67349) == 255">
                     <GetTo ZoneId="398" XYZ="-305.562, 39.04307, 22.9953" /> <!-- Ess Khas -->
                     <TurnIn QuestId="67349" NpcId="1011937" XYZ="-305.562, 39.04307, 22.9953" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6487,6 +6664,7 @@
 
                     <NoCombatMoveTo Name="Alphinaud" XYZ="240.3142, -42.31706, 615.1063" />
                     <TurnIn QuestId="67153" NpcId="1012661" XYZ="240.3142, -42.31706, 615.1063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6621,6 +6799,7 @@
                 <If Condition="GetQuestStep(67154) == 255">
                     <GetTo ZoneId="400" XYZ="364.3091, -74.10719, 654.322" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67154" NpcId="1012664" XYZ="364.3091, -74.10719, 654.322" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6649,6 +6828,7 @@
                 <If Condition="GetQuestStep(67655) == 255">
                     <GetTo ZoneId="418" XYZ="73.89941, 24.3075, 22.04926" /> <!-- Clan Hunt Board -->
                     <TurnIn QuestId="67655" NpcId="2005909" XYZ="73.89941, 24.3075, 22.04926" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6759,10 +6939,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67155" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67155" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6829,10 +7011,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67158" NpcId="1012083" ItemId="2001583" XYZ="355.8556, -74.53787, 639.6123" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67158" NpcId="1012083" ItemId="2001583" XYZ="355.8556, -74.53787, 639.6123" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6892,10 +7076,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67157" NpcId="1012080" XYZ="392.2026, -72.34356, 649.5612" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67157" NpcId="1012080" XYZ="392.2026, -72.34356, 649.5612" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6915,10 +7101,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67156" NpcId="1012078" ItemId="2001581" XYZ="375.3567, -69.42934, 693.5072" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67156" NpcId="1012078" ItemId="2001581" XYZ="375.3567, -69.42934, 693.5072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6990,6 +7178,7 @@
                 <If Condition="GetQuestStep(67159) == 255">
                     <GetTo ZoneId="400" XYZ="375.3567, -69.42934, 693.5072" /> <!-- Moghan -->
                     <TurnIn QuestId="67159" NpcId="1012078" XYZ="375.3567, -69.42934, 693.5072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7052,6 +7241,7 @@
                 <If Condition="GetQuestStep(67160) == 255">
                     <GetTo ZoneId="400" XYZ="241.1992, -42.24947, 609.2775" /> <!-- Moghan -->
                     <TurnIn QuestId="67160" NpcId="1012682" XYZ="241.1992, -42.24947, 609.2775" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7161,6 +7351,7 @@
                 <If Condition="GetQuestStep(67358) == 255">
                     <GetTo ZoneId="400" XYZ="364.0955, -73.26239, 678.004" /> <!-- Mogomo -->
                     <TurnIn QuestId="67358" NpcId="1012081" ItemId="2001632" XYZ="364.0955, -73.26239, 678.004" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7177,6 +7368,7 @@
                     -->
 
                     <TurnIn QuestId="67355" NpcId="1012284" XYZ="363.241, -73.25598, 678.4314" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7186,6 +7378,7 @@
                 <If Condition="GetQuestStep(67356) == 255">
                     <GetTo ZoneId="400" XYZ="392.2026, -72.34356, 649.5612" /> <!-- Mogmug -->
                     <TurnIn QuestId="67356" NpcId="1012080" ItemId="2001631" XYZ="392.2026, -72.34356, 649.5612" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7205,10 +7398,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67357" NpcId="1014427" XYZ="474.6012, -4.475058, 721.5532" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67357" NpcId="1014427" XYZ="474.6012, -4.475058, 721.5532" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7225,6 +7420,7 @@
                     -->
 
                     <TurnIn QuestId="67359" NpcId="1012288" XYZ="-47.04364, -8.866012, 165.9418" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7244,10 +7440,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67161" NpcId="1013202" XYZ="-79.88104, -8.844478, 206.2256" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67161" NpcId="1013202" XYZ="-79.88104, -8.844478, 206.2256" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7411,6 +7609,7 @@
                 <If Condition="GetQuestStep(67363) == 255">
                     <GetTo ZoneId="400" XYZ="-47.04364, -8.866012, 165.9418" /> <!-- Mogmont -->
                     <TurnIn QuestId="67363" NpcId="1012288" XYZ="-47.04364, -8.866012, 165.9418" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7429,10 +7628,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67360" NpcId="1014431" XYZ="-77.37854, -8.65556, 166.369" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67360" NpcId="1014431" XYZ="-77.37854, -8.65556, 166.369" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7452,10 +7653,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67361" NpcId="1012091" ItemId="2001633" XYZ="-94.80432, -2.981276, 250.782" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67361" NpcId="1012091" ItemId="2001633" XYZ="-94.80432, -2.981276, 250.782" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7474,10 +7677,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67362" NpcId="1012092" XYZ="-124.0406, 36.39444, 180.621" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67362" NpcId="1012092" XYZ="-124.0406, 36.39444, 180.621" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7497,10 +7702,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67361" NpcId="1012091" ItemId="2001633" XYZ="-94.80432, -2.981276, 250.782" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67361" NpcId="1012091" ItemId="2001633" XYZ="-94.80432, -2.981276, 250.782" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7519,10 +7726,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67162" NpcId="1012757" XYZ="-261.8297, 30.37311, 557.946" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67162" NpcId="1012757" XYZ="-261.8297, 30.37311, 557.946" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7571,10 +7780,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67163" NpcId="1012694" XYZ="-758.3276, 123.7287, 210.7423" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67163" NpcId="1012694" XYZ="-758.3276, 123.7287, 210.7423" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7659,10 +7870,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67367" NpcId="1014435" XYZ="-109.0563, -8.84447, 209.3385" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67367" NpcId="1014435" XYZ="-109.0563, -8.84447, 209.3385" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7725,10 +7938,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67164" NpcId="1012698" XYZ="569.1766, -1.191689, -370.2297" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67164" NpcId="1012698" XYZ="569.1766, -1.191689, -370.2297" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7773,6 +7988,7 @@
                     -->
 
                     <TurnIn QuestId="67371" NpcId="1013434" XYZ="517.9064, -1.191711, -354.6349" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7823,6 +8039,7 @@
                 <If Condition="GetQuestStep(67366) == 255">
                     <GetTo ZoneId="400" XYZ="364.0955, -73.26239, 678.004" /> <!-- Mogomo -->
                     <TurnIn QuestId="67366" NpcId="1012081" ItemId="2001635" XYZ="364.0955, -73.26239, 678.004" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7848,10 +8065,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67368" NpcId="1012082" XYZ="381.7043, -69.41491, 691.5541" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67368" NpcId="1012082" XYZ="381.7043, -69.41491, 691.5541" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7921,6 +8140,7 @@
                 <If Condition="GetQuestStep(67370) == 255">
                     <GetTo ZoneId="400" XYZ="360.83, -30.18121, -91.35577" /> <!-- Mazed Moogle -->
                     <TurnIn QuestId="67370" NpcId="1013430" XYZ="360.83, -30.18121, -91.35577" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7941,10 +8161,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67369" NpcId="1012085" ItemId="2001636" XYZ="286.8848, 14.36517, 645.1666" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67369" NpcId="1012085" ItemId="2001636" XYZ="286.8848, 14.36517, 645.1666" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7986,10 +8208,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67364" NpcId="1013420" XYZ="-511.4672, 50, 347.0968" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67364" NpcId="1013420" XYZ="-511.4672, 50, 347.0968" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8025,6 +8249,7 @@
                     -->
 
                     <TurnIn QuestId="67365" NpcId="1012081" ItemId="2001634" XYZ="364.0955, -73.26239, 678.004" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8061,6 +8286,7 @@
                 <If Condition="GetQuestStep(67165) == 255">
                     <GetTo ZoneId="418" XYZ="-160.5402, 16.97958, -39.96344" /> <!-- Biggs -->
                     <TurnIn QuestId="67165" NpcId="1012714" XYZ="-160.5402, 16.97958, -39.96344" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8136,10 +8362,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67364" NpcId="1013420" XYZ="-511.4672, 50, 347.0968" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67166" NpcId="1012729" XYZ="-229.2058, 33.90731, 428.4275" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8177,10 +8405,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67364" NpcId="1013420" XYZ="-511.4672, 50, 347.0968" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67167" NpcId="1012731" XYZ="-23.91095, 37.76, 78.81274" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8229,6 +8459,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-1.876892, 7.450581E-09, -9.079163" />
                     <TurnIn QuestId="67168" NpcId="1012733" XYZ="-1.876892, 7.450581E-09, -9.079163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8287,6 +8518,7 @@
                 <If Condition="GetQuestStep(65581) == 255">
                     <GetTo ZoneId="156" XYZ="55.43604, 31.18755, -763.4241" /> <!-- Yozan -->
                     <TurnIn QuestId="65581" NpcId="1009813" XYZ="55.43604, 31.18755, -763.4241" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8330,6 +8562,7 @@
                 <If Condition="GetQuestStep(65586) == 255">
                     <GetTo ZoneId="156" XYZ="55.43604, 31.18755, -763.4241" /> <!-- Yozan -->
                     <TurnIn QuestId="65586" NpcId="1009813" XYZ="55.43604, 31.18755, -763.4241" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8388,10 +8621,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="65636" NpcId="1006530" ItemId="2001463" XYZ="21.92719, 20.74698, -682.063" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="65636" NpcId="1006530" ItemId="2001463" XYZ="21.92719, 20.74698, -682.063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8467,6 +8702,7 @@
                 <If Condition="GetQuestStep(67169) == 255">
                     <GetTo ZoneId="418" XYZ="107.4692, 24.37563, -8.407776" /> <!-- Estinien -->
                     <TurnIn QuestId="67169" NpcId="1012589" XYZ="107.4692, 24.37563, -8.407776" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8507,6 +8743,7 @@
                     -->
 
                     <TurnIn QuestId="67170" NpcId="1012746" XYZ="550.4386, -1.191689, -354.9401" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8545,10 +8782,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67171" NpcId="1013172" XYZ="-756.0998, 123.7287, 214.8013" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67171" NpcId="1013172" XYZ="-756.0998, 123.7287, 214.8013" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8761,6 +9000,7 @@
                     <ExFlyTo Name="Mogeuge" XYZ="-65.87323, 91.65202, 264.4846" />
                     <NoCombatMoveTo Name="Mogeuge" XYZ="-65.87323, 91.65202, 264.4846" />
                     <TurnIn QuestId="67379" NpcId="1012089" XYZ="-65.87323, 91.65202, 264.4846" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -8784,12 +9024,14 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67378" NpcId="1012090" XYZ="-93.85828, 90.08418, 283.3142" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Mognell" XYZ="-93.85828, 90.08418, 283.3142" />
                     <NoCombatMoveTo Name="Mognell" XYZ="-93.85828, 90.08418, 283.3142" />
                     <TurnIn QuestId="67378" NpcId="1012090" XYZ="-93.85828, 90.08418, 283.3142" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -8838,6 +9080,7 @@
                     </If>
                     <NoCombatMoveTo Name="Moggzia" XYZ="225.5436, 6.960201, 709.3461" />
                     <TurnIn QuestId="67380" NpcId="1012084" ItemId="2001645" XYZ="225.5436, 6.960201, 709.3461" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -8862,6 +9105,7 @@
                 <If Condition="GetQuestStep(67377) == 255">
                     <GetTo ZoneId="400" XYZ="-47.04364, -8.866012, 165.9418" /> <!-- Mogmont -->
                     <TurnIn QuestId="67377" NpcId="1012288" ItemId="2001680" XYZ="-47.04364, -8.866012, 165.9418" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8909,6 +9153,7 @@
                     </If>
                     <ExFlyTo Name="Mewling Moogle" XYZ="638.4526, -1.263453, -46.37219" />
                     <TurnIn QuestId="67398" NpcId="1013548" ItemId="2001653" XYZ="638.4526, -1.263453, -46.37219" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -8956,6 +9201,7 @@
                     </If>
                     <NoCombatMoveTo Name="Malcontent Moogle" XYZ="354.2076, -72.89233, 698.1155" />
                     <TurnIn QuestId="67372" NpcId="1013501" ItemId="2001639" XYZ="354.2076, -72.89233, 698.1155" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -8998,6 +9244,7 @@
                     </If>
                     <NoCombatMoveTo Name="Malcontent Moogle" XYZ="354.2076, -72.89233, 698.1155" />
                     <TurnIn QuestId="67374" NpcId="1013501" ItemId="2001643" XYZ="354.2076, -72.89233, 698.1155" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9038,6 +9285,7 @@
                     </If>
                     <NoCombatMoveTo Name="Meandering Moogle" XYZ="355.3673, -73.13647, 698.7257" />
                     <TurnIn QuestId="67375" NpcId="1013504" XYZ="355.3673, -73.13647, 698.7257" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9088,6 +9336,7 @@
                     </If>
                     <NoCombatMoveTo Name="Moggzia" XYZ="225.5436, 6.960201, 709.3461" />
                     <TurnIn QuestId="67396" NpcId="1012084" ItemId="2001651" XYZ="225.5436, 6.960201, 709.3461" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9152,10 +9401,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67373" NpcId="1012284" ItemId="2001641" XYZ="363.241, -73.25598, 678.4314" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67373" NpcId="1012284" ItemId="2001641" XYZ="363.241, -73.25598, 678.4314" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9188,6 +9439,7 @@
                     </If>
                     <NoCombatMoveTo Name="Mogmill" XYZ="286.8848, 14.36517, 645.1666" />
                     <TurnIn QuestId="67376" NpcId="1012085" ItemId="2001644" XYZ="286.8848, 14.36517, 645.1666" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -9208,6 +9460,7 @@
                 <If Condition="GetQuestStep(67399) == 255">
                     <GetTo ZoneId="400" XYZ="-106.8895, 36.39444, 186.1753" /> <!-- Mogkul -->
                     <TurnIn QuestId="67399" NpcId="1014293" XYZ="-106.8895, 36.39444, 186.1753" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9248,6 +9501,7 @@
                 <If Condition="GetQuestStep(67400) == 255">
                     <GetTo ZoneId="400" XYZ="-696.3455, 79, 269.0012" /> <!-- Mogkul -->
                     <TurnIn QuestId="67400" NpcId="1014300" XYZ="-696.3455, 79, 269.0012" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9285,10 +9539,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67401" NpcId="1014304" XYZ="-471.7937, 39.90609, 156.2981" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67401" NpcId="1014304" XYZ="-471.7937, 39.90609, 156.2981" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9330,6 +9586,7 @@
                 <If Condition="GetQuestStep(67382) == 255">
                     <GetTo ZoneId="400" XYZ="-548.0278, 54.15157, 203.6621" /> <!-- Impatient Moogle -->
                     <TurnIn QuestId="67382" NpcId="1013507" XYZ="-548.0278, 54.15157, 203.6621" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9354,6 +9611,7 @@
                 <If Condition="GetQuestStep(67384) == 255">
                     <GetTo ZoneId="400" XYZ="-562.4346, 59.43623, 199.0779" /> <!-- Unmaneuvering Moogle -->
                     <TurnIn QuestId="67384" NpcId="1013514" ItemId="2001678" XYZ="-613.3059, 69.99999, 205.2795" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9417,6 +9675,7 @@
                 <If Condition="GetQuestStep(67403) == 255">
                     <GetTo ZoneId="400" XYZ="-746.1204, 73, 318.7456" /> <!-- Mogok -->
                     <TurnIn QuestId="67403" NpcId="1014308" XYZ="-746.1204, 73, 318.7456" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9468,11 +9727,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67385" NpcId="1013514" ItemId="2001679" XYZ="-613.3059, 69.99999, 205.2795" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Unmaneuvering Moogle" XYZ="-613.3059, 69.99999, 205.2795" />
                     <TurnIn QuestId="67385" NpcId="1013514" ItemId="2001679" XYZ="-613.3059, 69.99999, 205.2795" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -9500,6 +9761,7 @@
                 <If Condition="GetQuestStep(67402) == 255">
                     <GetTo ZoneId="400" XYZ="-661.4023, 73, 171.0383" /> <!-- Mogga -->
                     <TurnIn QuestId="67402" NpcId="1014307" XYZ="-661.4023, 73, 171.0383" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9561,11 +9823,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67404" NpcId="1012082" XYZ="381.7043, -69.41491, 691.5541" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Mogloo" XYZ="381.7043, -69.41491, 691.5541" />
                     <TurnIn QuestId="67404" NpcId="1012082" XYZ="381.7043, -69.41491, 691.5541" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -9586,6 +9850,7 @@
                 <If Condition="GetQuestStep(67381) == 255">
                     <GetTo ZoneId="400" XYZ="-548.0278, 54.15157, 203.6621" /> <!-- Impatient Moogle -->
                     <TurnIn QuestId="67381" NpcId="1013507" XYZ="-548.0278, 54.15157, 203.6621" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9623,10 +9888,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67397" NpcId="1013547" ItemId="2001652" XYZ="-98.64966, 81.8169, -213.5806" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67397" NpcId="1013547" ItemId="2001652" XYZ="-98.64966, 81.8169, -213.5806" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9673,6 +9940,7 @@
                     </If>
                     <NoCombatMoveTo Name="Mogzun" XYZ="-214.313, 81.84055, -233.4478" />
                     <TurnIn QuestId="67386" NpcId="1013515" XYZ="-214.313, 81.84055, -233.4478" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9722,11 +9990,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67387" NpcId="1013520" ItemId="2001647" XYZ="-481.0712, 106.918, -113.0541" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <NoCombatMoveTo Name="Mogzun" XYZ="-481.0712, 106.918, -113.0541" />
                     <TurnIn QuestId="67387" NpcId="1013520" ItemId="2001647" XYZ="-481.0712, 106.918, -113.0541" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9775,11 +10045,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67388" NpcId="1013521" ItemId="2001648" XYZ="-520.7751, 116.3302, -239.1241" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <NoCombatMoveTo Name="Mogkon" XYZ="-520.7751, 116.3302, -239.1241" />
                     <TurnIn QuestId="67388" NpcId="1013521" ItemId="2001648" XYZ="-520.7751, 116.3302, -239.1241" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9857,10 +10129,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67389" NpcId="1013522" ItemId="2001649" XYZ="-708.4917, 90.86575, -436.3318" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67389" NpcId="1013522" ItemId="2001649" XYZ="-708.4917, 90.86575, -436.3318" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9870,6 +10144,7 @@
                 <If Condition="GetQuestStep(67395) == 255">
                     <GetTo ZoneId="400" XYZ="-637.9645, 108.7327, -341.1155" /> <!-- Meticulous Moogle -->
                     <TurnIn QuestId="67395" NpcId="1013546" ItemId="2001650" XYZ="-637.9645, 108.7327, -341.1155" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9924,11 +10199,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67390" NpcId="1013529" XYZ="-214.313, 81.84055, -233.4478" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <NoCombatMoveTo Name="Mogzun" XYZ="-214.313, 81.84055, -233.4478" />
                     <TurnIn QuestId="67390" NpcId="1013529" XYZ="-214.313, 81.84055, -233.4478" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9957,6 +10234,7 @@
                 <If Condition="GetQuestStep(67391) == 255">
                     <GetTo ZoneId="400" XYZ="-215.8389, 130.9513, -514.2138" /> <!-- Malingering Moogle -->
                     <TurnIn QuestId="67391" NpcId="1013535" XYZ="-215.8389, 130.9513, -514.2138" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10016,6 +10294,7 @@
                 <If Condition="GetQuestStep(67392) == 255">
                     <GetTo ZoneId="400" XYZ="-227.6799, 134.4906, -593.4386" /> <!-- Remarking Moogle -->
                     <TurnIn QuestId="67392" NpcId="1013536" XYZ="-227.6799, 134.4906, -593.4386" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10066,6 +10345,7 @@
                     </If>
                     <ExFlyTo Name="Glimpsing Moogle" XYZ="-167.4678, 144.6952, -593.5607" />
                     <TurnIn QuestId="67393" NpcId="1013537" XYZ="-167.4678, 144.6952, -593.5607" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -10116,6 +10396,7 @@
                     </If>
                     <ExFlyTo Name="Malingering Moogle" XYZ="-215.8389, 130.9513, -514.2138" />
                     <TurnIn QuestId="67394" NpcId="1013535" XYZ="-215.8389, 130.9513, -514.2138" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -10128,6 +10409,7 @@
                 <If Condition="GetQuestStep(67383) == 255">
                     <GetTo ZoneId="400" XYZ="-94.80432, -2.981276, 250.782" /> <!-- Mogson -->
                     <TurnIn QuestId="67383" NpcId="1012091" ItemId="2001646" XYZ="-94.80432, -2.981276, 250.782" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10214,10 +10496,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67172" NpcId="1012750" XYZ="-163.8972, 27.97913, -116.4111" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67172" NpcId="1012750" XYZ="-163.8972, 27.97913, -116.4111" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10255,6 +10539,7 @@
                 <If Condition="GetQuestStep(67656) == 255">
                     <GetTo ZoneId="418" XYZ="73.89941, 24.3075, 22.04926" /> <!-- Clan Hunt Board -->
                     <TurnIn QuestId="67656" NpcId="2005909" XYZ="73.89941, 24.3075, 22.04926" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10294,11 +10579,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67173" NpcId="1012753" XYZ="-2.578735, -7.450581E-09, 7.644714" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Lucia" XYZ="2.578735, -7.450581E-09, 7.644714" />
                     <TurnIn QuestId="67173" NpcId="1012753" XYZ="-2.578735, -7.450581E-09, 7.644714" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10456,10 +10743,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnInPlus QuestId="67405" NpcId="1012181" XYZ="-248.5543, -20.03492, -90.98956" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnInPlus QuestId="67405" NpcId="1012181" XYZ="-248.5543, -20.03492, -90.98956" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10493,10 +10782,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67406" NpcId="1012180" ItemId="2001821" XYZ="-174.1818, -12.55547, -21.56104" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67406" NpcId="1012180" ItemId="2001821" XYZ="-174.1818, -12.55547, -21.56104" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10528,10 +10819,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67174" NpcId="1013332" XYZ="94.95691, -22, 50.94983" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67174" NpcId="1013332" XYZ="94.95691, -22, 50.94983" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10594,10 +10887,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67529" NpcId="1011192" ItemId="2001591" XYZ="88.36499, 15.09468, 31.29626" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67529" NpcId="1011192" ItemId="2001591" XYZ="88.36499, 15.09468, 31.29626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10626,6 +10921,7 @@
                 <If Condition="GetQuestStep(67530) == 255">
                     <GetTo ZoneId="418" XYZ="88.36499, 15.09468, 31.29626" /> <!-- Gibrillont -->
                     <TurnIn QuestId="67530" NpcId="1011192" XYZ="88.36499, 15.09468, 31.29626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10654,6 +10950,7 @@
                 <If Condition="GetQuestStep(67531) == 255">
                     <GetTo ZoneId="418" XYZ="88.36499, 15.09468, 31.29626" /> <!-- Gibrillont -->
                     <TurnIn QuestId="67531" NpcId="1011192" XYZ="88.36499, 15.09468, 31.29626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10682,6 +10979,7 @@
                 <If Condition="GetQuestStep(67532) == 255">
                     <GetTo ZoneId="418" XYZ="104.387, 15, 25.55884" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67532" NpcId="1013260" XYZ="104.387, 15, 25.55884" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10701,6 +10999,7 @@
                 <If Condition="GetQuestStep(67409) == 255">
                     <GetTo ZoneId="397" XYZ="-293.6294, 125.4389, -19.05853" /> <!-- Noble Youth -->
                     <TurnIn QuestId="67409" NpcId="1014719" XYZ="-293.6294, 125.4389, -19.05853" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10836,6 +11135,7 @@
                     </If>
                     <ExFlyTo Name="Margyt" XYZ="-258.7473, 126.9855, 12.64966" />
                     <TurnIn QuestId="67425" NpcId="1014146" ItemId="2001748" XYZ="-258.7473, 126.9855, 12.64966" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -10872,6 +11172,7 @@
                     </If>
                     <MoveTo Name="Pierriquet" XYZ="-311.1467, 126.5033, -6.729248" />
                     <TurnIn QuestId="67433" NpcId="1012283" ItemId="2001654" XYZ="-311.1467, 126.5033, -6.729248" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11026,6 +11327,7 @@
                     </If>
                     <ExFlyTo Name="Redwald" XYZ="503.1051, 217.9515, 790.2189" />
                     <TurnIn QuestId="67422" NpcId="1011231" ItemId="2001654" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11080,6 +11382,7 @@
                 <If Condition="GetQuestStep(67424) == 255">
                     <GetTo ZoneId="397" XYZ="692.3474, 134.8718, -630.1213" /> <!-- Emont -->
                     <TurnIn QuestId="67424" NpcId="1012280" XYZ="692.3474, 134.8718, -630.1213" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11149,11 +11452,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67426" NpcId="1014146" XYZ="-258.7473, 126.9855, 12.64966" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Margyt" XYZ="-258.7473, 126.9855, 12.64966" />
                     <TurnIn QuestId="67426" NpcId="1014146" XYZ="-258.7473, 126.9855, 12.64966" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11195,10 +11500,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67431" NpcId="1011907" XYZ="-288.8686, 127.0664, 13.19904" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67431" NpcId="1011907" XYZ="-288.8686, 127.0664, 13.19904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11229,6 +11536,7 @@
                 <If Condition="GetQuestStep(67432) == 255">
                     <GetTo ZoneId="397" XYZ="-298.2681, 126.6705, -1.419189" /> <!-- Luciae -->
                     <TurnIn QuestId="67432" NpcId="1011910" XYZ="-298.2681, 126.6705, -1.419189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11273,11 +11581,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67430" NpcId="1011908" ItemId="2001685" XYZ="-285.3895, 127.1065, 14.69434" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Bonifoix" XYZ="-285.3895, 127.1065, 14.69434" />
                     <TurnIn QuestId="67430" NpcId="1011908" ItemId="2001685" XYZ="-285.3895, 127.1065, 14.69434" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11326,11 +11636,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67427" NpcId="1014146" XYZ="-258.7473, 126.9855, 12.64966" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Margyt" XYZ="-258.7473, 126.9855, 12.64966" />
                     <TurnIn QuestId="67427" NpcId="1014146" XYZ="-258.7473, 126.9855, 12.64966" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -11379,6 +11691,7 @@
                     </If>
                     <ExFlyTo Name="Margyt" XYZ="-258.7473, 126.9855, 12.64966" />
                     <TurnIn QuestId="67428" NpcId="1014146" XYZ="-258.7473, 126.9855, 12.64966" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -11430,6 +11743,7 @@
                     </If>
                     <NoCombatMoveTo Name="Margyt" XYZ="-295.8267, 126.8374, 3.829956" />
                     <TurnIn QuestId="67429" NpcId="1014153" XYZ="-295.8267, 126.8374, 3.829956" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -11547,11 +11861,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67434" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <NoCombatMoveTo Name="Dominiac" XYZ="-294.6975, 126.8487, 4.53186" />
                     <TurnIn QuestId="67434" NpcId="1013710" XYZ="-294.6975, 126.8487, 4.53186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -11564,6 +11880,7 @@
                 <If Condition="GetQuestStep(67421) == 255">
                     <GetTo ZoneId="397" XYZ="493.1563, 200.2377, 663.0197" /> <!-- Ingaret -->
                     <TurnIn QuestId="67421" NpcId="1011240" XYZ="493.1563, 200.2377, 663.0197" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11573,6 +11890,7 @@
                 <If Condition="GetQuestStep(67423) == 255">
                     <GetTo ZoneId="397" XYZ="472.0989, 217.9388, 760.3723" /> <!-- Troubled Elezen -->
                     <TurnIn QuestId="67423" NpcId="1013553" XYZ="472.0989, 217.9388, 760.3723" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11602,10 +11920,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67410" NpcId="1011952" ItemId="2001807" XYZ="-277.6379, -184.5974, 741.6038" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67410" NpcId="1011952" ItemId="2001807" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11717,6 +12037,7 @@
                     -->
 
                     <TurnIn QuestId="67437" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11726,6 +12047,7 @@
                 <If Condition="GetQuestStep(67435) == 255">
                     <GetTo ZoneId="401" XYZ="-344.9608, -164.6414, 836.3317" /> <!-- Gildon -->
                     <TurnIn QuestId="67435" NpcId="1012059" XYZ="-344.9608, -164.6414, 836.3317" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11750,6 +12072,7 @@
                 <If Condition="GetQuestStep(67436) == 255">
                     <GetTo ZoneId="401" XYZ="-640.1007, -119.5621, 469.5963" /> <!-- Fabrellet -->
                     <TurnIn QuestId="67436" NpcId="1012054" ItemId="2001655" XYZ="-640.1007, -119.5621, 469.5963" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11759,6 +12082,7 @@
                 <If Condition="GetQuestStep(67438) == 255">
                     <GetTo ZoneId="401" XYZ="-658.8998, -127.7836, 622.98" /> <!-- Caribault -->
                     <TurnIn QuestId="67438" NpcId="1012056" ItemId="2001656" XYZ="-658.8998, -127.7836, 622.98" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11812,6 +12136,7 @@
                 <If Condition="GetQuestStep(67440) == 255">
                     <GetTo ZoneId="401" XYZ="-344.9608, -164.6414, 836.3317" /> <!-- Gildon -->
                     <TurnIn QuestId="67440" NpcId="1012059" XYZ="-344.9608, -164.6414, 836.3317" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11821,6 +12146,7 @@
                 <If Condition="GetQuestStep(67439) == 255">
                     <GetTo ZoneId="401" XYZ="-640.1007, -119.5621, 469.5963" /> <!-- Fabrellet -->
                     <TurnIn QuestId="67439" NpcId="1012054" ItemId="2001658" XYZ="-640.1007, -119.5621, 469.5963" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11830,6 +12156,7 @@
                 <If Condition="GetQuestStep(67408) == 255">
                     <GetTo ZoneId="400" XYZ="15.60992, 81.8406, -317.3724" /> <!-- Maenne -->
                     <TurnIn QuestId="67408" NpcId="1013560" XYZ="15.60992, 81.8406, -317.3724" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11880,6 +12207,7 @@
                     </If>
                     <ExFlyTo Name="Maenne" XYZ="15.60992, 81.8406, -317.3724" />
                     <TurnIn QuestId="67414" NpcId="1013560" XYZ="15.60992, 81.8406, -317.3724" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -11948,6 +12276,7 @@
                     </If>
                     <ExFlyTo Name="Northeastern Scouting Party Dragoon" XYZ="330.7391, 223.0154, -480.3693" />
                     <TurnIn QuestId="67417" NpcId="1013569" XYZ="330.7391, 223.0154, -480.3693" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -12000,6 +12329,7 @@
                     </If>
                     <ExFlyTo Name="Maenne" XYZ="15.60992, 81.8406, -317.3724" />
                     <TurnIn QuestId="67418" NpcId="1013560" ItemId="2001659" XYZ="15.60992, 81.8406, -317.3724" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12047,6 +12377,7 @@
                     </If>
                     <ExFlyTo Name="Southern Scouting Party Dragoon" XYZ="-753.5974, 285.6566, -168.658" />
                     <TurnIn QuestId="67415" NpcId="1013566" XYZ="-753.5974, 285.6566, -168.658" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12098,6 +12429,7 @@
                     </If>
                     <ExFlyTo Name="Northern Scouting Party Dragoon" XYZ="-556.4203, 266.003, -673.7926" />
                     <TurnIn QuestId="67419" NpcId="1013570" ItemId="2001660" XYZ="-556.4203, 266.003, -673.7926" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12198,11 +12530,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67420" NpcId="1013567" XYZ="15.60992, 81.8406, -317.3724" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <NoCombatMoveTo Name="Maenne" XYZ="15.60992, 81.8406, -317.3724" />
                     <TurnIn QuestId="67420" NpcId="1013567" XYZ="15.60992, 81.8406, -317.3724" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12248,11 +12582,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67416" NpcId="1013560" XYZ="15.60992, 81.8406, -317.3724" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Maenne" XYZ="15.60992, 81.8406, -317.3724" />
                     <TurnIn QuestId="67416" NpcId="1013560" ItemId="2001684" XYZ="15.60992, 81.8406, -317.3724" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12331,11 +12667,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67411" NpcId="1012286" XYZ="-658.6251, 209.1895, 622.8579" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <MoveTo Name="Mogoon" XYZ="-658.6251, 209.1895, 622.8579" />
                     <TurnIn QuestId="67411" NpcId="1012286" XYZ="-658.6251, 209.1895, 622.8579" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -12397,11 +12735,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67412" NpcId="1012286" XYZ="-658.6251, 209.1895, 622.8579" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <ExFlyTo Name="Mogoon" XYZ="-658.6251, 209.1895, 622.8579" />
                     <TurnIn QuestId="67412" NpcId="1012286" XYZ="-658.6251, 209.1895, 622.8579" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12445,6 +12785,7 @@
                     </If>
                     <ExFlyTo Name="Mogoon" XYZ="-658.6251, 209.1895, 622.8579" />
                     <TurnIn QuestId="67413" NpcId="1012286" ItemId="2001683" XYZ="-658.6251, 209.1895, 622.8579" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -12477,10 +12818,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67407" NpcId="1014314" XYZ="12.10034, 81.8406, -318.0133" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67407" NpcId="1014314" XYZ="12.10034, 81.8406, -318.0133" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12545,6 +12888,7 @@
                 <If Condition="GetQuestStep(67175) == 255">
                     <GetTo ZoneId="418" XYZ="86.38135, 23.97913, 12.80225" /> <!-- Hilda -->
                     <TurnIn QuestId="67175" NpcId="1012780" XYZ="86.38135, 23.97913, 12.80225" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12597,6 +12941,7 @@
                     </If>
                     <GetTo ZoneId="419" XYZ="14.8775, 16.00967, -4.196289" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67176" NpcId="1013227" XYZ="14.8775, 16.00967, -4.196289" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12628,6 +12973,7 @@
 
                     <MoveTo Name="Aymeric" XYZ="-0.01531982, 0.01999969, -6.302063" />
                     <TurnIn QuestId="67177" NpcId="1013183" XYZ="-0.01531982, 0.01999969, -6.302063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12692,6 +13038,7 @@
                 <If Condition="GetQuestStep(67178) == 255">
                     <GetTo ZoneId="418" XYZ="-158.4955, 17.06621, -56.26001" /> <!-- Cid -->
                     <TurnIn QuestId="67178" NpcId="1013261" XYZ="-158.4955, 17.06621, -56.26001" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12746,10 +13093,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67441" NpcId="1012178" XYZ="-128.13, 5.467082, 34.37854" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67441" NpcId="1012178" XYZ="-128.13, 5.467082, 34.37854" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12766,6 +13115,7 @@
                 <If Condition="GetQuestStep(67442) == 255">
                     <GetTo ZoneId="418" XYZ="102.9221, 3.629973, 65.56799" /> <!-- Brictt -->
                     <TurnIn QuestId="67442" NpcId="1012170" XYZ="102.9221, 3.629973, 65.56799" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12799,6 +13149,7 @@
                     </If>
                     <NoCombatMoveTo Name="Alphinaud" XYZ="-805.5391, -57.82888, 157.6409" />
                     <TurnIn QuestId="67179" NpcId="1013085" XYZ="-805.5391, -57.82888, 157.6409" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12853,6 +13204,7 @@
                 <If Condition="GetQuestStep(67180) == 255">
                     <GetTo ZoneId="401" XYZ="-751.6747, -35.95642, 18.72278" /> <!-- Lonu Vanu -->
                     <TurnIn QuestId="67180" NpcId="1013089" XYZ="-751.6747, -35.95642, 18.72278" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12882,6 +13234,7 @@
                 <If Condition="GetQuestStep(67181) == 255">
                     <GetTo ZoneId="401" XYZ="-560.6927, -52.30738, -427.5731" /> <!-- Lonu Vanu -->
                     <TurnIn QuestId="67181" NpcId="1013095" XYZ="-560.6927, -52.30738, -427.5731" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12911,6 +13264,7 @@
                 <If Condition="GetQuestStep(67182) == 255">
                     <GetTo ZoneId="401" XYZ="-583.032, -52.12611, -447.4403" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67182" NpcId="1014570" XYZ="-583.032, -52.12611, -447.4403" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13000,6 +13354,7 @@
                 <If Condition="GetQuestStep(67443) == 255">
                     <GetTo ZoneId="401" XYZ="-568.5969, -50.64948, -452.1096" /> <!-- Conu Vanu -->
                     <TurnIn QuestId="67443" NpcId="1012072" ItemId="2001668" XYZ="-568.5969, -50.64948, -452.1096" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13098,6 +13453,7 @@
                 <If Condition="GetQuestStep(67444) == 255">
                     <GetTo ZoneId="401" XYZ="-568.3833, -50.60525, -449.1188" /> <!-- Hinu Vali -->
                     <TurnIn QuestId="67444" NpcId="1012071" ItemId="2001669" XYZ="-568.3833, -50.60525, -449.1188" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13114,6 +13470,7 @@
                     -->
 
                     <TurnIn QuestId="67445" NpcId="1012069" ItemId="2001670" XYZ="-647.0283, -51.05719, -417.7463" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13133,10 +13490,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67447" NpcId="1014173" XYZ="-502.2813, -37.36346, -405.8442" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67447" NpcId="1014173" XYZ="-502.2813, -37.36346, -405.8442" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13183,10 +13542,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67450" NpcId="1014173" XYZ="-502.2813, -37.36346, -405.8442" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67450" NpcId="1014173" XYZ="-502.2813, -37.36346, -405.8442" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13225,6 +13586,7 @@
                 <If Condition="GetQuestStep(67451) == 255">
                     <GetTo ZoneId="401" XYZ="-502.2813, -37.36346, -405.8442" /> <!-- Gunu Vanu -->
                     <TurnIn QuestId="67451" NpcId="1014173" XYZ="-502.2813, -37.36346, -405.8442" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13292,10 +13654,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67452" NpcId="1012068" XYZ="-597.0398, -51.05185, -387.0451" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67452" NpcId="1012068" XYZ="-597.0398, -51.05185, -387.0451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13322,6 +13686,7 @@
                     -->
 
                     <TurnIn QuestId="67183" NpcId="1014575" XYZ="-156.6644, -14.15376, -543.0228" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13504,6 +13869,7 @@
                     -->
 
                     <TurnIn QuestId="67184" NpcId="1012195" XYZ="-155.9319, -14.15376, -542.1378" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13638,6 +14004,7 @@
                     </If>
                     <ExFlyTo Name="Aanu Vanu" XYZ="-498.0087, -37.44285, -403.6164" />
                     <TurnIn QuestId="67453" NpcId="1012067" XYZ="-498.0087, -37.44285, -403.6164" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -13662,6 +14029,7 @@
                 <If Condition="GetQuestStep(67456) == 255">
                     <GetTo ZoneId="401" XYZ="-542.7787, -37.11544, -386.7094" /> <!-- Sonu Vanu -->
                     <TurnIn QuestId="67456" NpcId="1012064" XYZ="-542.7787, -37.11544, -386.7094" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13680,10 +14048,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67448" NpcId="1012071" ItemId="2001671" XYZ="-568.3833, -50.60525, -449.1188" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67448" NpcId="1012071" ItemId="2001671" XYZ="-568.3833, -50.60525, -449.1188" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13693,6 +14063,7 @@
                 <If Condition="GetQuestStep(67449) == 255">
                     <GetTo ZoneId="401" XYZ="-647.0283, -51.05719, -417.7463" /> <!-- Ganu Vali -->
                     <TurnIn QuestId="67449" NpcId="1012069" XYZ="-647.0283, -51.05719, -417.7463" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13742,6 +14113,7 @@
                     </If>
                     <MoveTo Name="Aanu Vanu" XYZ="-498.0087, -37.44285, -403.6164" />
                     <TurnIn QuestId="67457" NpcId="1012067" XYZ="-498.0087, -37.44285, -403.6164" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -13779,6 +14151,7 @@
                 <If Condition="GetQuestStep(67455) == 255">
                     <GetTo ZoneId="401" XYZ="-508.5374, -56.39412, -558.465" /> <!-- Rescued Zundu Youth -->
                     <TurnIn QuestId="67455" NpcId="1013575" XYZ="-508.5374, -56.39412, -558.465" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13861,11 +14234,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67454" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <!-- <MoveTo Name="Laniaitte" XYZ="-277.6379, -184.5974, 741.6038" />
                     <TurnIn QuestId="67454" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -13891,6 +14266,7 @@
                     -->
 
                     <TurnIn QuestId="67185" NpcId="1013111" XYZ="162.89, -15.13437, 37.0946" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13922,6 +14298,7 @@
                 <If Condition="GetQuestStep(67186) == 255">
                     <GetTo ZoneId="418" XYZ="92.36279, 15.09468, 33.18835" /> <!-- Tataru -->
                     <TurnIn QuestId="67186" NpcId="1013162" XYZ="92.36279, 15.09468, 33.18835" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13951,6 +14328,7 @@
                 <If Condition="GetQuestStep(67187) == 255">
                     <GetTo ZoneId="133" XYZ="-158.1903, 4, -21.19489" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67187" NpcId="1012394" XYZ="-158.1903, 4, -21.19489" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13990,6 +14368,7 @@
                 <If Condition="GetQuestStep(67188) == 255">
                     <GetTo ZoneId="132" XYZ="35.53821, -8, 98.13074" /> <!-- Tataru -->
                     <TurnIn QuestId="67188" NpcId="1012398" XYZ="35.53821, -8, 98.13074" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14021,6 +14400,7 @@
                 <If Condition="GetQuestStep(67189) == 255">
                     <GetTo ZoneId="132" XYZ="35.53821, -8, 98.13074" /> <!-- Tataru -->
                     <TurnIn QuestId="67189" NpcId="1012398" ItemIds="2001798,2001799" XYZ="35.53821, -8, 98.13074" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14046,6 +14426,7 @@
                 <If Condition="GetQuestStep(67190) == 255">
                     <GetTo ZoneId="398" XYZ="587.457, -50.81134, 69.16907" /> <!-- Y'shtola -->
                     <TurnIn QuestId="67190" NpcId="1012406" XYZ="587.457, -50.81134, 69.16907" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14110,10 +14491,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67458" NpcId="1014502" XYZ="455.5581, -51.1414, 21.59149" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67458" NpcId="1014502" XYZ="455.5581, -51.1414, 21.59149" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14229,6 +14612,7 @@
                 <If Condition="GetQuestStep(67461) == 255">
                     <GetTo ZoneId="398" XYZ="455.5581, -51.1414, 21.59149" /> <!-- Hervoix -->
                     <TurnIn QuestId="67461" NpcId="1014502" XYZ="455.5581, -51.1414, 21.59149" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14247,10 +14631,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67459" NpcId="1014502" XYZ="455.5581, -51.1414, 21.59149" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67459" NpcId="1014502" XYZ="455.5581, -51.1414, 21.59149" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14260,6 +14646,7 @@
                 <If Condition="GetQuestStep(67460) == 255">
                     <GetTo ZoneId="398" XYZ="455.5581, -51.1414, 21.59149" /> <!-- Hervoix -->
                     <TurnIn QuestId="67460" NpcId="1014502" XYZ="455.5581, -51.1414, 21.59149" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14269,6 +14656,7 @@
                 <If Condition="GetQuestStep(67464) == 255">
                     <GetTo ZoneId="398" XYZ="470.0236, -49.89133, 20.37079" /> <!-- Marcechamp -->
                     <TurnIn QuestId="67464" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14312,6 +14700,7 @@
                     <Dismount />
                     <MoveTo Name="Hervoix" XYZ="98.52747, -2.255482, -493.1258" />
                     <TurnIn QuestId="67462" NpcId="1014508" XYZ="98.52747, -2.255482, -493.1258" />
+                    <WaitTimer WaitTime="2"/>
                     <MoveTo Name="Jump Spot" XYZ="112.518, -5.506483, -440.5277" />
                     <RunCode Name="AHuntersTrueNatureComplete" />
                 </While>
@@ -14377,6 +14766,7 @@
                 <If Condition="GetQuestStep(67463) == 255">
                     <GetTo ZoneId="398" XYZ="535.3016, -51.34064, 65.29333" /> <!-- Loupard -->
                     <TurnIn QuestId="67463" NpcId="1011917" XYZ="535.3016, -51.34064, 65.29333" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14402,6 +14792,7 @@
                 <If Condition="GetQuestStep(67466) == 255">
                     <GetTo ZoneId="398" XYZ="70.81714, -49.2083, -141.558" /> <!-- Vath Fleetfoot -->
                     <TurnIn QuestId="67466" NpcId="1011929" XYZ="70.81714, -49.2083, -141.558" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14436,10 +14827,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67465" NpcId="1011938" ItemId="2001675" XYZ="-310.5364, 96.0603, 41.76392" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67465" NpcId="1011938" ItemId="2001675" XYZ="-310.5364, 96.0603, 41.76392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14548,11 +14941,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67191" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Slowfix" XYZ="73.3501, 205.8894, 23.48358" />
                     <TurnIn QuestId="67191" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14649,10 +15044,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67468" NpcId="1012133" XYZ="-26.84064, 206.5, 28.67163" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67468" NpcId="1012133" XYZ="-26.84064, 206.5, 28.67163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14672,10 +15069,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67192" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67192" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14866,6 +15265,7 @@
                 <If Condition="GetQuestStep(67469) == 255">
                     <GetTo ZoneId="399" XYZ="803.952, 150.1354, 164.7211" /> <!-- Feltsmox -->
                     <TurnIn QuestId="67469" NpcId="1013643" ItemId="2001691" XYZ="803.952, 150.1354, 164.7211" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14901,10 +15301,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67470" NpcId="1013644" XYZ="91.17261, 65.05788, -184.68" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67470" NpcId="1013644" XYZ="91.17261, 65.05788, -184.68" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14924,6 +15326,7 @@
                     -->
 
                     <TurnIn QuestId="67472" NpcId="1012287" XYZ="-28.39703, 100.9697, -186.4195" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14943,10 +15346,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67467" NpcId="1012100" XYZ="106.7368, 207.2281, 85.40466" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67467" NpcId="1012100" XYZ="106.7368, 207.2281, 85.40466" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14965,10 +15370,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67477" NpcId="1012099" ItemId="2001693" XYZ="50.27844, 206.047, 57.75537" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67477" NpcId="1012099" ItemId="2001693" XYZ="50.27844, 206.047, 57.75537" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14987,10 +15394,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67475" NpcId="1012132" ItemId="2001692" XYZ="43.01514, 206.0469, 56.50415" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67475" NpcId="1012132" ItemId="2001692" XYZ="43.01514, 206.0469, 56.50415" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15010,10 +15419,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67474" NpcId="1012101" XYZ="72.37354, 205.7478, 33.55457" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67474" NpcId="1012101" XYZ="72.37354, 205.7478, 33.55457" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15023,6 +15434,7 @@
                 <If Condition="GetQuestStep(67476) == 255">
                     <GetTo ZoneId="478" XYZ="72.40405, 205.6816, 31.63196" /> <!-- Halfsix -->
                     <TurnIn QuestId="67476" NpcId="1012102" XYZ="72.40405, 205.6816, 31.63196" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15042,10 +15454,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67193" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67193" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15123,10 +15537,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67194" NpcId="1012421" XYZ="77.98877, 203.9799, 127.9163" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67194" NpcId="1012421" XYZ="77.98877, 203.9799, 127.9163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15340,6 +15756,7 @@
                 <If Condition="GetQuestStep(67483) == 255">
                     <GetTo ZoneId="399" XYZ="-28.39703, 100.9697, -186.4195" /> <!-- Tapklix -->
                     <TurnIn QuestId="67483" NpcId="1012287" XYZ="-28.39703, 100.9697, -186.4195" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15358,10 +15775,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67482" NpcId="1012101" XYZ="72.37354, 205.7478, 33.55457" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67482" NpcId="1012101" XYZ="72.37354, 205.7478, 33.55457" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15382,10 +15801,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67481" NpcId="1012102" ItemId="2001696" XYZ="72.40405, 205.6816, 31.63196" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67481" NpcId="1012102" ItemId="2001696" XYZ="72.40405, 205.6816, 31.63196" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15395,6 +15816,7 @@
                 <If Condition="GetQuestStep(67479) == 255">
                     <GetTo ZoneId="478" XYZ="-26.84064, 206.5, 28.67163" /> <!-- Midnight Dew -->
                     <TurnIn QuestId="67479" NpcId="1012133" ItemId="2001695" XYZ="-26.84064, 206.5, 28.67163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15423,10 +15845,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67471" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67471" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15522,10 +15946,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67496" NpcId="1013647" ItemId="2001698" XYZ="-651.2398, 140.7067, 422.2018" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67496" NpcId="1013647" ItemId="2001698" XYZ="-651.2398, 140.7067, 422.2018" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15573,10 +15999,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67497" NpcId="1013648" XYZ="-527.6417, 153.4285, -35.6604" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67497" NpcId="1013648" XYZ="-527.6417, 153.4285, -35.6604" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15593,6 +16021,7 @@
                     -->
 
                     <TurnIn QuestId="67499" NpcId="1013651" ItemId="2001699" XYZ="-475.761, 155.8605, -209.7658" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15602,6 +16031,7 @@
                 <If Condition="GetQuestStep(67493) == 255">
                     <GetTo ZoneId="399" XYZ="-491.2642, 156.2549, -238.3002" /> <!-- Boomshox -->
                     <TurnIn QuestId="67493" NpcId="1013646" XYZ="-491.2642, 156.2549, -238.3002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15665,10 +16095,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67500" NpcId="1013655" XYZ="-669.9169, 154.3095, 191.0886" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67500" NpcId="1013655" XYZ="-669.9169, 154.3095, 191.0886" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15714,6 +16146,7 @@
                 <If Condition="GetQuestStep(67494) == 255">
                     <GetTo ZoneId="399" XYZ="-491.2642, 156.2549, -238.3002" /> <!-- Boomshox -->
                     <TurnIn QuestId="67494" NpcId="1013646" XYZ="-491.2642, 156.2549, -238.3002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15751,6 +16184,7 @@
                 <If Condition="GetQuestStep(67498) == 255">
                     <GetTo ZoneId="478" XYZ="106.7368, 207.2281, 85.40466" /> <!-- Woolnix -->
                     <TurnIn QuestId="67498" NpcId="1012100" XYZ="106.7368, 207.2281, 85.40466" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15771,10 +16205,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67495" NpcId="1012132" XYZ="43.01514, 206.0469, 56.50415" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67495" NpcId="1012132" XYZ="43.01514, 206.0469, 56.50415" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15793,10 +16229,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67501" NpcId="1012133" XYZ="-26.84064, 206.5, 28.67163" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67501" NpcId="1012133" XYZ="-26.84064, 206.5, 28.67163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15831,6 +16269,7 @@
                 <If Condition="GetQuestStep(67473) == 255">
                     <GetTo ZoneId="478" XYZ="73.3501, 205.8894, 23.48358" /> <!-- Slowfix -->
                     <TurnIn QuestId="67473" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15860,6 +16299,7 @@
                 <If Condition="GetQuestStep(67478) == 255">
                     <GetTo ZoneId="399" XYZ="302.449, 68.25281, -151.7205" /> <!-- Dripwix -->
                     <TurnIn QuestId="67478" NpcId="1014332" XYZ="302.449, 68.25281, -151.7205" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15893,6 +16333,7 @@
                 <If Condition="GetQuestStep(67480) == 255">
                     <GetTo ZoneId="478" XYZ="72.3125, 205.9933, 22.32391" /> <!-- Dripwix -->
                     <TurnIn QuestId="67480" NpcId="1014335" XYZ="72.3125, 205.9933, 22.32391" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15926,6 +16367,7 @@
                 <If Condition="GetQuestStep(67484) == 255">
                     <GetTo ZoneId="478" XYZ="72.3125, 205.9933, 22.32391" /> <!-- Dripwix -->
                     <TurnIn QuestId="67484" NpcId="1014335" XYZ="72.3125, 205.9933, 22.32391" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15985,10 +16427,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67485" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67485" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16026,6 +16470,7 @@
                 <If Condition="GetQuestStep(67486) == 255">
                     <GetTo ZoneId="478" XYZ="6.149353, 206.0954, 98.55798" /> <!-- Notched Bone -->
                     <TurnIn QuestId="67486" NpcId="1012134" XYZ="6.149353, 206.0954, 98.55798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16092,10 +16537,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67487" NpcId="1012134" XYZ="-6.149353, 206.0954, 98.55798" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67487" NpcId="1012134" XYZ="6.149353, 206.0954, 98.55798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16118,6 +16565,7 @@
                 <If Condition="GetQuestStep(67488) == 255">
                     <GetTo ZoneId="478" XYZ="6.301941, 206.169, 97.21521" /> <!-- Dedean -->
                     <TurnIn QuestId="67488" NpcId="1012136" XYZ="6.301941, 206.169, 97.21521" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16184,10 +16632,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67489" NpcId="1012134" XYZ="6.149353, 206.0954, 98.55798" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67489" NpcId="1012134" XYZ="6.149353, 206.0954, 98.55798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16217,6 +16667,7 @@
                 <If Condition="GetQuestStep(67490) == 255">
                     <GetTo ZoneId="478" XYZ="6.149353, 206.0954, 98.55798" /> <!-- Notched Bone -->
                     <TurnIn QuestId="67490" NpcId="1012134" XYZ="6.149353, 206.0954, 98.55798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16262,6 +16713,7 @@
                 <If Condition="GetQuestStep(67491) == 255">
                     <GetTo ZoneId="478" XYZ="6.149353, 206.0954, 98.55798" /> <!-- Notched Bone -->
                     <TurnIn QuestId="67491" NpcId="1012134" XYZ="6.149353, 206.0954, 98.55798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16320,10 +16772,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67492" NpcId="1012134" ItemId="2001779" XYZ="6.149353, 206.0954, 98.55798" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67492" NpcId="1012134" ItemId="2001779" XYZ="6.149353, 206.0954, 98.55798" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16382,6 +16836,7 @@
                 <If Condition="GetQuestStep(67195) == 255">
                     <GetTo ZoneId="399" XYZ="-476.585, 137.4297, 702.6931" /> <!-- Y'shtola -->
                     <TurnIn QuestId="67195" NpcId="1012423" XYZ="-476.585, 137.4297, 702.6931" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16503,6 +16958,7 @@
 
                     <MoveTo Name="Saro Roggo" XYZ="35.6908, 38.43, 12.98535" />
                     <TurnIn QuestId="67502" NpcId="1012141" XYZ="35.6908, 38.43, 12.98535" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16638,6 +17094,7 @@
                     </If>
                     <MoveTo Name="Statuesque Broom" XYZ="-3.463867, 37.42972, -6.607239" />
                     <TurnInPlus QuestId="67504" NpcId="1012140" XYZ="-3.463867, 37.42972, -6.607239" />
+                    <WaitTimer WaitTime="2"/>
                     <!-- <RunCode Name="A_Statuesque_Interest" /> -->
                 </If>
             </If>
@@ -16658,6 +17115,7 @@
                     </If>
                     <MoveTo Name="Self-possessed Broom" XYZ="-3.097595, 38.42918, 9.231689" />
                     <TurnIn QuestId="67505" NpcId="1013711" XYZ="-3.097595, 38.42918, 9.231689" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16674,6 +17132,7 @@
                     </If>
                     <MoveTo Name="Straightforward Broom" XYZ="15.76257, 38.43, 18.1734" />
                     <TurnIn QuestId="67503" NpcId="1012139" ItemId="2001767" XYZ="15.76257, 38.43, 18.1734" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16779,11 +17238,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67506" NpcId="1012141" XYZ="35.6908, 38.43, 12.98535" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Saro Roggo" XYZ="35.6908, 38.43, 12.98535" />
                     <TurnIn QuestId="67506" NpcId="1012141" XYZ="35.6908, 38.43, 12.98535" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16862,11 +17323,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67507" NpcId="1012138" XYZ="19.27209, 38.43, 15.85406" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Matoya" XYZ="19.27209, 38.43, 15.85406" />
                     <TurnIn QuestId="67507" NpcId="1012138" XYZ="19.27209, 38.43, 15.85406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16886,6 +17349,7 @@
                 <If Condition="GetQuestStep(67657) == 255">
                     <GetTo ZoneId="418" XYZ="73.89941, 24.3075, 22.04926" /> <!-- Clan Hunt Board -->
                     <TurnIn QuestId="67657" NpcId="2005909" XYZ="73.89941, 24.3075, 22.04926" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16916,6 +17380,7 @@
 
                     <MoveTo Name="Matoya" XYZ="19.27209, 38.43, 15.85406" />
                     <TurnIn QuestId="67196" NpcId="1012138" ItemId="2001575" XYZ="19.27209, 38.43, 15.85406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16955,6 +17420,7 @@
                 <If Condition="GetQuestStep(67197) == 255">
                     <GetTo ZoneId="419" XYZ="167.0404, -14.3133, 51.28552" /> <!-- Cid -->
                     <TurnIn QuestId="67197" NpcId="1013163" XYZ="167.0404, -14.3133, 51.28552" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17026,6 +17492,7 @@
 
                     <GetTo ZoneId="419" XYZ="165.9418, -14.34896, 51.65173" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67198" NpcId="1012430" XYZ="165.9418, -14.34896, 51.65173" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17081,6 +17548,7 @@
                     </If>
                     <NoCombatMoveTo Name="Cid" XYZ="-650.1717, -176.4502, -565.1484" />
                     <TurnIn QuestId="67199" NpcId="1012792" XYZ="-650.1717, -176.4502, -565.1484" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17132,10 +17600,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67200" NpcId="1014675" XYZ="-638.3612, -176.4502, -578.6679" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67200" NpcId="1014675" XYZ="-638.3612, -176.4502, -578.6679" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17262,6 +17732,7 @@
                 <If Condition="GetQuestStep(67518) == 255">
                     <GetTo ZoneId="402" XYZ="-173.2663, -162.034, -510.399" /> <!-- Suppression Node -->
                     <TurnIn QuestId="67518" NpcId="1012148" XYZ="-173.2663, -162.034, -510.399" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17280,10 +17751,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67517" NpcId="1012147" XYZ="-426.627, -162.1281, -328.6031" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67517" NpcId="1012147" XYZ="-426.627, -162.1281, -328.6031" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17300,6 +17773,7 @@
                     </If>
                     <NoCombatMoveTo Name="Training Node" XYZ="-607.7516, -176.4502, -527.5502" />
                     <TurnIn QuestId="67515" NpcId="1012145" XYZ="-607.7516, -176.4502, -527.5502" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17319,10 +17793,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67516" NpcId="1012146" XYZ="-643.7629, -176.4502, -527.3976" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67516" NpcId="1012146" XYZ="-643.7629, -176.4502, -527.3976" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17352,10 +17828,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67201" NpcId="1012802" XYZ="235.9807, -72.83498, -619.8978" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67201" NpcId="1012802" XYZ="235.9807, -72.83498, -619.8978" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17406,10 +17884,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67519" NpcId="1012289" XYZ="231.1893, -72.92926, -603.1434" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67519" NpcId="1012289" XYZ="231.1893, -72.92926, -603.1434" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17468,10 +17948,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67520" NpcId="1012290" XYZ="760.5248, -30.30704, -579.675" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67520" NpcId="1012290" XYZ="760.5248, -30.30704, -579.675" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17528,10 +18010,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67521" NpcId="1012291" XYZ="804.074, -26.32634, -527.4891" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67521" NpcId="1012291" XYZ="804.074, -26.32634, -527.4891" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17551,10 +18035,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67202" NpcId="2006364" XYZ="778.8052, -17.99042, -483.5432" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67202" NpcId="2006364" XYZ="778.8052, -17.99042, -483.5432" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17595,6 +18081,7 @@
                 <If Condition="GetQuestStep(67522) == 255">
                     <GetTo ZoneId="402" XYZ="583.9779, 10.93506, 100.0228" /> <!-- Expulsion Node -->
                     <TurnIn QuestId="67522" NpcId="1012292" XYZ="583.9779, 10.93506, 100.0228" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17659,10 +18146,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67523" NpcId="1012293" XYZ="573.4187, 13.07289, 329.2439" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67523" NpcId="1012293" XYZ="573.4187, 13.07289, 329.2439" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17700,10 +18189,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67525" NpcId="1012295" XYZ="214.6486, 13.75853, 536.9801" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67525" NpcId="1012295" XYZ="214.6486, 13.75853, 536.9801" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17737,6 +18228,7 @@
                 <If Condition="GetQuestStep(67524) == 255">
                     <GetTo ZoneId="402" XYZ="366.4148, 20.2141, 756.7101" /> <!-- Auditing Node -->
                     <TurnIn QuestId="67524" NpcId="1012294" ItemId="2001711" XYZ="366.4148, 20.2141, 756.7101" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17791,6 +18283,7 @@
 
                     <NoCombatMoveTo Name="Guidance Node" XYZ="-197.8638, -102.783, 456.5347" />
                     <TurnIn QuestId="67203" NpcId="1012834" XYZ="-197.8638, -102.783, 456.5347" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17841,6 +18334,7 @@
                 <If Condition="GetQuestStep(67528) == 255">
                     <GetTo ZoneId="402" XYZ="-192.6757, -102.7498, 476.9817" /> <!-- Enhancement Node -->
                     <TurnIn QuestId="67528" NpcId="1012298" XYZ="-192.6757, -102.7498, 476.9817" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17901,6 +18395,7 @@
                 <If Condition="GetQuestStep(67526) == 255">
                     <GetTo ZoneId="402" XYZ="-658.32, -75.48534, 699.1531" /> <!-- Restrainment Node -->
                     <TurnIn QuestId="67526" NpcId="1012296" XYZ="-658.32, -75.48534, 699.1531" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17919,10 +18414,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67527" NpcId="1012297" XYZ="-554.9554, -89.69182, 771.8776" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67527" NpcId="1012297" XYZ="-554.9554, -89.69182, 771.8776" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17940,6 +18437,7 @@
                     -->
 
                     <TurnIn QuestId="67204" NpcId="2005465" XYZ="-696.1318, -37.06427, 432.4253" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17963,6 +18461,7 @@
                 <If Condition="GetQuestStep(67508) == 255">
                     <GetTo ZoneId="400" XYZ="344.8997, 0.3596451, 555.3521" /> <!-- Mogule -->
                     <TurnIn QuestId="67508" NpcId="1013712" XYZ="344.8997, 0.3596451, 555.3521" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18055,6 +18554,7 @@
                     </If>
                     <ExFlyTo Name="Kupli Kuki" XYZ="-337.4533, -34.63925, -609.4606" />
                     <TurnIn QuestId="67509" NpcId="1014449" XYZ="-337.4533, -34.63925, -609.4606" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18122,6 +18622,7 @@
                     </If>
                     <ExFlyTo Name="Kupli Kuki" XYZ="-337.4533, -34.63925, -609.4606" />
                     <TurnIn QuestId="67510" NpcId="1014449" XYZ="-337.4533, -34.63925, -609.4606" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18213,6 +18714,7 @@
                     </If>
                     <ExFlyTo Name="Kupli Kuki" XYZ="641.6265, -97.81962, -714.1069" />
                     <TurnIn QuestId="67511" NpcId="1014452" ItemId="2001781" XYZ="641.6265, -97.81962, -714.1069" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18337,6 +18839,7 @@
                     </If>
                     <ExFlyTo Name="Kupli Kuki" XYZ="734.4014, -154.9205, 560.0823" />
                     <TurnIn QuestId="67512" NpcId="1014454" XYZ="734.4014, -154.9205, 560.0823" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18384,6 +18887,7 @@
                     </If>
                     <NoCombatMoveTo Name="Moglin" XYZ="381.7043, -66.84979, 700.8619" />
                     <TurnIn QuestId="67513" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18437,10 +18941,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67514" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67514" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18517,6 +19023,7 @@
                 <If Condition="GetQuestStep(67658) == 255">
                     <GetTo ZoneId="418" XYZ="73.89941, 24.3075, 22.04926" /> <!-- Clan Hunt Board -->
                     <TurnIn QuestId="67658" NpcId="2005909" XYZ="73.89941, 24.3075, 22.04926" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18592,6 +19099,7 @@
 
                     <!-- <MoveTo Name="Alphinaud" XYZ="0.7476196, 0.02225424, 4.623413" />
                     <TurnIn QuestId="67205" NpcId="1012857" XYZ="0.7476196, 0.02225424, 4.623413" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18662,6 +19170,7 @@
 
                     <!-- <ExFlyTo Name="Wedge" XYZ="-63.58441, 271.2328, -4.898254" />
                     <TurnIn QuestId="67649" NpcId="1015104" ItemId="2001882" XYZ="-63.58441, 271.2328, -4.898254" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -18733,6 +19242,7 @@
                     </If>
                     <MoveTo Name="Sanu Vanu" XYZ="-539.6353, -37.0904, -381.7655" />
                     <TurnIn QuestId="67648" NpcId="1012066" ItemId="2001884" XYZ="-539.6353, -37.0904, -381.7655" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>

--- a/Questing/[O] Heavensward.xml
+++ b/Questing/[O] Heavensward.xml
@@ -358,8 +358,8 @@
         <If Condition="not IsQuestCompleted(67263)">
             <If Condition="HasQuest(67263)">
                 <If Condition="GetQuestStep(67263) == 1">
-                    <GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" /> <!-- Jannequinard -->
-                    <HandOver ItemId="2001820" QuestId="67263" StepId="1" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+                    <GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" /> <!-- Jannequinard -->
+                    <HandOver ItemId="2001820" QuestId="67263" StepId="1" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
                 </If>
             </If>
         </If>

--- a/Questing/[O] Stormblood (Patch 4.1).xml
+++ b/Questing/[O] Stormblood (Patch 4.1).xml
@@ -96,6 +96,7 @@
             <If Condition="GetQuestStep(68498) == 255">
                 <GetTo ZoneId="635" XYZ="49.66809, -0.01531982, 58.18262" /> <!-- Destination -->
                 <TurnIn QuestId="68498" NpcId="2009050" XYZ="49.66809, -0.01531982, 58.18262" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -121,6 +122,7 @@
             <If Condition="GetQuestStep(68499) == 255">
                 <GetTo ZoneId="621" XYZ="532.494, 70, 576.1653" /> <!-- Arenvald -->
                 <TurnIn QuestId="68499" NpcId="1024103" XYZ="532.494, 70, 576.1653" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -233,6 +235,7 @@
             <If Condition="GetQuestStep(68500) == 255">
                 <GetTo ZoneId="621" XYZ="530.8156, 70, 576.0128" /> <!-- Alphinaud -->
                 <TurnIn QuestId="68500" NpcId="1024104" XYZ="530.8156, 70, 576.0128" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -256,6 +259,7 @@
             <If Condition="GetQuestStep(68501) == 255">
                 <GetTo ZoneId="621" XYZ="796.933, 69.9999, 634.76" /> <!-- Prison Guard -->
                 <TurnInPlus QuestId="68501" NpcId="1024112" XYZ="796.933, 69.9999, 634.76" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -308,6 +312,7 @@
             <If Condition="GetQuestStep(68502) == 255">
                 <GetTo ZoneId="621" XYZ="758.6632, 70, 446.311" /> <!-- Lyse -->
                 <TurnIn QuestId="68502" NpcId="1024119" XYZ="758.6632, 70, 446.311" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -343,6 +348,7 @@
             <If Condition="GetQuestStep(68503) == 255">
                 <GetTo ZoneId="131" XYZ="-105.7298, 6.98399, -4.135254" /> <!-- Nanamo Ul Namo -->
                 <TurnIn QuestId="68503" NpcId="1024102" XYZ="-105.7298, 6.98399, -4.135254" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -370,6 +376,7 @@
             <If Condition="GetQuestStep(68504) == 255">
                 <GetTo ZoneId="144" XYZ="-12.77179, 20.99973, 47.83704" /> <!-- Nanamo Ul Namo -->
                 <TurnIn QuestId="68504" NpcId="1024043" XYZ="-12.77179, 20.99973, 47.83704" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -421,6 +428,7 @@
                 </If>
                 <MoveTo Name="Nanamo Ul Namo" XYZ="-2.822998, -2.000001, -17.16644" />
                 <TurnIn QuestId="68505" NpcId="1024045" XYZ="-2.822998, -2.000001, -17.16644" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -495,6 +503,7 @@
             <If Condition="GetQuestStep(68506) == 255">
                 <GetTo ZoneId="621" XYZ="-285.2369, 11.18324, 188.8303" /> <!-- Watt -->
                 <TurnIn QuestId="68506" NpcId="1023036" XYZ="-285.2369, 11.18324, 188.8303" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -518,6 +527,7 @@
             <If Condition="GetQuestStep(68507) == 255">
                 <GetTo ZoneId="621" XYZ="340.2302, 74.00002, 70.66455" /> <!-- Lyse -->
                 <TurnIn QuestId="68507" NpcId="1024057" XYZ="340.2302, 74.00002, 70.66455" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -590,6 +600,7 @@
             <If Condition="GetQuestStep(68508) == 255">
                 <GetTo ZoneId="635" XYZ="170.5806, 13.02367, -91.96619" /> <!-- Lyse -->
                 <TurnIn QuestId="68508" NpcId="1019468" XYZ="170.5806, 13.02367, -91.96619" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>

--- a/Questing/[O] Stormblood (Patch 4.2).xml
+++ b/Questing/[O] Stormblood (Patch 4.2).xml
@@ -97,6 +97,7 @@
             <If Condition="GetQuestStep(68558) == 255">
                 <GetTo ZoneId="628" XYZ="-11.36798, 10.50388, -212.7566" /> <!-- Alisaie -->
                 <TurnIn QuestId="68558" NpcId="1024726" XYZ="-11.36798, 10.50388, -212.7566" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -116,6 +117,7 @@
             <If Condition="GetQuestStep(68559) == 255">
                 <GetTo ZoneId="628" XYZ="-0.04809813, -1.192093E-07, -78.75706" /> <!-- Ume -->
                 <TurnIn QuestId="68559" NpcId="1019061" XYZ="-0.04577637, 0, -80.8576" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -160,6 +162,7 @@
             <If Condition="GetQuestStep(68560) == 255">
                 <GetTo ZoneId="613" XYZ="-788.2658, 11.70907, -283.0091" /> <!-- Soroban -->
                 <TurnIn QuestId="68560" NpcId="1024836" XYZ="-788.2658, 11.70907, -283.0091" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -196,6 +199,7 @@
             <If Condition="GetQuestStep(68561) == 255">
                 <GetTo ZoneId="614" XYZ="173.2051, 5.191043, -433.2495" /> <!-- Hien -->
                 <TurnIn QuestId="68561" NpcId="1020524" XYZ="173.2051, 5.191043, -433.2495" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -268,6 +272,7 @@
                 </If>
                 <MoveTo Name="Alisaie" XYZ="6.027222, 0, 18.63123" />
                 <TurnIn QuestId="68562" NpcId="1024971" XYZ="6.027222, 0, 18.63123" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -312,6 +317,7 @@
             <If Condition="GetQuestStep(68563) == 255">
                 <GetTo ZoneId="614" XYZ="464.1031, 17.72051, 301.5945" /> <!-- Asahi -->
                 <TurnIn QuestId="68563" NpcId="1024989" XYZ="464.1031, 17.72051, 301.5945" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -346,6 +352,7 @@
                 </If>
                 <MoveTo Name="Hien" XYZ="0.1983643, 0.02109136, -3.097595" />
                 <TurnIn QuestId="68564" NpcId="1024999" XYZ="0.1983643, 0.02109136, -3.097595" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
     </If>
@@ -396,6 +403,7 @@
                 </If>
                 <MoveTo Name="Hancock" XYZ="0.04577637, 0, -2.304138" />
                 <TurnIn QuestId="68565" NpcId="1020622" XYZ="0.04577637, 0, -2.304138" />
+                <WaitTimer WaitTime="2"/>
                 </If>
         </If>
     </If>

--- a/Questing/[O] Stormblood.xml
+++ b/Questing/[O] Stormblood.xml
@@ -132,6 +132,7 @@
                 <If Condition="GetQuestStep(67982) == 255">
                     <GetTo ZoneId="612" XYZ="-606.7445, 130, -506.9505" /> <!-- Raubahn -->
                     <TurnIn QuestId="67982" NpcId="1020304" XYZ="-606.7445, 130, -506.9505" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -169,6 +170,7 @@
                 <If Condition="GetQuestStep(67983) == 255">
                     <GetTo ZoneId="635" XYZ="-32.97479, 18.04509, 129.4117" /> <!-- Conrad -->
                     <TurnIn QuestId="67983" NpcId="1020329" XYZ="-32.97479, 18.04509, 129.4117" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -187,6 +189,7 @@
                 <If Condition="GetQuestStep(67984) == 255">
                     <GetTo ZoneId="635" XYZ="170.9163, 13.02367, -91.38635" /> <!-- Conrad -->
                     <TurnIn QuestId="67984" NpcId="1019466" XYZ="170.9163, 13.02367, -91.38635" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -224,6 +227,7 @@
                 <If Condition="GetQuestStep(67985) == 255">
                     <GetTo ZoneId="635" XYZ="59.67798, 0, -4.074219" /> <!-- Lyse -->
                     <TurnIn QuestId="67985" NpcId="1020347" XYZ="59.67798, 0, -4.074219" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -249,6 +253,7 @@
                 <If Condition="GetQuestStep(67986) == 255">
                     <GetTo ZoneId="635" XYZ="164.1412, 13.02367, -92.30188" /> <!-- Alisaie -->
                     <TurnIn QuestId="67986" NpcId="1020333" XYZ="164.1412, 13.02367, -92.30188" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -325,6 +330,7 @@
                 <If Condition="GetQuestStep(67987) == 255">
                     <GetTo ZoneId="612" XYZ="-95.84198, 59.80103, -551.9341" /> <!-- M'naago -->
                     <TurnIn QuestId="67987" NpcId="1020351" XYZ="-95.84198, 59.80103, -551.9341" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -353,6 +359,7 @@
                 <If Condition="GetQuestStep(67988) == 255">
                     <GetTo ZoneId="612" XYZ="-606.7445, 130, -506.9505" /> <!-- Raubahn -->
                     <TurnIn QuestId="67988" NpcId="1020304" XYZ="-606.7445, 130, -506.9505" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -510,6 +517,7 @@
                     -->
 
                     <TurnIn QuestId="68175" NpcId="1019517" XYZ="-653.0099, 129.9154, -510.6737" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -646,6 +654,7 @@
                 <If Condition="GetQuestStep(68178) == 255">
                     <GetTo ZoneId="612" XYZ="-620.142, 130.2031, -480.9186" /> <!-- Resistance Fighter -->
                     <TurnIn QuestId="68178" NpcId="1021654" XYZ="-620.142, 130.2031, -480.9186" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -655,6 +664,7 @@
                 <If Condition="GetQuestStep(68176) == 255">
                     <GetTo ZoneId="612" XYZ="-613.1228, 130, -529.839" /> <!-- Serpent Marshal Brookstone -->
                     <TurnIn QuestId="68176" NpcId="1019519" XYZ="-613.1228, 130, -529.839" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -664,6 +674,7 @@
                 <If Condition="GetQuestStep(68180) == 255">
                     <GetTo ZoneId="612" XYZ="-630.6401, 130.1741, -527.306" /> <!-- Quincompaix -->
                     <TurnIn QuestId="68180" ItemIds="2002085,2002086" NpcId="1019520" XYZ="-630.6401, 130.1741, -527.306" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -673,6 +684,7 @@
                 <If Condition="GetQuestStep(68179) == 255">
                     <GetTo ZoneId="612" XYZ="-647.2725, 129.8381, -549.6147" /> <!-- Lucinne -->
                     <TurnIn QuestId="68179" ItemIds="2002083,2002084" NpcId="1019524" XYZ="-647.2725, 129.8381, -549.6147" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -682,6 +694,7 @@
                 <If Condition="GetQuestStep(68177) == 255">
                     <GetTo ZoneId="612" XYZ="-658.2894, 130, -536.4919" /> <!-- Maelstrom Officer -->
                     <TurnIn QuestId="68177" NpcId="1022954" XYZ="-658.2894, 130, -536.4919" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -718,6 +731,7 @@
                 <If Condition="GetQuestStep(67989) == 255">
                     <GetTo ZoneId="612" XYZ="-507.4388, 86.34846, -289.8452" /> <!-- M'naago -->
                     <TurnIn QuestId="67989" NpcId="1020361" XYZ="-507.4388, 86.34846, -289.8452" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -739,6 +753,7 @@
                 <If Condition="GetQuestStep(67990) == 255">
                     <GetTo ZoneId="635" XYZ="171.313, 13.02367, -89.95197" /> <!-- M'naago -->
                     <TurnIn QuestId="67990" NpcId="1020337" XYZ="171.313, 13.02367, -89.95197" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -762,6 +777,7 @@
                 <If Condition="GetQuestStep(67991) == 255">
                     <GetTo ZoneId="620" XYZ="36.42322, 117.956, -742.2446" /> <!-- Meffrid -->
                     <TurnIn QuestId="67991" NpcId="1020372" XYZ="36.42322, 117.956, -742.2446" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -790,6 +806,7 @@
                 <If Condition="GetQuestStep(67992) == 255">
                     <GetTo ZoneId="620" XYZ="89.21948, 119.4052, -684.7792" /> <!-- Meffrid -->
                     <TurnIn QuestId="67992" NpcId="1020374" XYZ="89.21948, 119.4052, -684.7792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -851,6 +868,7 @@
                 <If Condition="GetQuestStep(68490) == 255">
                     <GetTo ZoneId="620" XYZ="81.55945, 118.1558, -717.8912" /> <!-- Griseldis -->
                     <TurnIn QuestId="68490" ItemIds="2002391,2002392" NpcId="1020842" XYZ="81.55945, 118.1558, -717.8912" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -860,6 +878,7 @@
                 <If Condition="GetQuestStep(68491) == 255">
                     <GetTo ZoneId="620" XYZ="113.7255, 118.1558, -715.6634" /> <!-- Angry Coeurl -->
                     <TurnIn QuestId="68491" ItemId="2002393" NpcId="1020848" XYZ="113.7255, 118.1558, -715.6634" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -892,6 +911,7 @@
                 <If Condition="GetQuestStep(67993) == 255">
                     <GetTo ZoneId="620" XYZ="85.40466, 118.1558, -719.9664" /> <!-- Meffrid -->
                     <TurnIn QuestId="67993" NpcId="1020379" XYZ="85.40466, 118.1558, -719.9664" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -953,6 +973,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="-284.596, 200.7199, -287.2511" /> <!-- Lyse -->
                     <TurnIn QuestId="67994" NpcId="1020382" XYZ="-284.596, 200.7199, -287.2511" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -994,6 +1015,7 @@
                 <If Condition="GetQuestStep(67995) == 255">
                     <GetTo ZoneId="620" XYZ="-140.9476, 104.1659, -401.8159" /> <!-- Meffrid -->
                     <TurnIn QuestId="67995" NpcId="1020387" XYZ="-140.9476, 104.1659, -401.8159" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1119,6 +1141,7 @@
                 <If Condition="GetQuestStep(68182) == 255">
                     <GetTo ZoneId="620" XYZ="-83.48212, 104.3904, -424.7654" /> <!-- Bent Frond -->
                     <TurnIn QuestId="68182" NpcId="1020860" XYZ="-83.48212, 104.3904, -424.7654" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1193,6 +1216,7 @@
                 <If Condition="GetQuestStep(68184) == 255">
                     <GetTo ZoneId="620" XYZ="-106.5843, 104.0316, -477.5311" /> <!-- Panicked Man -->
                     <TurnIn QuestId="68184" NpcId="1021224" XYZ="-106.5843, 104.0316, -477.5311" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1205,6 +1229,7 @@
                 <If Condition="GetQuestStep(68185) == 255">
                     <GetTo ZoneId="620" XYZ="-49.33246, 104.3626, -420.0046" /> <!-- Leaning Ent -->
                     <TurnIn QuestId="68185" NpcId="1020861" XYZ="-49.33246, 104.3626, -420.0046" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1238,6 +1263,7 @@
                 <If Condition="GetQuestStep(68181) == 255">
                     <GetTo ZoneId="620" XYZ="127.1534, 118.3947, -704.1581" /> <!-- Ansger -->
                     <TurnIn QuestId="68181" ItemId="2002335" NpcId="1020854" XYZ="127.1534, 118.3947, -704.1581" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1247,6 +1273,7 @@
                 <If Condition="GetQuestStep(68183) == 255">
                     <GetTo ZoneId="620" XYZ="168.1392, 149.4622, -810.0251" /> <!-- Gelen -->
                     <TurnIn QuestId="68183" ItemId="2002087" NpcId="1020843" XYZ="168.1392, 149.4622, -810.0251" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1276,6 +1303,7 @@
                 <If Condition="GetQuestStep(68186) == 255">
                     <GetTo ZoneId="620" XYZ="87.35791, 118.1558, -758.6023" /> <!-- Hungry Hyur -->
                     <TurnIn QuestId="68186" NpcId="1021388" XYZ="87.35791, 118.1558, -758.6023" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1288,6 +1316,7 @@
                 <If Condition="GetQuestStep(67996) == 255">
                     <GetTo ZoneId="635" XYZ="170.3059, 13.02367, -93.06476" /> <!-- Meffrid -->
                     <TurnIn QuestId="67996" NpcId="1020338" XYZ="170.3059, 13.02367, -93.06476" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1309,6 +1338,7 @@
                 <If Condition="GetQuestStep(67997) == 255">
                     <GetTo ZoneId="635" XYZ="164.2633, 13.02367, -88.91437" /> <!-- M'naago -->
                     <TurnIn QuestId="67997" NpcId="1020390" XYZ="164.2633, 13.02367, -88.91437" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1364,6 +1394,7 @@
                 <If Condition="GetQuestStep(68171) == 255">
                     <GetTo ZoneId="635" XYZ="152.1172, 13.15332, -118.4863" /> <!-- Beves -->
                     <TurnIn QuestId="68171" ItemId="2002076" NpcId="1019470" XYZ="152.1172, 13.15332, -118.4863" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1388,6 +1419,7 @@
                 <If Condition="GetQuestStep(68173) == 255">
                     <GetTo ZoneId="635" XYZ="-43.96124, 0, -15.03015" /> <!-- Ananta Battlemaid -->
                     <TurnIn QuestId="68173" NpcId="1021167" XYZ="-43.96124, 0, -15.03015" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1418,6 +1450,7 @@
                 <If Condition="GetQuestStep(68172) == 255">
                     <GetTo ZoneId="635" XYZ="77.25635, 0, -14.17566" /> <!-- Ahelissa -->
                     <TurnIn QuestId="68172" ItemId="2002077" NpcId="1019476" XYZ="77.25635, 0, -14.17566" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1446,6 +1479,7 @@
                 <If Condition="GetQuestStep(68174) == 255">
                     <GetTo ZoneId="635" XYZ="152.8496, 13.09733, -94.16345" /> <!-- Swarthy Resistance Fighter -->
                     <TurnIn QuestId="68174" ItemId="2002334" NpcId="1023638" XYZ="152.8496, 13.09733, -94.16345" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1491,6 +1525,7 @@
                 <If Condition="GetQuestStep(67998) == 255">
                     <GetTo ZoneId="612" XYZ="-609.6132, 130, -501.1216" /> <!-- Alisaie -->
                     <TurnIn QuestId="67998" NpcId="1020526" XYZ="-609.6132, 130, -501.1216" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1540,6 +1575,7 @@
                 <If Condition="GetQuestStep(67999) == 255">
                     <GetTo ZoneId="635" XYZ="71.30542, 0.02469154, -75.76111" /> <!-- Raubahn -->
                     <TurnIn QuestId="67999" NpcId="1020400" XYZ="71.30542, 0.02469154, -75.76111" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1565,6 +1601,7 @@
                 <If Condition="GetQuestStep(68000) == 255">
                     <GetTo ZoneId="635" XYZ="-135.8206, 0.5980504, -83.6347" /> <!-- Conrad -->
                     <TurnIn QuestId="68000" ItemId="2002109" NpcId="1020416" XYZ="-135.8206, 0.5980504, -83.6347" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1612,6 +1649,7 @@
                 <If Condition="GetQuestStep(68001) == 255">
                     <GetTo ZoneId="635" XYZ="-85.92358, 0, -18.05151" /> <!-- Flame Courier -->
                     <TurnIn QuestId="68001" ItemId="2002110" NpcId="1020422" XYZ="-85.92358, 0, -18.05151" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1677,6 +1715,7 @@
                 <If Condition="GetQuestStep(68187) == 255">
                     <GetTo ZoneId="635" XYZ="212.6954, 12.96548, -68.61987" /> <!-- Straight-arrow Sutler -->
                     <TurnIn QuestId="68187" NpcId="1022057" XYZ="212.6954, 12.96548, -68.61987" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1689,6 +1728,7 @@
                 <If Condition="GetQuestStep(68188) == 255">
                     <GetTo ZoneId="620" XYZ="142.2903, 134.1458, -797.9095" /> <!-- Resistance Fighter's Mother -->
                     <TurnIn QuestId="68188" ItemId="2002078" NpcId="1021174" XYZ="142.2903, 134.1458, -797.9095" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1734,6 +1774,7 @@
                 <If Condition="GetQuestStep(68191) == 255">
                     <GetTo ZoneId="620" XYZ="14.72491, 118.0859, -776.8215" /> <!-- Sayer -->
                     <TurnIn QuestId="68191" ItemId="2002205" NpcId="1021752" XYZ="14.72491, 118.0859, -776.8215" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1765,6 +1806,7 @@
                 <If Condition="GetQuestStep(68192) == 255">
                     <GetTo ZoneId="620" XYZ="178.3016, 116.7168, -695.8572" /> <!-- Sayer -->
                     <TurnIn QuestId="68192" NpcId="1021759" XYZ="178.3016, 116.7168, -695.8572" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1822,6 +1864,7 @@
                 <If Condition="GetQuestStep(68193) == 255">
                     <GetTo ZoneId="620" XYZ="14.72491, 118.0859, -776.8215" /> <!-- Sayer -->
                     <TurnIn QuestId="68193" NpcId="1021752" XYZ="14.72491, 118.0859, -776.8215" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1846,6 +1889,7 @@
                 <If Condition="GetQuestStep(68189) == 255">
                     <GetTo ZoneId="620" XYZ="109.9413, 133.8152, -823.9719" /> <!-- Gerbert -->
                     <TurnIn QuestId="68189" NpcId="1021544" XYZ="109.9413, 133.8152, -823.9719" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1895,6 +1939,7 @@
                 <If Condition="GetQuestStep(68194) == 255">
                     <GetTo ZoneId="620" XYZ="15.03003, 118.0737, -778.378" /> <!-- Swetelove -->
                     <TurnIn QuestId="68194" NpcId="1021762" XYZ="15.03003, 118.0737, -778.378" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1927,6 +1972,7 @@
                 <If Condition="GetQuestStep(68190) == 255">
                     <GetTo ZoneId="635" XYZ="58.88452, -0.5383847, -54.18488" /> <!-- Luckless Merchant -->
                     <TurnIn QuestId="68190" ItemId="2002277" NpcId="1022957" XYZ="58.88452, -0.5383847, -54.18488" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1946,6 +1992,7 @@
                 <If Condition="GetQuestStep(68002) == 255">
                     <GetTo ZoneId="612" XYZ="-610.2846, 130, -501.8845" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68002" NpcId="1020525" XYZ="-610.2846, 130, -501.8845" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2028,6 +2075,7 @@
                 <If Condition="GetQuestStep(68197) == 255">
                     <GetTo ZoneId="612" XYZ="-429.4652, 75.3867, -124.712" /> <!-- Tahla Molkoh -->
                     <TurnIn QuestId="68197" NpcId="1023147" XYZ="-429.4652, 75.3867, -124.712" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2109,6 +2157,7 @@
                 <If Condition="GetQuestStep(68195) == 255">
                     <GetTo ZoneId="612" XYZ="-613.1228, 130, -529.839" /> <!-- Serpent Marshal Brookstone -->
                     <TurnIn QuestId="68195" NpcId="1019519" XYZ="-613.1228, 130, -529.839" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2118,6 +2167,7 @@
                 <If Condition="GetQuestStep(68198) == 255">
                     <GetTo ZoneId="612" XYZ="-613.1228, 130, -529.839" /> <!-- Serpent Marshal Brookstone -->
                     <TurnIn QuestId="68198" NpcId="1019519" XYZ="-613.1228, 130, -529.839" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2151,6 +2201,7 @@
                 <If Condition="GetQuestStep(68196) == 255">
                     <GetTo ZoneId="612" XYZ="-647.2725, 129.8381, -549.6147" /> <!-- Lucinne -->
                     <TurnIn QuestId="68196" ItemIds="2002336,2002337" NpcId="1019524" XYZ="-647.2725, 129.8381, -549.6147" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2178,6 +2229,7 @@
                 <If Condition="GetQuestStep(68199) == 255">
                     <GetTo ZoneId="612" XYZ="-613.1228, 130, -529.839" /> <!-- Serpent Marshal Brookstone -->
                     <TurnIn QuestId="68199" NpcId="1019519" XYZ="-613.1228, 130, -529.839" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2226,6 +2278,7 @@
                 <If Condition="GetQuestStep(68200) == 255">
                     <GetTo ZoneId="612" XYZ="-613.1228, 130, -529.839" /> <!-- Serpent Marshal Brookstone -->
                     <TurnIn QuestId="68200" NpcId="1019519" XYZ="-613.1228, 130, -529.839" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2245,6 +2298,7 @@
                 <If Condition="GetQuestStep(68003) == 255">
                     <GetTo ZoneId="128" XYZ="13.30885, 44, -37.32566" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68003" NpcId="1020434" XYZ="13.30885, 44, -37.32566" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2296,6 +2350,7 @@
                     </If>
                     <GetTo ZoneId="156" XYZ="40.80162, 20.495, -649.8046" /> <!-- Lyse -->
                     <TurnIn QuestId="68004" NpcId="1020436" XYZ="40.80162, 20.495, -649.8046" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2349,6 +2404,7 @@
                 <If Condition="GetQuestStep(68005) == 255">
                     <GetTo ZoneId="628" XYZ="-123.0982, -6.999998, -59.63268" /> <!-- Carvallain -->
                     <TurnIn QuestId="68005" NpcId="1020454" XYZ="-123.0982, -6.999998, -59.63268" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2377,6 +2433,7 @@
                 <If Condition="GetQuestStep(68006) == 255">
                     <GetTo ZoneId="628" XYZ="16.59662, -6.198883E-06, -41.32873" /> <!-- Hancock -->
                     <TurnIn QuestId="68006" NpcId="1020460" XYZ="16.59662, -6.198883E-06, -41.32873" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2409,6 +2466,7 @@
                 <If Condition="GetQuestStep(68007) == 255">
                     <GetTo ZoneId="628" XYZ="96.17687, 8.02, 151.8455" /> <!-- Hancock -->
                     <TurnIn QuestId="68007" NpcId="1020462" XYZ="96.17687, 8.02, 151.8455" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2443,6 +2501,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="1.81313, 0, -0.1843593" />
                     <TurnIn QuestId="68008" NpcId="1020465" XYZ="1.81313, 0, -0.1843593" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2508,6 +2567,7 @@
                 <If Condition="GetQuestStep(68203) == 255">
                     <GetTo ZoneId="628" XYZ="114.4884, 12, 53.08606" /> <!-- Modest Maiden -->
                     <TurnIn QuestId="68203" NpcId="1022447" XYZ="114.4884, 12, 53.08606" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2544,6 +2604,7 @@
                 <If Condition="GetQuestStep(68472) == 255">
                     <GetTo ZoneId="628" XYZ="-29.16003, 0.09999965, -46.18909" /> <!-- Wlveva -->
                     <TurnIn QuestId="68472" NpcId="1019009" XYZ="-29.16003, 0.09999965, -46.18909" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2600,6 +2661,7 @@
                     <If Condition="GetQuestStep(68205) == 255">
                         <GetTo ZoneId="628" XYZ="2.700867, 2.04891E-06, -52.84204" /> <!-- Teahouse Serving Girl -->
                         <TurnIn QuestId="68205" NpcId="1023304" XYZ="2.700867, 2.04891E-06, -52.84204" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
             </If>
@@ -2694,6 +2756,7 @@
                 <If Condition="GetQuestStep(68202) == 255">
                     <GetTo ZoneId="628" XYZ="-94.09793, 11.8, -147.2643" /> <!-- Amaji -->
                     <TurnIn QuestId="68202" NpcId="1019034" XYZ="-95.84198, 11.8, -147.2954" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2706,6 +2769,7 @@
                 <If Condition="GetQuestStep(68201) == 255">
                     <GetTo ZoneId="628" XYZ="-34.86688, 4.26418, 59.22021" /> <!-- Near Eastern Merchant -->
                     <TurnIn QuestId="68201" ItemId="2002338" NpcId="1023300" XYZ="-34.86688, 4.26418, 59.22021" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2732,6 +2796,7 @@
                 <If Condition="GetQuestStep(68204) == 255">
                     <GetTo ZoneId="628" XYZ="25.25366, 8, 159.472" /> <!-- Foreignly Lass -->
                     <TurnIn QuestId="68204" NpcId="1022958" XYZ="25.25366, 8, 159.472" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2741,6 +2806,7 @@
                 <If Condition="GetQuestStep(68009) == 255">
                     <GetTo ZoneId="628" XYZ="-33.20004, 0.0298152, -68.53907" /> <!-- Lyse -->
                     <TurnIn QuestId="68009" NpcId="1020472" XYZ="-33.20004, 0.0298152, -68.53907" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2819,6 +2885,7 @@
                 <If Condition="GetQuestStep(68010) == 255">
                     <GetTo ZoneId="628" XYZ="147.6232, 14.77572, 92.13142" /> <!-- Lyse -->
                     <TurnIn QuestId="68010" NpcId="1020476" XYZ="147.6232, 14.77572, 92.13142" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2868,6 +2935,7 @@
                 <If Condition="GetQuestStep(68011) == 255">
                     <GetTo ZoneId="628" XYZ="127.4131, 14.51298, -101.0447" /> <!-- Lyse -->
                     <TurnIn QuestId="68011" NpcId="1020483" XYZ="127.4131, 14.51298, -101.0447" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2955,6 +3023,7 @@
                 <If Condition="GetQuestStep(68208) == 255">
                     <GetTo ZoneId="628" XYZ="4.409851, 4.000001, 27.0542" /> <!-- Peddler of Peculiars -->
                     <TurnIn QuestId="68208" NpcId="1021269" XYZ="4.409851, 4.000001, 27.0542" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2964,6 +3033,7 @@
                 <If Condition="GetQuestStep(68206) == 255">
                     <GetTo ZoneId="628" XYZ="28.94629, 5.999998, -106.4622" /> <!-- Graceful Geiko -->
                     <TurnIn QuestId="68206" ItemId="2002097" NpcId="1021331" XYZ="28.94629, 5.999998, -106.4622" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2973,6 +3043,7 @@
                 <If Condition="GetQuestStep(68207) == 255">
                 <GetTo ZoneId="628" XYZ="-157.1832, 4.000006, 92.11865" /> <!-- Yamabiko -->
                     <TurnIn QuestId="68207" NpcId="1019048" XYZ="-157.1832, 4.000006, 92.11865" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3037,6 +3108,7 @@
                 <If Condition="GetQuestStep(68012) == 255">
                     <GetTo ZoneId="613" XYZ="852.4982, 5.923008, 848.586" /> <!-- Soroban -->
                     <TurnIn QuestId="68012" NpcId="1019891" XYZ="852.4982, 5.923008, 848.586" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3066,6 +3138,7 @@
                 <If Condition="GetQuestStep(68013) == 255">
                     <GetTo ZoneId="613" XYZ="465.0686, 30.19312, 791.2009" /> <!-- Tansui -->
                     <TurnIn QuestId="68013" NpcId="1019898" XYZ="465.0686, 30.19312, 791.2009" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3095,6 +3168,7 @@
                 <If Condition="GetQuestStep(68014) == 255">
                     <GetTo ZoneId="613" XYZ="404.9196, 19.55959, 755.218" /> <!-- Soroban -->
                     <TurnIn QuestId="68014" NpcId="1023650" XYZ="404.9196, 19.55959, 755.218" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3174,6 +3248,7 @@
                 <If Condition="GetQuestStep(68015) == 255">
                     <GetTo ZoneId="613" XYZ="-58.56174, 1.99137, -596.7916" /> <!-- Lyse -->
                     <TurnIn QuestId="68015" NpcId="1019930" XYZ="-58.56174, 1.99137, -596.7916" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3221,6 +3296,7 @@
                 <If Condition="GetQuestStep(68016) == 255">
                     <GetTo ZoneId="613" XYZ="69.44886, 25.00783, -643.0053" /> <!-- Alisaie -->
                     <TurnIn QuestId="68016" NpcId="1019939" XYZ="69.44886, 25.00783, -643.0053" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3294,6 +3370,7 @@
                 <If Condition="GetQuestStep(68215) == 255">
                     <GetTo ZoneId="613" XYZ="107.8049, 0.8069639, -574.5175" /> <!-- Aranami -->
                     <TurnIn QuestId="68215" NpcId="1021509" XYZ="107.8049, 0.8069639, -574.5175" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3303,6 +3380,7 @@
                 <If Condition="GetQuestStep(68217) == 255">
                     <GetTo ZoneId="613" XYZ="84.91299, 41.11266, -716.7828" /> <!-- Afumi -->
                     <TurnIn QuestId="68217" NpcId="1021517" XYZ="84.91299, 41.11266, -716.7828" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3330,6 +3408,7 @@
                 <If Condition="GetQuestStep(68489) == 255">
                     <GetTo ZoneId="613" XYZ="57.23657, 1.575162, -578.2407" /> <!-- Kajika -->
                     <TurnIn QuestId="68489" ItemIds="2002387,2002388" NpcId="1021507" XYZ="57.23657, 1.575162, -578.2407" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3379,6 +3458,7 @@
                 <If Condition="GetQuestStep(68017) == 255">
                     <GetTo ZoneId="613" XYZ="79.42322, 33.00897, -669.9474" /> <!-- Rasho -->
                     <TurnIn QuestId="68017" NpcId="1021505" XYZ="79.42322, 33.00897, -669.9474" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3593,6 +3673,7 @@
                 <If Condition="GetQuestStep(68222) == 255">
                     <GetTo ZoneId="613" XYZ="107.8049, 0.8069639, -574.5175" /> <!-- Aranami -->
                     <TurnIn QuestId="68222" NpcId="1021509" XYZ="107.8049, 0.8069639, -574.5175" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3602,6 +3683,7 @@
                 <If Condition="GetQuestStep(68220) == 255">
                     <GetTo ZoneId="613" XYZ="31.3573, 3.245383, -602.7466" /> <!-- Hirase -->
                     <TurnIn QuestId="68220" ItemId="2002212" NpcId="1021511" XYZ="31.3573, 3.245383, -602.7466" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3611,6 +3693,7 @@
                 <If Condition="GetQuestStep(68216) == 255">
                     <GetTo ZoneId="613" XYZ="45.85339, 21.00391, -641.5045" /> <!-- Kaizan -->
                     <TurnIn QuestId="68216" ItemId="2002282" NpcId="1021519" XYZ="45.85339, 21.00391, -641.5045" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3620,6 +3703,7 @@
                 <If Condition="GetQuestStep(68221) == 255">
                     <GetTo ZoneId="613" XYZ="-5.783203, 33.22287, -633.7834" /> <!-- Yana -->
                     <TurnIn QuestId="68221" NpcId="1021512" XYZ="-5.783203, 33.22287, -633.7834" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3629,6 +3713,7 @@
                 <If Condition="GetQuestStep(68219) == 255">
                     <GetTo ZoneId="613" XYZ="12.13086, 49.21076, -718.5016" /> <!-- Hayase -->
                     <TurnIn QuestId="68219" NpcId="1021520" XYZ="12.13086, 49.21076, -718.5016" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3638,6 +3723,7 @@
                 <If Condition="GetQuestStep(68218) == 255">
                     <GetTo ZoneId="613" XYZ="-28.64117, 61.34498, -679.3469" /> <!-- Perplexed Confederate -->
                     <TurnIn QuestId="68218" NpcId="1023307" XYZ="-28.64117, 61.34498, -679.3469" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3661,6 +3747,7 @@
                 <If Condition="GetQuestStep(68018) == 255">
                     <GetTo ZoneId="613" XYZ="422.1102, -98.96018, -223.1022" /> <!-- Alisaie -->
                     <TurnIn QuestId="68018" NpcId="1019956" XYZ="422.1102, -98.96018, -223.1022" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3697,6 +3784,7 @@
                 <If Condition="GetQuestStep(68019) == 255">
                     <GetTo ZoneId="613" XYZ="420.3403, -99.19678, -221.3627" /> <!-- Soroban -->
                     <TurnIn QuestId="68019" ItemId="2002094" NpcId="1019958" XYZ="420.3403, -99.19678, -221.3627" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3798,6 +3886,7 @@
                 <If Condition="GetQuestStep(68229) == 255">
                     <GetTo ZoneId="613" XYZ="608.5145, -3.478438, -92.82062" /> <!-- Slender Kojin -->
                     <TurnIn QuestId="68229" NpcId="1023358" XYZ="608.5145, -3.478438, -92.82062" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3869,6 +3958,7 @@
                 <If Condition="GetQuestStep(68227) == 255">
                     <GetTo ZoneId="613" XYZ="353.5667, -120.0134, -251.9723" /> <!-- Tsuzura -->
                     <TurnIn QuestId="68227" NpcId="1019184" XYZ="353.5667, -120.0134, -251.9723" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3878,6 +3968,7 @@
                 <If Condition="GetQuestStep(68231) == 255">
                     <GetTo ZoneId="613" XYZ="343.099, -120.0865, -277.3328" /> <!-- Kefusan -->
                     <TurnIn QuestId="68231" NpcId="1019182" XYZ="343.099, -120.0865, -277.3328" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3887,6 +3978,7 @@
                 <If Condition="GetQuestStep(68232) == 255">
                     <GetTo ZoneId="613" XYZ="367.1777, -119.9468, -292.3781" /> <!-- Urokuzu -->
                     <TurnIn QuestId="68232" NpcId="1019180" XYZ="367.1777, -119.9468, -292.3781" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3896,6 +3988,7 @@
                 <If Condition="GetQuestStep(68230) == 255">
                     <GetTo ZoneId="613" XYZ="334.4929, -120.3585, -307.3625" /> <!-- Toro -->
                     <TurnIn QuestId="68230" NpcId="1019187" XYZ="334.4929, -120.3585, -307.3625" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3920,6 +4013,7 @@
                 <If Condition="GetQuestStep(68228) == 255">
                     <GetTo ZoneId="613" XYZ="374.0443, -119.9219, -238.1171" /> <!-- Kaioke -->
                     <TurnIn QuestId="68228" ItemId="2002289" NpcId="1019183" XYZ="374.0443, -119.9219, -238.1171" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3954,6 +4048,7 @@
                 <If Condition="GetQuestStep(68211) == 255">
                     <GetTo ZoneId="613" XYZ="447.5623, 34.29651, 732.6619" /> <!-- Hiun -->
                     <TurnIn QuestId="68211" ItemId="2002098" NpcId="1019167" XYZ="447.5623, 34.29651, 732.6619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3966,6 +4061,7 @@
                 <If Condition="GetQuestStep(68210) == 255">
                     <GetTo ZoneId="613" XYZ="476.829, 30.11333, 763.546" /> <!-- Shihoji -->
                     <TurnIn QuestId="68210" ItemId="2002264" NpcId="1019169" XYZ="476.829, 30.11333, 763.546" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3990,6 +4086,7 @@
                 <If Condition="GetQuestStep(68209) == 255">
                     <GetTo ZoneId="613" XYZ="829.1294, 5.923008, 859.739" /> <!-- Ikaruga -->
                     <TurnIn QuestId="68209" NpcId="1019154" XYZ="829.1294, 5.923008, 859.739" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4056,6 +4153,7 @@
                 <If Condition="GetQuestStep(68212) == 255">
                     <GetTo ZoneId="613" XYZ="808.6212, 6.945029, 857.1754" /> <!-- Kumoji -->
                     <TurnIn QuestId="68212" ItemId="2002088" NpcId="1019155" XYZ="808.6212, 6.945029, 857.1754" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4065,6 +4163,7 @@
                 <If Condition="GetQuestStep(68213) == 255">
                     <GetTo ZoneId="613" XYZ="835.5687, 6.351519, 831.8149" /> <!-- Hayama -->
                     <TurnIn QuestId="68213" NpcId="1019156" XYZ="835.5687, 6.351519, 831.8149" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4097,6 +4196,7 @@
                 <If Condition="GetQuestStep(68214) == 255">
                     <GetTo ZoneId="613" XYZ="487.0831, 31.7337, 817.4104" /> <!-- Guardian Pirate -->
                     <TurnIn QuestId="68214" NpcId="1022747" XYZ="487.0831, 31.7337, 817.4104" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4120,6 +4220,7 @@
                 <If Condition="GetQuestStep(68223) == 255">
                     <GetTo ZoneId="613" XYZ="-49.51556, 2.658728, -636.5607" /> <!-- Tsukikage -->
                     <TurnIn QuestId="68223" ItemIds="2002223,2002224" NpcId="1022117" XYZ="-49.51556, 2.658728, -636.5607" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4164,6 +4265,7 @@
                 <If Condition="GetQuestStep(68224) == 255">
                     <GetTo ZoneId="613" XYZ="30.10596, 16.89733, -625.8793" /> <!-- Tsukikage -->
                     <TurnIn QuestId="68224" ItemId="2002226" NpcId="1022106" XYZ="30.10596, 16.89733, -625.8793" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4198,6 +4300,7 @@
                 <If Condition="GetQuestStep(68225) == 255">
                     <GetTo ZoneId="613" XYZ="603.5706, 0.9353817, 867.9789" /> <!-- Tsukikage -->
                     <TurnIn QuestId="68225" NpcId="1022110" XYZ="603.5706, 0.9353817, 867.9789" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4236,6 +4339,7 @@
                 <If Condition="GetQuestStep(68226) == 255">
                     <GetTo ZoneId="613" XYZ="30.10596, 16.89733, -625.8793" /> <!-- Tsukikage -->
                     <TurnIn QuestId="68226" NpcId="1022106" XYZ="30.10596, 16.89733, -625.8793" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4350,6 +4454,7 @@
                     <GetTo ZoneId="613" XYZ="19.42468, -197.5309, -143.9384" /> <!-- Lyse -->
                     <Dismount />
                     <TurnIn QuestId="68020" NpcId="1019970" XYZ="19.42468, -197.5309, -143.9384" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4456,6 +4561,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="20.24866, -197.5632, -145.4032" /> <!-- Alisaie -->
                     <TurnIn QuestId="68021" NpcId="1019971" XYZ="20.24866, -197.5632, -145.4032" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5029,6 +5135,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-77.47009, -198.955, -149.7673" /> <!-- Mahiwa -->
                     <TurnIn QuestId="68234" NpcId="1019215" XYZ="-77.47009, -198.955, -149.7673" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5302,6 +5409,7 @@
                     <MoveTo Name="Diving" Distance="1" UseMesh="False" XYZ="-228.3217, -170.3914, 185.3949" />
                     <MoveTo Name="Alisaie" Distance="0.1" UseMesh="False" XYZ="-227.863, -179.2102, 185.748" />
                     <TurnIn QuestId="68022" ItemId="2002095" NpcId="1019978" XYZ="-227.863, -179.2102, 185.748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5404,6 +5512,7 @@
                 <If Condition="GetQuestStep(68023) == 255">
                     <GetTo ZoneId="613" XYZ="323.0487, -120.035, -249.012" /> <!-- Alisaie -->
                     <TurnIn QuestId="68023" NpcId="1019961" XYZ="323.0487, -120.035, -249.012" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5581,6 +5690,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-50.61426, -198.6673, -162.707" /> <!-- Sapphire-haired Girl -->
                     <TurnIn QuestId="68237" ItemId="2002340" NpcId="1023310" XYZ="-50.61426, -198.6673, -162.707" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5617,6 +5727,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-68.46729, -199.1032, -156.0541" /> <!-- Mozu -->
                     <TurnIn QuestId="68238" NpcId="1019218" XYZ="-68.46729, -199.1032, -156.0541" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5653,6 +5764,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-35.935, -198.3163, -45.12097" /> <!-- Kagero -->
                     <TurnIn QuestId="68236" NpcId="1019198" XYZ="-35.935, -198.3163, -45.12097" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5886,6 +5998,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-797.3602, 48.41823, 149.6453" /> <!-- Alisaie -->
                     <TurnIn QuestId="68024" NpcId="1019985" XYZ="-797.3602, 48.41823, 149.6453" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6043,6 +6156,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="421.8967, -104.3417, -285.1149" /> <!-- Affable Kojin -->
                     <TurnIn QuestId="68244" ItemId="2002290" NpcId="1023096" XYZ="421.8967, -104.3417, -285.1149" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6212,6 +6326,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="321.4923, -120.3839, -274.5251" /> <!-- Takotsubo -->
                     <TurnIn QuestId="68245" NpcId="1019181" XYZ="321.4923, -120.3839, -274.5251" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6309,6 +6424,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="321.4923, -120.3839, -274.5251" /> <!-- Takotsubo -->
                     <TurnIn QuestId="68246" NpcId="1019181" XYZ="321.4923, -120.3839, -274.5251" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6355,6 +6471,7 @@
                     <GetTo ZoneId="613" XYZ="321.4923, -120.3839, -274.5251" /> <!-- Takotsubo -->
                     <Dismount />
                     <TurnIn QuestId="68248" NpcId="1019181" XYZ="321.4923, -120.3839, -274.5251" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6401,6 +6518,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-87.66315, -199.1481, -112.0775" /> <!-- Seizau -->
                     <TurnIn QuestId="68233" ItemId="2002320" NpcId="1019205" XYZ="-87.66315, -199.1481, -112.0775" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6417,6 +6535,7 @@
                 <If Condition="GetQuestStep(68247) == 255">
                     <GetTo ZoneId="613" XYZ="351.3389, -120.4575, -307.9424" /> <!-- Seizau -->
                     <TurnIn QuestId="68247" ItemId="2002101" NpcId="1019179" XYZ="351.3389, -120.4575, -307.9424" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6460,6 +6579,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-38.65112, -198.5753, -62.33313" /> <!-- Mine -->
                     <TurnIn QuestId="68235" ItemId="2002275" NpcId="1019201" XYZ="-38.65112, -198.5753, -62.33313" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6480,6 +6600,7 @@
             <If Condition="GetQuestStep(68025) == 255">
                 <GetTo ZoneId="613" XYZ="-761.8372, 4.763445, -455.2224" /> <!-- Lyse -->
                 <TurnIn QuestId="68025" NpcId="1019988" XYZ="-761.8372, 4.763445, -455.2224" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
 
@@ -6514,6 +6635,7 @@
                 <If Condition="GetQuestStep(68026) == 255">
                     <GetTo ZoneId="613" XYZ="-761.8372, 4.763445, -453.4829" /> <!-- Alisaie -->
                     <TurnIn QuestId="68026" NpcId="1019989" XYZ="-761.8372, 4.763445, -453.4829" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6651,6 +6773,7 @@
                 <If Condition="GetQuestStep(68255) == 255">
                     <GetTo ZoneId="613" XYZ="-787.808, 4.871922, -336.6903" /> <!-- Nayoshi -->
                     <TurnIn QuestId="68255" NpcId="1023219" XYZ="-787.808, 4.871922, -336.6903" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6699,6 +6822,7 @@
                 <If Condition="GetQuestStep(68249) == 255">
                     <GetTo ZoneId="613" XYZ="-740.1083, 2.081819, -570.0923" /> <!-- Abiki -->
                     <TurnIn QuestId="68249" NpcId="1019229" XYZ="-740.1083, 2.081819, -570.0923" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6739,6 +6863,7 @@
                 <If Condition="GetQuestStep(68256) == 255">
                     <GetTo ZoneId="613" XYZ="-787.808, 4.871922, -336.6903" /> <!-- Nayoshi -->
                     <TurnIn QuestId="68256" ItemId="2002374" NpcId="1023219" XYZ="-787.808, 4.871922, -336.6903" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6794,6 +6919,7 @@
                 <If Condition="GetQuestStep(68251) == 255">
                     <GetTo ZoneId="613" XYZ="-746.0593, 1.97366, -595.5444" /> <!-- Motogoe -->
                     <TurnIn QuestId="68251" ItemId="2002089" NpcId="1019228" XYZ="-746.0593, 1.97366, -595.5444" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7012,6 +7138,7 @@
             <If Condition="GetQuestStep(68257) == 255">
                 <GetTo ZoneId="613" XYZ="-631.2505, 24.14959, -622.4003" /> <!-- Nayoshi -->
                 <TurnIn QuestId="68257" NpcId="1023233" XYZ="-631.2505, 24.14959, -622.4003" />
+                <WaitTimer WaitTime="2"/>
             </If>
         </If>
 
@@ -7035,6 +7162,7 @@
                 <If Condition="GetQuestStep(68252) == 255">
                     <GetTo ZoneId="613" XYZ="-726.833, 1.489459, -582.147" /> <!-- Misago -->
                     <TurnIn QuestId="68252" ItemIds="2002102,2002103,2002104" NpcId="1019231" XYZ="-726.833, 1.489459, -582.147" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7044,6 +7172,7 @@
                 <If Condition="GetQuestStep(68250) == 255">
                     <GetTo ZoneId="613" XYZ="-712.1233, 0.8259376, -560.235" /> <!-- Kansui -->
                     <TurnIn QuestId="68250" NpcId="1019230" XYZ="-712.1233, 0.8259376, -560.235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7080,6 +7209,7 @@
                 <If Condition="GetQuestStep(68258) == 255">
                     <GetTo ZoneId="613" XYZ="-769.9855, 2.545372, -574.2733" /> <!-- Koruri -->
                     <TurnIn QuestId="68258" NpcId="1023625" XYZ="-769.9855, 2.545372, -574.2733" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7124,6 +7254,7 @@
                 <If Condition="GetQuestStep(68254) == 255">
                     <GetTo ZoneId="613" XYZ="-728.4504, 0.3577975, -338.613" /> <!-- Anxious Boy -->
                     <TurnIn QuestId="68254" NpcId="1022453" XYZ="-728.4504, 0.3577975, -338.613" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7185,6 +7316,7 @@
                 <If Condition="GetQuestStep(68259) == 255">
                     <GetTo ZoneId="613" XYZ="-726.3142, 0.4992163, -458.3963" /> <!-- Nayoshi -->
                     <TurnIn QuestId="68259" NpcId="1018347" XYZ="-726.3142, 0.4992163, -458.3963" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7373,6 +7505,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="4.379272, -196.4494, -80.0946" /> <!-- Sayo -->
                     <TurnIn QuestId="68239" ItemId="2002100" NpcId="1019199" XYZ="4.379272, -196.4494, -80.0946" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7409,6 +7542,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-62.79089, -198.9651, -64.34735" /> <!-- Kurenai -->
                     <TurnIn QuestId="68168" NpcId="1023280" XYZ="-62.79089, -198.9651, -64.34735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7518,6 +7652,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-62.79089, -198.9651, -64.34735" /> <!-- Kurenai -->
                     <TurnIn QuestId="68240" NpcId="1023280" XYZ="-62.79089, -198.9651, -64.34735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7601,6 +7736,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-62.79089, -198.9651, -64.34735" /> <!-- Kurenai -->
                     <TurnIn QuestId="68241" NpcId="1023280" XYZ="-62.79089, -198.9651, -64.34735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7783,6 +7919,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-62.79089, -198.9651, -64.34735" /> <!-- Kurenai -->
                     <TurnIn QuestId="68242" NpcId="1023280" XYZ="-62.79089, -198.9651, -64.34735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7889,6 +8026,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="8.46875, -198.3421, -157.1526" /> <!-- Kurenai -->
                     <TurnIn QuestId="68243" NpcId="1023291" XYZ="8.46875, -198.3421, -157.1526" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7922,6 +8060,7 @@
                     <!-- </If>
                     <ExFlyTo Name="Zansetsu" XYZ="-769.894, 4.785435, -481.0406" />
                     <TurnIn QuestId="68253" ItemId="2002105" NpcId="1019232" XYZ="-769.894, 4.785435, -481.0406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -7942,6 +8081,7 @@
                 <If Condition="GetQuestStep(68027) == 255">
                     <GetTo ZoneId="614" XYZ="527.9164, 43.697, -156.0541" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68027" NpcId="1019997" XYZ="527.9164, 43.697, -156.0541" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7963,6 +8103,7 @@
                 <If Condition="GetQuestStep(68473) == 255">
                     <GetTo ZoneId="628" XYZ="-29.16003, 0.09999965, -46.18909" /> <!-- Wlveva -->
                     <TurnIn QuestId="68473" NpcId="1019009" XYZ="-29.16003, 0.09999965, -46.18909" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8038,6 +8179,7 @@
                     </If>
                     <MoveTo Name="Gosetsu" XYZ="277.9735, 3.262752, -378.9578" />
                     <TurnIn QuestId="68028" NpcId="1020007" XYZ="277.9735, 3.262752, -378.9578" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8178,6 +8320,7 @@
 
                     <MoveTo Name="Yugiri" XYZ="-49.88184, -0.2605122, -12.89392" />
                     <TurnIn QuestId="68470" NpcId="1020011" XYZ="-49.88184, -0.2605122, -12.89392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8250,6 +8393,7 @@
                 <If Condition="GetQuestStep(68029) == 255">
                     <GetTo ZoneId="614" XYZ="486.9917, 50.48013, -115.404" /> <!-- Yugiri -->
                     <TurnIn QuestId="68029" NpcId="1020012" XYZ="486.9917, 50.48013, -115.404" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8385,6 +8529,7 @@
                 <If Condition="GetQuestStep(68264) == 255">
                     <GetTo ZoneId="614" XYZ="451.5602, 58.77665, -188.3421" /> <!-- Honami -->
                     <TurnIn QuestId="68264" NpcId="1019263" XYZ="451.5602, 58.77665, -188.3421" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8397,6 +8542,7 @@
                 <If Condition="GetQuestStep(68261) == 255">
                     <GetTo ZoneId="614" XYZ="521.2023, 71.3054, -258.7778" /> <!-- Hojo -->
                     <TurnIn QuestId="68261" NpcId="1019315" XYZ="521.2023, 71.3054, -258.7778" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8406,6 +8552,7 @@
                 <If Condition="GetQuestStep(68260) == 255">
                     <GetTo ZoneId="614" XYZ="421.7745, -0.3000138, -293.9651" /> <!-- Fukata -->
                     <TurnIn QuestId="68260" NpcId="1019314" XYZ="421.7745, -0.3000138, -293.9651" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8455,6 +8602,7 @@
                 <If Condition="GetQuestStep(68030) == 255">
                     <GetTo ZoneId="614" XYZ="397.7568, 72.83517, -97.06268" /> <!-- Yugiri -->
                     <TurnIn QuestId="68030" NpcId="1020020" XYZ="397.7568, 72.83517, -97.06268" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8534,6 +8682,7 @@
                 <If Condition="GetQuestStep(68265) == 255">
                     <GetTo ZoneId="614" XYZ="473.4722, 58.55711, -175.5856" /> <!-- Aohata -->
                     <TurnIn QuestId="68265" NpcId="1019265" XYZ="473.4722, 58.55711, -175.5856" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8571,6 +8720,7 @@
                 <If Condition="GetQuestStep(68267) == 255">
                     <GetTo ZoneId="614" XYZ="417.5935, 68.02854, -110.2465" /> <!-- Shinden -->
                     <TurnIn QuestId="68267" NpcId="1019260" XYZ="417.5935, 68.02854, -110.2465" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8580,6 +8730,7 @@
                 <If Condition="GetQuestStep(68268) == 255">
                     <GetTo ZoneId="614" XYZ="405.4779, 67.4601, -61.53973" /> <!-- Masatsuchi -->
                     <TurnIn QuestId="68268" ItemId="2002206" NpcId="1019259" XYZ="405.4779, 67.4601, -61.53973" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8708,6 +8859,7 @@
                 <If Condition="GetQuestStep(68031) == 255">
                     <GetTo ZoneId="614" XYZ="406.2714, 14.64187, 626.1234" /> <!-- Yugiri -->
                     <TurnIn QuestId="68031" NpcId="1020283" XYZ="406.2714, 14.64187, 626.1234" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8764,6 +8916,7 @@
                 <If Condition="GetQuestStep(68032) == 255">
                     <GetTo ZoneId="614" XYZ="457.6943, 30.0019, 764.187" /> <!-- Captured Villager -->
                     <TurnIn QuestId="68032" NpcId="1020029" XYZ="457.6943, 30.0019, 764.187" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8776,6 +8929,7 @@
                 <If Condition="GetQuestStep(68266) == 255">
                     <GetTo ZoneId="614" XYZ="756.3439, 98.04659, -229.9382" /> <!-- Sentei -->
                     <TurnIn QuestId="68266" ItemId="2002239" NpcId="1019295" XYZ="756.3439, 98.04659, -229.9382" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8813,6 +8967,7 @@
                 <If Condition="GetQuestStep(68262) == 255">
                     <GetTo ZoneId="614" XYZ="756.3439, 98.04659, -229.9382" /> <!-- Sentei -->
                     <TurnIn QuestId="68262" NpcId="1019295" XYZ="756.3439, 98.04659, -229.9382" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8844,6 +8999,7 @@
                 <If Condition="GetQuestStep(68263) == 255">
                     <GetTo ZoneId="614" XYZ="465.2628, 58.52148, -171.0995" /> <!-- Kohagi -->
                     <TurnIn QuestId="68263" ItemIds="2002246,2002247" NpcId="1019313" XYZ="465.2628, 58.52148, -171.0995" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8944,6 +9100,7 @@
                 <If Condition="GetQuestStep(68269) == 255">
                     <GetTo ZoneId="614" XYZ="434.8973, 68.02076, -125.0172" /> <!-- Ryosen -->
                     <TurnIn QuestId="68269" NpcId="1019316" XYZ="434.8973, 68.02076, -125.0172" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8993,6 +9150,7 @@
 
                     <MoveTo Name="Yugiri" XYZ="278.3093, 2.954496, -378.439" />
                     <TurnIn QuestId="68033" NpcId="1023787" XYZ="278.3093, 2.954496, -378.439" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9061,6 +9219,7 @@
                 <If Condition="GetQuestStep(68471) == 255">
                     <GetTo ZoneId="614" XYZ="-463.2181, 1.230005, 535.6068" /> <!-- Yugiri -->
                     <TurnIn QuestId="68471" NpcId="1020055" XYZ="-463.2181, 1.230005, 535.6068" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9107,6 +9266,7 @@
                 <If Condition="GetQuestStep(68034) == 255">
                     <GetTo ZoneId="614" XYZ="488.3038, 7.396728, 375.1429" /> <!-- Alisaie -->
                     <TurnIn QuestId="68034" NpcId="1020057" XYZ="488.3038, 7.396728, 375.1429" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9139,6 +9299,7 @@
                 <If Condition="GetQuestStep(68035) == 255">
                     <GetTo ZoneId="614" XYZ="446.6774, 68.02853, -74.47931" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68035" NpcId="1020067" XYZ="446.6774, 68.02853, -74.47931" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9232,6 +9393,7 @@
                     <!-- </If>
                     <ExFlyTo Name="Dispirited Woman" XYZ="466.4529, 68.02766, -85.98462" />
                     <TurnIn QuestId="68271" NpcId="1023699" XYZ="466.4529, 68.02766, -85.98462" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -9255,6 +9417,7 @@
                 <If Condition="GetQuestStep(68272) == 255">
                     <GetTo ZoneId="614" XYZ="473.8077, 58.44831, -182.7878" /> <!-- Fukudo -->
                     <TurnIn QuestId="68272" NpcId="1019312" XYZ="473.8077, 58.44831, -182.7878" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9295,6 +9458,7 @@
                 <If Condition="GetQuestStep(68273) == 255">
                     <GetTo ZoneId="614" XYZ="473.8077, 58.44831, -182.7878" /> <!-- Fukudo -->
                     <TurnIn QuestId="68273" NpcId="1019312" XYZ="473.8077, 58.44831, -182.7878" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9334,6 +9498,7 @@
                 <If Condition="GetQuestStep(68274) == 255">
                     <GetTo ZoneId="614" XYZ="473.8077, 58.44831, -182.7878" /> <!-- Fukudo -->
                     <TurnIn QuestId="68274" NpcId="1019312" XYZ="473.8077, 58.44831, -182.7878" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9375,6 +9540,7 @@
                 <If Condition="GetQuestStep(68275) == 255">
                     <GetTo ZoneId="614" XYZ="473.8077, 58.44831, -182.7878" /> <!-- Fukudo -->
                     <TurnIn QuestId="68275" NpcId="1019312" XYZ="473.8077, 58.44831, -182.7878" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9387,6 +9553,7 @@
                 <If Condition="GetQuestStep(68270) == 255">
                     <GetTo ZoneId="614" XYZ="-279.347, 17.31996, 498.4968" /> <!-- Gyotai -->
                     <TurnIn QuestId="68270" ItemIds="2002250,2002251" NpcId="1019302" XYZ="-279.347, 17.31996, 498.4968" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9601,6 +9768,7 @@
                     </If>
                     <GetTo ZoneId="614" XYZ="-289.2348, 17.31996, 520.9276" /> <!-- Gyoei -->
                     <TurnIn QuestId="68281" ItemId="2002253" NpcId="1019301" XYZ="-289.2348, 17.31996, 520.9276" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9613,6 +9781,7 @@
                 <If Condition="GetQuestStep(68277) == 255">
                     <GetTo ZoneId="614" XYZ="-308.9495, 17.73554, 512.4742" /> <!-- Gyoku -->
                     <TurnIn QuestId="68277" NpcId="1019303" XYZ="-308.9495, 17.73554, 512.4742" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9622,6 +9791,7 @@
                 <If Condition="GetQuestStep(68284) == 255">
                     <GetTo ZoneId="614" XYZ="-233.7224, 17.6282, 485.3131" /> <!-- Gyorin -->
                     <TurnIn QuestId="68284" NpcId="1023237" XYZ="-233.7224, 17.6282, 485.3131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9666,6 +9836,7 @@
                 <If Condition="GetQuestStep(68285) == 255">
                     <GetTo ZoneId="614" XYZ="-233.7224, 17.6282, 485.3131" /> <!-- Gyorin -->
                     <TurnIn QuestId="68285" NpcId="1023237" XYZ="-233.7224, 17.6282, 485.3131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9707,6 +9878,7 @@
                 <If Condition="GetQuestStep(68282) == 255">
                     <GetTo ZoneId="614" XYZ="-226.1846, 16.93272, 579.7054" /> <!-- Old Namazu Master -->
                     <TurnIn QuestId="68282" NpcId="1022468" XYZ="-226.1846, 16.93272, 579.7054" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9804,6 +9976,7 @@
                 <If Condition="GetQuestStep(68286) == 255">
                     <GetTo ZoneId="614" XYZ="-233.7224, 17.6282, 485.3131" /> <!-- Gyorin -->
                     <TurnIn QuestId="68286" NpcId="1023237" XYZ="-233.7224, 17.6282, 485.3131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9837,6 +10010,7 @@
                 <If Condition="GetQuestStep(68280) == 255">
                     <GetTo ZoneId="614" XYZ="-306.9047, 17.73554, 503.563" /> <!-- Hard-whiskered Namazu -->
                     <TurnIn QuestId="68280" ItemId="2002368" NpcId="1023359" XYZ="-306.9047, 17.73554, 503.563" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9846,6 +10020,7 @@
                 <If Condition="GetQuestStep(68279) == 255">
                     <GetTo ZoneId="614" XYZ="-310.6584, 18.25329, 502.5558" /> <!-- Gyoboku -->
                     <TurnIn QuestId="68279" NpcId="1019299" XYZ="-310.6584, 18.25329, 502.5558" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9855,6 +10030,7 @@
                 <If Condition="GetQuestStep(68278) == 255">
                     <GetTo ZoneId="614" XYZ="-318.5931, 17.97489, 510.8262" /> <!-- Gyoen -->
                     <TurnIn QuestId="68278" ItemIds="2002107,2002108" NpcId="1019300" XYZ="-318.5931, 17.97489, 510.8262" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9886,6 +10062,7 @@
                 <If Condition="GetQuestStep(68287) == 255">
                     <GetTo ZoneId="614" XYZ="-290.1503, 17.31996, 490.8674" /> <!-- Gyorin -->
                     <TurnIn QuestId="68287" NpcId="1023244" XYZ="-290.1503, 17.31996, 490.8674" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9918,6 +10095,7 @@
                 <If Condition="GetQuestStep(68283) == 255">
                     <GetTo ZoneId="614" XYZ="403.0059, 76.16982, -148.8518" /> <!-- Yamakage -->
                     <TurnIn QuestId="68283" NpcId="1019261" XYZ="403.0059, 76.16982, -148.8518" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9951,6 +10129,7 @@
                 <If Condition="GetQuestStep(68276) == 255">
                     <GetTo ZoneId="614" XYZ="462.7603, 68.01855, -106.5538" /> <!-- Gyorin -->
                     <TurnIn QuestId="68276" NpcId="1023465" XYZ="462.7603, 68.01855, -106.5538" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10044,6 +10223,7 @@
                 <If Condition="GetQuestStep(68166) == 255">
                     <GetTo ZoneId="622" XYZ="560.235, -19.50564, 408.6824" /> <!-- Yugiri -->
                     <TurnIn QuestId="68166" NpcId="1020079" XYZ="560.235, -19.50564, 408.6824" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10080,6 +10260,7 @@
                 <If Condition="GetQuestStep(68036) == 255">
                     <GetTo ZoneId="622" XYZ="571.5876, -19.50566, 313.7101" /> <!-- Cirina -->
                     <TurnIn QuestId="68036" NpcId="1020281" XYZ="571.5876, -19.50566, 313.7101" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10178,6 +10359,7 @@
                 <If Condition="GetQuestStep(68293) == 255">
                     <GetTo ZoneId="622" XYZ="570.0007, -19.50564, 361.0131" /> <!-- Uto -->
                     <TurnIn QuestId="68293" NpcId="1019352" XYZ="570.0007, -19.50564, 361.0131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10242,6 +10424,7 @@
                 <If Condition="GetQuestStep(68288) == 255">
                     <GetTo ZoneId="622" XYZ="548.7296, -19.50577, 286.5797" /> <!-- Oroniri Youth -->
                     <TurnIn QuestId="68288" ItemIds="2002291,2002292,2002293" NpcId="1023098" XYZ="548.7296, -19.50577, 286.5797" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10278,6 +10461,7 @@
                 <If Condition="GetQuestStep(68292) == 255">
                     <GetTo ZoneId="622" XYZ="556.8779, -19.50564, 397.1465" /> <!-- Chambui -->
                     <TurnIn QuestId="68292" NpcId="1019355" XYZ="556.8779, -19.50564, 397.1465" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10290,6 +10474,7 @@
                 <If Condition="GetQuestStep(68037) == 255">
                     <GetTo ZoneId="622" XYZ="571.5876, -19.50566, 313.7101" /> <!-- Cirina -->
                     <TurnIn QuestId="68037" ItemId="2002204" NpcId="1020281" XYZ="571.5876, -19.50566, 313.7101" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10345,6 +10530,7 @@
                 <If Condition="GetQuestStep(68296) == 255">
                     <GetTo ZoneId="622" XYZ="588.0063, -19.50565, 316.5789" /> <!-- Gascot -->
                     <TurnIn QuestId="68296" NpcId="1022128" XYZ="588.0063, -19.50565, 316.5789" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10390,6 +10576,7 @@
                 <If Condition="GetQuestStep(68295) == 255">
                     <GetTo ZoneId="622" XYZ="590.692, -19.50566, 305.0736" /> <!-- Togene -->
                     <TurnIn QuestId="68295" NpcId="1019362" XYZ="590.692, -19.50566, 305.0736" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10406,6 +10593,7 @@
                 <If Condition="GetQuestStep(68297) == 255">
                     <GetTo ZoneId="622" XYZ="588.0063, -19.50565, 316.5789" /> <!-- Gascot -->
                     <TurnIn QuestId="68297" NpcId="1022128" XYZ="588.0063, -19.50565, 316.5789" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10445,6 +10633,7 @@
                 <If Condition="GetQuestStep(68298) == 255">
                     <GetTo ZoneId="622" XYZ="605.7678, -14.99195, 327.2296" /> <!-- Cotota -->
                     <TurnIn QuestId="68298" ItemId="2002229" NpcId="1019346" XYZ="605.7678, -14.99195, 327.2296" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10485,6 +10674,7 @@
                 <If Condition="GetQuestStep(68038) == 255">
                     <GetTo ZoneId="622" XYZ="592.9198, 24.94365, 380.0564" /> <!-- Hien -->
                     <TurnIn QuestId="68038" NpcId="1020543" XYZ="592.9198, 24.94365, 380.0564" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10561,6 +10751,7 @@
                 <If Condition="GetQuestStep(68294) == 255">
                     <GetTo ZoneId="622" XYZ="594.4456, -19.50579, 285.603" /> <!-- Adarkim Warrior -->
                     <TurnIn QuestId="68294" ItemId="2002321" NpcId="1023253" XYZ="594.4456, -19.50579, 285.603" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10570,6 +10761,7 @@
                 <If Condition="GetQuestStep(68289) == 255">
                     <GetTo ZoneId="622" XYZ="612.6954, -15.04196, 341.6342" /> <!-- Khaishan -->
                     <TurnIn QuestId="68289" NpcId="1019345" XYZ="612.6954, -15.04196, 341.6342" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10579,6 +10771,7 @@
                 <If Condition="GetQuestStep(68299) == 255">
                     <GetTo ZoneId="622" XYZ="558.0072, -19.50578, 423.5447" /> <!-- Gascot -->
                     <TurnIn QuestId="68299" ItemId="2002231" NpcId="1022141" XYZ="558.0072, -19.50578, 423.5447" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10602,6 +10795,7 @@
                 <If Condition="GetQuestStep(68039) == 255">
                     <GetTo ZoneId="622" XYZ="484.4891, 40.21725, -469.5354" /> <!-- Cirina -->
                     <TurnIn QuestId="68039" NpcId="1020501" XYZ="484.4891, 40.21725, -469.5354" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10711,6 +10905,7 @@
                 <If Condition="GetQuestStep(68040) == 255">
                     <GetTo ZoneId="622" XYZ="484.4891, 40.21725, -469.5354" /> <!-- Cirina -->
                     <TurnIn QuestId="68040" ItemId="2002197" NpcId="1020501" XYZ="484.4891, 40.21725, -469.5354" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10753,6 +10948,7 @@
                 <If Condition="GetQuestStep(68301) == 255">
                     <GetTo ZoneId="622" XYZ="521.0498, 40.4757, -497.3068" /> <!-- Buqatai -->
                     <TurnIn QuestId="68301" ItemId="2002284" NpcId="1019404" XYZ="521.0498, 40.4757, -497.3068" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10795,6 +10991,7 @@
                 <If Condition="GetQuestStep(68041) == 255">
                     <GetTo ZoneId="622" XYZ="485.2522, 40.32777, -472.1904" /> <!-- Hien -->
                     <TurnIn QuestId="68041" NpcId="1020544" XYZ="485.2522, 40.32777, -472.1904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10903,6 +11100,7 @@
                 <If Condition="GetQuestStep(68303) == 255">
                     <GetTo ZoneId="622" XYZ="508.0491, 40.4257, -482.7802" /> <!-- Cotan -->
                     <TurnIn QuestId="68303" ItemId="2002202" NpcId="1019388" XYZ="508.0491, 40.4257, -482.7802" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10915,6 +11113,7 @@
                 <If Condition="GetQuestStep(68302) == 255">
                     <GetTo ZoneId="622" XYZ="525.6886, 40.4257, -494.4991" /> <!-- Nigen -->
                     <TurnIn QuestId="68302" NpcId="1019387" XYZ="525.6886, 40.4257, -494.4991" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -10939,6 +11138,7 @@
                 <If Condition="GetQuestStep(68300) == 255">
                     <GetTo ZoneId="622" XYZ="514.7631, 40.4257, -501.03" /> <!-- Mol Maiden -->
                     <TurnIn QuestId="68300" ItemIds="2002322,2002323" NpcId="1023254" XYZ="514.7631, 40.4257, -501.03" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11055,6 +11255,7 @@
                 <If Condition="GetQuestStep(68307) == 255">
                     <GetTo ZoneId="622" XYZ="343.5873, 26.26189, -326.5583" /> <!-- Sukegei -->
                     <TurnIn QuestId="68307" ItemId="2002173" NpcId="1019405" XYZ="343.5873, 26.26189, -326.5583" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11064,6 +11265,7 @@
                 <If Condition="GetQuestStep(68306) == 255">
                     <GetTo ZoneId="622" XYZ="511.9554, 39.81247, -471.3359" /> <!-- Ujin -->
                     <TurnIn QuestId="68306" NpcId="1019389" XYZ="511.9554, 39.81247, -471.3359" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11073,6 +11275,7 @@
                 <If Condition="GetQuestStep(68305) == 255">
                     <GetTo ZoneId="622" XYZ="524.4678, 40.39071, -486.2593" /> <!-- Caur -->
                     <TurnIn QuestId="68305" ItemId="2002294" NpcId="1019402" XYZ="524.4678, 40.39071, -486.2593" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11082,6 +11285,7 @@
                 <If Condition="GetQuestStep(68304) == 255">
                     <GetTo ZoneId="622" XYZ="525.6886, 40.4257, -494.4991" /> <!-- Nigen -->
                     <TurnIn QuestId="68304" NpcId="1019387" XYZ="525.6886, 40.4257, -494.4991" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11118,6 +11322,7 @@
                 <If Condition="GetQuestStep(68308) == 255">
                     <GetTo ZoneId="622" XYZ="525.6886, 40.4257, -494.4991" /> <!-- Nigen -->
                     <TurnIn QuestId="68308" NpcId="1019387" XYZ="525.6886, 40.4257, -494.4991" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11130,6 +11335,7 @@
                 <If Condition="GetQuestStep(68309) == 255">
                     <GetTo ZoneId="622" XYZ="514.6409, 40.4257, -491.5999" /> <!-- Mol Maiden -->
                     <TurnIn QuestId="68309" ItemIds="2002255,2002256,2002257" NpcId="1022479" XYZ="514.6409, 40.4257, -491.5999" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11149,6 +11355,7 @@
                 <If Condition="GetQuestStep(68042) == 255">
                     <GetTo ZoneId="622" XYZ="-507.805, 71.23162, -512.0775" /> <!-- Hien -->
                     <TurnIn QuestId="68042" NpcId="1020679" XYZ="-507.805, 71.23162, -512.0775" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11177,6 +11384,7 @@
                 <If Condition="GetQuestStep(68043) == 255">
                     <GetTo ZoneId="622" XYZ="-507.4998, 70.84219, -501.4573" /> <!-- Lyse -->
                     <TurnIn QuestId="68043" NpcId="1020682" XYZ="-507.4998, 70.84219, -501.4573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11195,6 +11403,7 @@
                 <If Condition="GetQuestStep(68044) == 255">
                     <GetTo ZoneId="622" XYZ="-39.41406, 122.1, 63.61487" /> <!-- Magnai -->
                     <TurnIn QuestId="68044" NpcId="1019417" XYZ="-39.41406, 122.1, 63.61487" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11327,6 +11536,7 @@
                 <If Condition="GetQuestStep(68312) == 255">
                     <GetTo ZoneId="622" XYZ="99.07678, 114.905, 65.2323" /> <!-- Charakha -->
                     <TurnIn QuestId="68312" NpcId="1019427" XYZ="99.07678, 114.905, 65.2323" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11336,6 +11546,7 @@
                 <If Condition="GetQuestStep(68314) == 255">
                     <GetTo ZoneId="622" XYZ="85.89294, 114.905, 15.64044" /> <!-- Guyug -->
                     <TurnIn QuestId="68314" NpcId="1019428" XYZ="85.89294, 114.905, 15.64044" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11345,6 +11556,7 @@
                 <If Condition="GetQuestStep(68311) == 255">
                     <GetTo ZoneId="622" XYZ="27.66455, 114.905, -36.14868" /> <!-- Ogodei -->
                     <TurnIn QuestId="68311" ItemIds="2002295,2002296" NpcId="1019421" XYZ="27.66455, 114.905, -36.14868" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11354,6 +11566,7 @@
                 <If Condition="GetQuestStep(68310) == 255">
                     <GetTo ZoneId="622" XYZ="-12.64978, 121.2, 66.453" /> <!-- Abaka -->
                     <TurnIn QuestId="68310" NpcId="1019425" XYZ="-12.64978, 121.2, 66.453" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11363,6 +11576,7 @@
                 <If Condition="GetQuestStep(68313) == 255">
                     <GetTo ZoneId="622" XYZ="-78.50769, 114.905, 110.3685" /> <!-- Budugan Warrior -->
                     <TurnIn QuestId="68313" NpcId="1023311" XYZ="-78.50769, 114.905, 110.3685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11468,6 +11682,7 @@
                 <If Condition="GetQuestStep(68045) == 255">
                     <GetTo ZoneId="622" XYZ="-39.41406, 122.1, 63.61487" /> <!-- Magnai -->
                     <TurnIn QuestId="68045" NpcId="1019417" XYZ="-39.41406, 122.1, 63.61487" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11553,6 +11768,7 @@
                 <If Condition="GetQuestStep(68046) == 255">
                     <GetTo ZoneId="622" XYZ="-39.41406, 122.1, 63.61487" /> <!-- Magnai -->
                     <TurnIn QuestId="68046" NpcId="1019417" XYZ="-39.41406, 122.1, 63.61487" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11609,6 +11825,7 @@
                 <If Condition="GetQuestStep(68318) == 255">
                     <GetTo ZoneId="622" XYZ="79.24011, 114.905, 95.99438" /> <!-- Esugen -->
                     <TurnIn QuestId="68318" ItemId="2002380" NpcId="1023348" XYZ="79.24011, 114.905, 95.99438" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11710,6 +11927,7 @@
                 <If Condition="GetQuestStep(68047) == 255">
                     <GetTo ZoneId="622" XYZ="-290.3334, 10.38987, 598.9928" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68047" NpcId="1021625" XYZ="-290.3334, 10.38987, 598.9928" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11748,6 +11966,7 @@
                 <If Condition="GetQuestStep(68048) == 255">
                     <GetTo ZoneId="622" XYZ="-399.0387, 2.257562, 599.2675" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68048" NpcId="1021615" XYZ="-399.0387, 2.257562, 599.2675" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11847,6 +12066,7 @@
                 <If Condition="GetQuestStep(68327) == 255">
                     <GetTo ZoneId="622" XYZ="-434.0429, 2.55011, 650.019" /> <!-- Mauci -->
                     <TurnIn QuestId="68327" NpcId="1023193" XYZ="-434.0429, 2.55011, 650.019" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11878,6 +12098,7 @@
                 <If Condition="GetQuestStep(68049) == 255">
                     <GetTo ZoneId="622" XYZ="-705.5009, 6.554513, 613.1837" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68049" NpcId="1021628" XYZ="-705.5009, 6.554513, 613.1837" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11950,6 +12171,7 @@
                 <If Condition="GetQuestStep(68325) == 255">
                     <GetTo ZoneId="622" XYZ="-436.7285, 2.253339, 573.4187" /> <!-- Agujam -->
                     <TurnIn QuestId="68325" NpcId="1022228" XYZ="-436.7285, 2.253339, 573.4187" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11959,6 +12181,7 @@
                 <If Condition="GetQuestStep(68323) == 255">
                     <GetTo ZoneId="622" XYZ="-400.412, 2.61689, 586.1141" /> <!-- Dagasi -->
                     <TurnIn QuestId="68323" NpcId="1022223" XYZ="-400.412, 2.61689, 586.1141" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -11968,6 +12191,7 @@
                 <If Condition="GetQuestStep(68328) == 255">
                     <GetTo ZoneId="622" XYZ="-434.0429, 2.55011, 650.019" /> <!-- Mauci -->
                     <TurnIn QuestId="68328" NpcId="1023193" XYZ="-434.0429, 2.55011, 650.019" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12053,6 +12277,7 @@
                 <If Condition="GetQuestStep(68324) == 255">
                     <GetTo ZoneId="622" XYZ="-414.6029, 2.570885, 641.5961" /> <!-- Dotharli Warrior -->
                     <TurnIn QuestId="68324" NpcId="1023353" XYZ="-414.6029, 2.570885, 641.5961" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12065,6 +12290,7 @@
                 <If Condition="GetQuestStep(68329) == 255">
                     <GetTo ZoneId="622" XYZ="-432.3644, 2.647673, 650.5989" /> <!-- Khulan -->
                     <TurnIn QuestId="68329" NpcId="1023195" XYZ="-432.3644, 2.647673, 650.5989" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12114,6 +12340,7 @@
                 <If Condition="GetQuestStep(68326) == 255">
                     <GetTo ZoneId="622" XYZ="-415.9762, 2.430035, 579.5223" /> <!-- Maral -->
                     <TurnIn QuestId="68326" ItemId="2002183" NpcId="1019325" XYZ="-415.9762, 2.430035, 579.5223" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12126,6 +12353,7 @@
                 <If Condition="GetQuestStep(68319) == 255">
                     <GetTo ZoneId="622" XYZ="79.24011, 114.905, 95.99438" /> <!-- Esugen -->
                     <TurnIn QuestId="68319" ItemId="2002362" NpcId="1023348" XYZ="79.24011, 114.905, 95.99438" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12159,6 +12387,7 @@
                 <If Condition="GetQuestStep(68317) == 255">
                     <GetTo ZoneId="622" XYZ="30.16699, 114.905, 95.2926" /> <!-- Oroniri Hunter -->
                     <TurnIn QuestId="68317" NpcId="1023313" XYZ="30.16699, 114.905, 95.2926" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12187,6 +12416,7 @@
                 <If Condition="GetQuestStep(68315) == 255">
                     <GetTo ZoneId="622" XYZ="33.98181, 114.905, -40.69586" /> <!-- Sorocan -->
                     <TurnIn QuestId="68315" NpcId="1019430" XYZ="33.98181, 114.905, -40.69586" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12196,6 +12426,7 @@
                 <If Condition="GetQuestStep(68316) == 255">
                     <GetTo ZoneId="622" XYZ="-103.5935, 114.905, 19.05847" /> <!-- Yabuqa -->
                     <TurnIn QuestId="68316" NpcId="1019434" XYZ="-103.5935, 114.905, 19.05847" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12219,6 +12450,7 @@
                 <If Condition="GetQuestStep(68320) == 255">
                     <GetTo ZoneId="622" XYZ="79.24011, 114.905, 95.99438" /> <!-- Esugen -->
                     <TurnIn QuestId="68320" NpcId="1023348" XYZ="79.24011, 114.905, 95.99438" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12263,6 +12495,7 @@
                 <If Condition="GetQuestStep(68321) == 255">
                     <GetTo ZoneId="622" XYZ="79.24011, 114.905, 95.99438" /> <!-- Esugen -->
                     <TurnIn QuestId="68321" NpcId="1023348" XYZ="79.24011, 114.905, 95.99438" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12275,6 +12508,7 @@
                 <If Condition="GetQuestStep(68050) == 255">
                     <GetTo ZoneId="622" XYZ="498.2832, 40.8361, -508.2017" /> <!-- Cirina -->
                     <TurnIn QuestId="68050" NpcId="1020539" XYZ="498.2832, 40.8361, -508.2017" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12348,6 +12582,7 @@
                 <If Condition="GetQuestStep(68051) == 255">
                     <GetTo ZoneId="622" XYZ="486.6864, 40.08099, -465.7206" /> <!-- Hien -->
                     <TurnIn QuestId="68051" NpcId="1020540" XYZ="486.6864, 40.08099, -465.7206" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12383,6 +12618,7 @@
                 <If Condition="GetQuestStep(68052) == 255">
                     <GetTo ZoneId="622" XYZ="498.2832, 40.8361, -508.2017" /> <!-- Cirina -->
                     <TurnIn QuestId="68052" NpcId="1020539" XYZ="498.2832, 40.8361, -508.2017" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12524,6 +12760,7 @@
                     </If>
                     <GetTo ZoneId="622" XYZ="436.057, 59.01295, -452.9946" /> --> <!-- Maqali -->
                     <!-- <TurnIn QuestId="68339" NpcId="1019380" XYZ="436.057, 59.01295, -452.9946" />
+ <WaitTimer WaitTime="2"/>
                     <If Condition="IsOnMap(622) and Clio.Utilities.Vector3.Distance(Core.Player.Location, Vector3(436.057, 59.01295, -452.9946)) &lt; 5">
                         <MoveTo Name="Jump Spot" Distance="1" UseMesh="False" XYZ="439.5659, 58.97764, -454.063" />
                         <MoveTo Name="Jump" Distance="1" UseMesh="False" XYZ="448.0489, 41.16454, -469.3901" />
@@ -12557,6 +12794,7 @@
                     <!-- </If>
                     <ExFlyTo Name="Jenkshi" XYZ="462.7299, 40.40665, -498.6496" />
                     <TurnIn QuestId="68338" ItemId="2002300" NpcId="1019400" XYZ="462.7299, 40.40665, -498.6496" />
+                    <WaitTimer WaitTime="2"/>
                 </If> -->
             </If>
         </If>
@@ -12569,6 +12807,7 @@
                 <If Condition="GetQuestStep(68336) == 255">
                     <GetTo ZoneId="622" XYZ="478.2634, 40.39893, -483.3295" /> <!-- Mild-mannered Mol -->
                     <TurnIn QuestId="68336" NpcId="1022531" XYZ="478.2634, 40.39893, -483.3295" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12588,6 +12827,7 @@
                 <If Condition="GetQuestStep(68337) == 255">
                     <GetTo ZoneId="622" XYZ="501.2131, 40.83608, -505.9129" /> <!-- Bujeg -->
                     <TurnIn QuestId="68337" NpcId="1019386" XYZ="501.2131, 40.83608, -505.9129" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12604,6 +12844,7 @@
                 <If Condition="GetQuestStep(68053) == 255">
                     <GetTo ZoneId="622" XYZ="-167.895, 0.8849516, 816.8002" /> <!-- Cirina -->
                     <TurnIn QuestId="68053" NpcId="1021646" XYZ="-167.895, 0.8849516, 816.8002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12628,6 +12869,7 @@
                 <If Condition="GetQuestStep(68322) == 255">
                     <GetTo ZoneId="622" XYZ="-770.0466, 7.846129, 392.5078" /> <!-- Sechen -->
                     <TurnIn QuestId="68322" ItemId="2002308" NpcId="1022702" XYZ="-770.0466, 7.846129, 392.5078" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12711,6 +12953,7 @@
                 <If Condition="GetQuestStep(68334) == 255">
                     <GetTo ZoneId="622" XYZ="-775.7534, 7.88716, 402.7924" /> <!-- Ibakha -->
                     <TurnIn QuestId="68334" ItemId="2002259" NpcId="1019328" XYZ="-775.7534, 7.88716, 402.7924" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12775,6 +13018,7 @@
                 <If Condition="GetQuestStep(68330) == 255">
                     <GetTo ZoneId="622" XYZ="-416.8307, 3.632954, 551.6898" /> <!-- Mauci -->
                     <TurnIn QuestId="68330" NpcId="1023211" XYZ="-416.8307, 3.632954, 551.6898" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12808,6 +13052,7 @@
                 <If Condition="GetQuestStep(68332) == 255">
                     <GetTo ZoneId="622" XYZ="-760.2197, 7.846382, 410.7881" /> <!-- Bujir -->
                     <TurnIn QuestId="68332" NpcId="1019329" XYZ="-760.2197, 7.846382, 410.7881" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12817,6 +13062,7 @@
                 <If Condition="GetQuestStep(68333) == 255">
                     <GetTo ZoneId="622" XYZ="-767.7272, 7.88637, 396.231" /> <!-- Caalun -->
                     <TurnIn QuestId="68333" ItemId="2002258" NpcId="1019327" XYZ="-767.7272, 7.88637, 396.231" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12863,6 +13109,7 @@
                 <If Condition="GetQuestStep(68335) == 255">
                     <GetTo ZoneId="622" XYZ="-442.1302, 2.535343, 575.1278" /> <!-- Uyagiri Youth -->
                     <TurnIn QuestId="68335" NpcId="1023317" XYZ="-442.1302, 2.535343, 575.1278" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12898,6 +13145,7 @@
                 <If Condition="GetQuestStep(68331) == 255">
                     <GetTo ZoneId="622" XYZ="138.6892, 16.20243, 170.7026" /> <!-- Mauci -->
                     <TurnIn QuestId="68331" NpcId="1023415" XYZ="138.6892, 16.20243, 170.7026" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12918,6 +13166,7 @@
                 <If Condition="GetQuestStep(68054) == 255">
                     <GetTo ZoneId="614" XYZ="173.785, 5.16971, -417.4106" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68054" NpcId="1020519" XYZ="173.785, 5.16971, -417.4106" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12939,6 +13188,7 @@
                 <If Condition="GetQuestStep(68474) == 255">
                     <GetTo ZoneId="628" XYZ="-29.16003, 0.09999965, -46.18909" /> <!-- Wlveva -->
                     <TurnIn QuestId="68474" NpcId="1019009" XYZ="-29.16003, 0.09999965, -46.18909" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -12986,6 +13236,7 @@
                     </If>
                     <MoveTo Name="Tataru" XYZ="-1.571716, 0, -1.449646" />
                     <TurnIn QuestId="68055" NpcId="1023084" XYZ="-1.571716, 0, -1.449646" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13030,6 +13281,7 @@
                 <If Condition="GetQuestStep(68482) == 255">
                     <GetTo ZoneId="614" XYZ="173.785, 5.16971, -417.4106" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68482" ItemId="2002175" NpcId="1020519" XYZ="173.785, 5.16971, -417.4106" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13157,6 +13409,7 @@
                 <If Condition="GetQuestStep(68343) == 255">
                     <GetTo ZoneId="614" XYZ="265.4001, 7.960517, -417.2885" /> <!-- Spineless Soldier -->
                     <TurnIn QuestId="68343" NpcId="1023100" XYZ="265.4001, 7.960517, -417.2885" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13193,6 +13446,7 @@
                 <If Condition="GetQuestStep(68056) == 255">
                     <GetTo ZoneId="614" XYZ="235.8586, 4.456162, -382.8031" /> <!-- Alisaie -->
                     <TurnIn QuestId="68056" NpcId="1020520" XYZ="235.8586, 4.456162, -382.8031" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13368,6 +13622,7 @@
                     <!-- </If>
                     <ExFlyTo Name="Sharp-eyed Samurai" XYZ="312.1233, 17.50058, -415.3353" />
                     <TurnIn QuestId="68347" NpcId="1023112" XYZ="312.1233, 17.50058, -415.3353" />
+                    <WaitTimer WaitTime="2"/>
                 </If> -->
             </If>
         </If>
@@ -13380,6 +13635,7 @@
                 <If Condition="GetQuestStep(68345) == 255">
                     <GetTo ZoneId="614" XYZ="256.3058, 5.172042, -374.9294" /> <!-- Slight Soldier -->
                     <TurnIn QuestId="68345" NpcId="1023108" XYZ="256.3058, 5.172042, -374.9294" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13389,6 +13645,7 @@
                 <If Condition="GetQuestStep(68346) == 255">
                     <GetTo ZoneId="614" XYZ="196.5514, 5.169405, -410.6661" /> <!-- Motojiro -->
                     <TurnIn QuestId="68346" NpcId="1019287" XYZ="196.5514, 5.169405, -410.6661" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13398,6 +13655,7 @@
                 <If Condition="GetQuestStep(68342) == 255">
                     <GetTo ZoneId="614" XYZ="195.6359, 5.16971, -437.2473" /> <!-- Haname -->
                     <TurnIn QuestId="68342" ItemId="2002266" NpcId="1019285" XYZ="195.6359, 5.16971, -437.2473" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13423,6 +13681,7 @@
                 <If Condition="GetQuestStep(68341) == 255">
                     <GetTo ZoneId="614" XYZ="173.4492, 5.16971, -413.7179" /> <!-- Yagoro -->
                     <TurnIn QuestId="68341" ItemIds="2002301,2002302" NpcId="1019288" XYZ="173.4492, 5.16971, -413.7179" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13459,6 +13718,7 @@
                 <If Condition="GetQuestStep(68344) == 255">
                     <GetTo ZoneId="614" XYZ="218.7075, 6.137936, -372.9152" /> <!-- Stalwart Soldier -->
                     <TurnIn QuestId="68344" NpcId="1023104" XYZ="218.7075, 6.137936, -372.9152" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13475,6 +13735,7 @@
                 <If Condition="GetQuestStep(68057) == 255">
                     <GetTo ZoneId="614" XYZ="337.2701, 31.03499, 206.4392" /> <!-- Tsuranuki -->
                     <TurnIn QuestId="68057" NpcId="1020232" XYZ="337.2701, 31.03499, 206.4392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13530,6 +13791,7 @@
                 <If Condition="GetQuestStep(68483) == 255">
                     <GetTo ZoneId="614" XYZ="337.2701, 31.03499, 206.4392" /> <!-- Tsuranuki -->
                     <TurnIn QuestId="68483" ItemId="2002177" NpcId="1020232" XYZ="337.2701, 31.03499, 206.4392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13574,6 +13836,7 @@
                 <If Condition="GetQuestStep(68340) == 255">
                     <GetTo ZoneId="614" XYZ="244.007, 5.172036, -374.8989" /> <!-- Auri Samurai -->
                     <TurnIn QuestId="68340" ItemId="2002341" NpcId="1023321" XYZ="244.007, 5.172036, -374.8989" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13608,6 +13871,7 @@
                 <If Condition="GetQuestStep(68058) == 255">
                     <GetTo ZoneId="614" XYZ="-291.4321, 53.21751, -614.313" /> <!-- Hien -->
                     <TurnIn QuestId="68058" ItemId="2002178" NpcId="1020239" XYZ="-291.4321, 53.21751, -614.313" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13642,6 +13906,7 @@
                 <If Condition="GetQuestStep(68059) == 255">
                     <GetTo ZoneId="614" XYZ="173.785, 5.16971, -417.4106" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68059" NpcId="1020519" XYZ="173.785, 5.16971, -417.4106" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13679,6 +13944,7 @@
                 <If Condition="GetQuestStep(68060) == 255">
                     <GetTo ZoneId="614" XYZ="-390.28, 30.64617, -455.8633" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68060" NpcId="1020248" XYZ="-390.28, 30.64617, -455.8633" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13721,6 +13987,7 @@
                 <If Condition="GetQuestStep(68061) == 255">
                     <GetTo ZoneId="628" XYZ="-175.9213, -7.000108, 53.81848" /> <!-- Rasho -->
                     <TurnIn QuestId="68061" NpcId="1020265" XYZ="-175.9213, -7.000108, 53.81848" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13800,6 +14067,7 @@
                 <If Condition="GetQuestStep(68351) == 255">
                     <GetTo ZoneId="628" XYZ="-63.18768, -4.733875, 157.8545" /> <!-- Puissant Porter -->
                     <TurnIn QuestId="68351" ItemId="2002343" NpcId="1023328" XYZ="-63.18768, -4.733875, 157.8545" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13872,6 +14140,7 @@
                 <If Condition="GetQuestStep(68349) == 255">
                     <GetTo ZoneId="628" XYZ="-4.745544, 0.02283034, -113.9697" /> <!-- Keisetsu -->
                     <TurnIn QuestId="68349" NpcId="1022620" XYZ="-4.745544, 0.02283034, -113.9697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13881,6 +14150,7 @@
                 <If Condition="GetQuestStep(68348) == 255">
                     <GetTo ZoneId="628" XYZ="127.3976, 25, 14.08405" /> <!-- Ijin Merchant -->
                     <TurnIn QuestId="68348" NpcId="1023124" XYZ="127.3976, 25, 14.08405" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13912,6 +14182,7 @@
                 <If Condition="GetQuestStep(68062) == 255">
                     <GetTo ZoneId="129" XYZ="-355.5811, 8.000015, 40.78735" /> <!-- Lyse -->
                     <TurnIn QuestId="68062" NpcId="1020441" XYZ="-355.5811, 8.000015, 40.78735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -13944,6 +14215,7 @@
                 <If Condition="GetQuestStep(68063) == 255">
                     <GetTo ZoneId="612" XYZ="-605.2186, 130, -506.2486" /> <!-- Pipin -->
                     <TurnIn QuestId="68063" NpcId="1020354" XYZ="-605.2186, 130, -506.2486" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14007,6 +14279,7 @@
                 <If Condition="GetQuestStep(68064) == 255">
                     <GetTo ZoneId="612" XYZ="-91.23376, 50.00444, 187.8538" /> <!-- Lyse -->
                     <TurnIn QuestId="68064" NpcId="1020567" XYZ="-91.23376, 50.00444, 187.8538" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14037,6 +14310,7 @@
                 <If Condition="GetQuestStep(68065) == 255">
                     <GetTo ZoneId="612" XYZ="-92.42395, 50.00444, 185.6565" /> <!-- Conrad -->
                     <TurnIn QuestId="68065" NpcId="1020568" XYZ="-92.42395, 50.00444, 185.6565" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14066,6 +14340,7 @@
                 <If Condition="GetQuestStep(68066) == 255">
                     <GetTo ZoneId="612" XYZ="426.5659, 114.5499, 221.7898" /> <!-- M'naago -->
                     <TurnIn QuestId="68066" NpcId="1020578" XYZ="426.5659, 114.5499, 221.7898" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14112,6 +14387,7 @@
                 <If Condition="GetQuestStep(68357) == 255">
                     <GetTo ZoneId="612" XYZ="433.9818, 114.483, 233.2952" /> <!-- M'zimzizi -->
                     <TurnIn QuestId="68357" ItemId="2002325" NpcId="1020807" XYZ="433.9818, 114.483, 233.2952" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14128,6 +14404,7 @@
                 <If Condition="GetQuestStep(68356) == 255">
                     <GetTo ZoneId="612" XYZ="391.4397, 105.2514, 276.9664" /> <!-- M'linhbo -->
                     <TurnIn QuestId="68356" NpcId="1020808" XYZ="391.4397, 105.2514, 276.9664" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14144,6 +14421,7 @@
                 <If Condition="GetQuestStep(68067) == 255">
                     <GetTo ZoneId="612" XYZ="334.1267, 82.94969, -101.2742" /> <!-- Vajra -->
                     <TurnIn QuestId="68067" NpcId="1020827" XYZ="334.1267, 82.94969, -101.2742" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14216,6 +14494,7 @@
                 <If Condition="GetQuestStep(68352) == 255">
                     <GetTo ZoneId="612" XYZ="276.7223, 76.85394, -23.51416" /> <!-- Prapti -->
                     <TurnIn QuestId="68352" NpcId="1020821" XYZ="276.7223, 76.85394, -23.51416" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14257,6 +14536,7 @@
                 <If Condition="GetQuestStep(68355) == 255">
                     <GetTo ZoneId="612" XYZ="298.207, 71.86882, -88.7923" /> <!-- Vira Bowmaid -->
                     <TurnIn QuestId="68355" NpcId="1022054" XYZ="298.207, 71.86882, -88.7923" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14266,6 +14546,7 @@
                 <If Condition="GetQuestStep(68354) == 255">
                     <GetTo ZoneId="612" XYZ="273.4874, 77.24829, -46.34167" /> <!-- Jayanti -->
                     <TurnIn QuestId="68354" NpcId="1020819" XYZ="273.4874, 77.24829, -46.34167" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14302,6 +14583,7 @@
                 <If Condition="GetQuestStep(68068) == 255">
                     <GetTo ZoneId="612" XYZ="509.3918, 122.138, -242.1455" /> <!-- Lyse -->
                     <TurnIn QuestId="68068" NpcId="1020592" XYZ="509.3918, 122.138, -242.1455" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14338,6 +14620,7 @@
                 <If Condition="GetQuestStep(68069) == 255">
                     <GetTo ZoneId="612" XYZ="424.7349, 114.6093, 222.1865" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68069" NpcId="1020596" XYZ="424.7349, 114.6093, 222.1865" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14422,6 +14705,7 @@
                     <!-- </If>
                     <ExFlyTo Name="M'gizzoh" XYZ="384.6647, 105.184, 250.0496" />
                     <TurnIn QuestId="68359" NpcId="1020814" XYZ="384.6647, 105.184, 250.0496" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -14438,6 +14722,7 @@
                 <If Condition="GetQuestStep(68360) == 255">
                     <GetTo ZoneId="612" XYZ="465.629, 77.67306, 114.8546" /> <!-- M'zhet Tia -->
                     <TurnIn QuestId="68360" NpcId="1023161" XYZ="465.629, 77.67306, 114.8546" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14466,6 +14751,7 @@
                 <If Condition="GetQuestStep(68361) == 255">
                     <GetTo ZoneId="612" XYZ="305.1652, 45.65442, 491.5999" /> <!-- M'zhet Tia -->
                     <TurnIn QuestId="68361" NpcId="1023163" XYZ="305.1652, 45.65442, 491.5999" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14503,6 +14789,7 @@
                 <If Condition="GetQuestStep(68362) == 255">
                     <GetTo ZoneId="612" XYZ="-127.4586, 41.19766, 7.248047" /> <!-- M'zhet Tia -->
                     <TurnIn QuestId="68362" NpcId="1023164" XYZ="-127.4586, 41.19766, 7.248047" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14562,6 +14849,7 @@
                 <If Condition="GetQuestStep(68358) == 255">
                     <GetTo ZoneId="612" XYZ="460.4104, 114.2104, 222.736" /> <!-- M'septha -->
                     <TurnIn QuestId="68358" ItemId="2002215" NpcId="1020804" XYZ="460.4104, 114.2104, 222.736" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14571,6 +14859,7 @@
                 <If Condition="GetQuestStep(68353) == 255">
                     <GetTo ZoneId="612" XYZ="339.5588, 82.34022, -76.52399" /> <!-- Garima -->
                     <TurnIn QuestId="68353" ItemId="2002344" NpcId="1020818" XYZ="339.5588, 82.34022, -76.52399" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14594,6 +14883,7 @@
                 <If Condition="GetQuestStep(68363) == 255">
                     <GetTo ZoneId="612" XYZ="440.1158, 114.2544, 212.848" /> <!-- M'rahz Nunh -->
                     <TurnIn QuestId="68363" NpcId="1021565" XYZ="440.1158, 114.2544, 212.848" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14630,6 +14920,7 @@
                 <If Condition="GetQuestStep(68364) == 255">
                     <GetTo ZoneId="612" XYZ="440.1158, 114.2544, 212.848" /> <!-- M'rahz Nunh -->
                     <TurnIn QuestId="68364" NpcId="1021565" XYZ="440.1158, 114.2544, 212.848" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14722,6 +15013,7 @@
                 <If Condition="GetQuestStep(68070) == 255">
                     <GetTo ZoneId="620" XYZ="-286.7323, 256.9996, 696.2233" /> <!-- M'naago -->
                     <TurnIn QuestId="68070" NpcId="1020600" XYZ="-286.7323, 256.9996, 696.2233" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14747,6 +15039,7 @@
                 <If Condition="GetQuestStep(68071) == 255">
                     <GetTo ZoneId="620" XYZ="-297.4747, 257.5265, 765.3162" /> <!-- Alisaie -->
                     <TurnIn QuestId="68071" NpcId="1020630" XYZ="-297.4747, 257.5265, 765.3162" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14828,6 +15121,7 @@
                 <If Condition="GetQuestStep(68366) == 255">
                     <GetTo ZoneId="620" XYZ="-237.9034, 257.7197, 741.5731" /> <!-- Weidheri -->
                     <TurnIn QuestId="68366" NpcId="1020871" XYZ="-237.9034, 257.7197, 741.5731" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14874,6 +15168,7 @@
                 <If Condition="GetQuestStep(68072) == 255">
                     <GetTo ZoneId="620" XYZ="-346.1509, 305.933, 149.0348" /> <!-- Alisaie -->
                     <TurnIn QuestId="68072" NpcId="1020608" XYZ="-346.1509, 305.933, 149.0348" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14939,6 +15234,7 @@
                 <If Condition="GetQuestStep(68367) == 255">
                     <GetTo ZoneId="620" XYZ="-292.8359, 257.5265, 726.4667" /> <!-- Odo -->
                     <TurnIn QuestId="68367" NpcId="1021593" XYZ="-292.8359, 257.5265, 726.4667" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14951,6 +15247,7 @@
                 <If Condition="GetQuestStep(68365) == 255">
                     <GetTo ZoneId="620" XYZ="-277.821, 258.9065, 782.7725" /> <!-- Gerbod -->
                     <TurnIn QuestId="68365" ItemId="2002345" NpcId="1021591" XYZ="-277.821, 258.9065, 782.7725" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14960,6 +15257,7 @@
                 <If Condition="GetQuestStep(68368) == 255">
                     <GetTo ZoneId="620" XYZ="-254.7189, 260.0574, 805.8136" /> <!-- Lonesome Lass -->
                     <TurnIn QuestId="68368" ItemId="2002346" NpcId="1023330" XYZ="-254.7189, 260.0574, 805.8136" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -14969,6 +15267,7 @@
                 <If Condition="GetQuestStep(68369) == 255">
                     <GetTo ZoneId="620" XYZ="-210.6813, 257.8064, 767.4829" /> <!-- J'nairoh -->
                     <TurnIn QuestId="68369" NpcId="1021587" XYZ="-210.6813, 257.8064, 767.4829" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15033,6 +15332,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="7.827881, 317.5509, 112.4132" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68073" NpcId="1020611" XYZ="7.827881, 317.5509, 112.4132" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15077,6 +15377,7 @@
                 <If Condition="GetQuestStep(68074) == 255">
                     <GetTo ZoneId="620" XYZ="-286.5493, 256.8515, 693.1411" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68074" NpcId="1020601" XYZ="-286.5493, 256.8515, 693.1411" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15102,6 +15403,7 @@
                 <If Condition="GetQuestStep(68075) == 255">
                     <GetTo ZoneId="620" XYZ="-300.496, 257.5265, 765.0415" /> <!-- Lyse -->
                     <TurnIn QuestId="68075" NpcId="1020631" XYZ="-300.496, 257.5265, 765.0415" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15178,6 +15480,7 @@
                 <If Condition="GetQuestStep(68372) == 255">
                     <GetTo ZoneId="620" XYZ="-301.8387, 257.5265, 726.4667" /> <!-- Resistance Fighter -->
                     <TurnIn QuestId="68372" NpcId="1023256" XYZ="-301.8387, 257.5265, 726.4667" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15194,6 +15497,7 @@
                 <If Condition="GetQuestStep(68374) == 255">
                     <GetTo ZoneId="620" XYZ="-237.9034, 257.7197, 741.5731" /> <!-- Weidheri -->
                     <TurnIn QuestId="68374" ItemId="2002347" NpcId="1020871" XYZ="-237.9034, 257.7197, 741.5731" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15214,6 +15518,7 @@
                 <If Condition="GetQuestStep(68076) == 255">
                     <GetTo ZoneId="620" XYZ="-113.4203, 263.7311, 655.7563" /> <!-- Lyse -->
                     <TurnIn QuestId="68076" NpcId="1020633" XYZ="-113.4203, 263.7311, 655.7563" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15270,6 +15575,7 @@
                 <If Condition="GetQuestStep(68370) == 255">
                     <GetTo ZoneId="620" XYZ="-424.9791, 307.1777, 138.1704" /> <!-- Guntmar -->
                     <TurnIn QuestId="68370" ItemId="2002217" NpcId="1020882" XYZ="-424.9791, 307.1777, 138.1704" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15354,6 +15660,7 @@
                 <If Condition="GetQuestStep(68373) == 255">
                     <GetTo ZoneId="620" XYZ="-229.2974, 257.5265, 756.3134" /> <!-- Zuzudesu -->
                     <TurnIn QuestId="68373" ItemId="2002219" NpcId="1020872" XYZ="-229.2974, 257.5265, 756.3134" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15373,6 +15680,7 @@
                 <If Condition="GetQuestStep(68077) == 255">
                     <GetTo ZoneId="620" XYZ="-298.5123, 257.5265, 764.9805" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68077" NpcId="1020629" XYZ="-298.5123, 257.5265, 764.9805" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15397,6 +15705,7 @@
                 <If Condition="GetQuestStep(68371) == 255">
                     <GetTo ZoneId="620" XYZ="-321.8891, 258.9065, 769.1005" /> <!-- Hele -->
                     <TurnIn QuestId="68371" NpcId="1020876" XYZ="-321.8891, 258.9065, 769.1005" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15470,6 +15779,7 @@
                 <If Condition="GetQuestStep(68378) == 255">
                     <GetTo ZoneId="620" XYZ="-232.3186, 258.9065, 799.4659" /> <!-- Baut -->
                     <TurnIn QuestId="68378" NpcId="1023258" XYZ="-232.3186, 258.9065, 799.4659" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15543,6 +15853,7 @@
                 <If Condition="GetQuestStep(68377) == 255">
                     <GetTo ZoneId="620" XYZ="-214.4656, 257.5265, 751.8578" /> <!-- Well-meaning Mother -->
                     <TurnIn QuestId="68377" NpcId="1023334" XYZ="-214.4656, 257.5265, 751.8578" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15552,6 +15863,7 @@
                 <If Condition="GetQuestStep(68379) == 255">
                     <GetTo ZoneId="620" XYZ="-232.3186, 258.9065, 799.4659" /> <!-- Baut -->
                     <TurnIn QuestId="68379" NpcId="1023258" XYZ="-232.3186, 258.9065, 799.4659" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15592,6 +15904,7 @@
                 <If Condition="GetQuestStep(68380) == 255">
                     <GetTo ZoneId="620" XYZ="-232.0134, 258.9065, 801.4801" /> <!-- J'dyalani -->
                     <TurnIn QuestId="68380" NpcId="1023264" XYZ="-232.0134, 258.9065, 801.4801" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15642,6 +15955,7 @@
                 <If Condition="GetQuestStep(68376) == 255">
                     <GetTo ZoneId="620" XYZ="-210.6813, 257.8064, 767.4829" /> <!-- J'nairoh -->
                     <TurnIn QuestId="68376" NpcId="1021587" XYZ="-210.6813, 257.8064, 767.4829" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15651,6 +15965,7 @@
                 <If Condition="GetQuestStep(68375) == 255">
                     <GetTo ZoneId="620" XYZ="-239.5209, 257.6817, 770.4126" /> <!-- Emory -->
                     <TurnIn QuestId="68375" NpcId="1020868" XYZ="-239.5209, 257.6817, 770.4126" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15660,6 +15975,7 @@
                 <If Condition="GetQuestStep(68383) == 255">
                     <GetTo ZoneId="620" XYZ="-424.9791, 307.1777, 138.1704" /> <!-- Guntmar -->
                     <TurnIn QuestId="68383" ItemId="2002220" NpcId="1020882" XYZ="-424.9791, 307.1777, 138.1704" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15700,6 +16016,7 @@
                 <If Condition="GetQuestStep(68384) == 255">
                     <GetTo ZoneId="620" XYZ="-267.9943, 257.5265, 711.9097" /> <!-- Resistance Fighter -->
                     <TurnIn QuestId="68384" ItemId="2002221" NpcId="1022066" XYZ="-267.9943, 257.5265, 711.9097" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15709,6 +16026,7 @@
                 <If Condition="GetQuestStep(68381) == 255">
                     <GetTo ZoneId="620" XYZ="-327.9622, 258.9065, 757.3815" /> <!-- Brazen Brook -->
                     <TurnIn QuestId="68381" NpcId="1020873" XYZ="-327.9622, 258.9065, 757.3815" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15764,6 +16082,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="353.7803, 323.7739, 273.3043" /> <!-- Lyse -->
                     <TurnIn QuestId="68078" NpcId="1022344" XYZ="353.7803, 323.7739, 273.3043" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -15804,6 +16123,7 @@
                 <If Condition="GetQuestStep(68079) == 255">
                     <GetTo ZoneId="620" XYZ="257.8011, 314.4075, 416.1592" /> <!-- Young Hellsguard -->
                     <TurnIn QuestId="68079" NpcId="1020645" XYZ="257.8011, 314.4075, 416.1592" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16067,6 +16387,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="321.2177, 324.3033, 390.7072" /> <!-- Mawt -->
                     <TurnIn QuestId="68388" ItemId="2002353" NpcId="1020888" XYZ="321.2177, 324.3033, 390.7072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16082,6 +16403,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="326.8634, 324.5136, 369.8634" /> <!-- Hruodiger -->
                     <TurnIn QuestId="68392" ItemId="2002356" NpcId="1021579" XYZ="326.8634, 324.5136, 369.8634" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16097,6 +16419,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="342.7023, 325.546, 359.5482" /> <!-- Oggery -->
                     <TurnIn QuestId="68391" NpcId="1020886" XYZ="342.7023, 325.546, 359.5482" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16236,6 +16559,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="337.209, 324.3009, 328.5114" /> <!-- Godafre -->
                     <TurnIn QuestId="68386" ItemId="2002350" NpcId="1020887" XYZ="337.209, 324.3009, 328.5114" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16272,6 +16596,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="357.9308, 325.7602, 342.4581" /> <!-- Dob -->
                     <TurnIn QuestId="68389" NpcId="1021580" XYZ="357.9308, 325.7602, 342.4581" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16287,6 +16612,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="331.6853, 324.3033, 387.7164" /> <!-- Garrulous Gall -->
                     <TurnIn QuestId="68385" ItemId="2002348" NpcId="1020885" XYZ="331.6853, 324.3033, 387.7164" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16318,6 +16644,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="337.209, 324.3009, 328.5114" /> <!-- Godafre -->
                     <TurnIn QuestId="68390" ItemId="2002354" NpcId="1020887" XYZ="337.209, 324.3009, 328.5114" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16353,6 +16680,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="313.283, 324.5136, 362.4475" /> <!-- Ponderous Porter -->
                     <TurnIn QuestId="68387" NpcId="1023167" XYZ="313.283, 324.5136, 362.4475" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16458,6 +16786,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="561.4556, 344.1177, 435.3551" /> <!-- Lyse -->
                     <TurnIn QuestId="68080" NpcId="1020647" XYZ="561.4556, 344.1177, 435.3551" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16488,6 +16817,7 @@
                 <If Condition="GetQuestStep(68081) == 255">
                     <GetTo ZoneId="620" XYZ="260.3951, 322.8362, 742.0309" /> <!-- Raubahn -->
                     <TurnIn QuestId="68081" NpcId="1020656" XYZ="260.3951, 322.8362, 742.0309" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16625,6 +16955,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="291.2794, 322.8362, 722.3467" /> <!-- Raganher -->
                     <TurnIn QuestId="68393" NpcId="1020894" XYZ="291.2794, 322.8362, 722.3467" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16721,6 +17052,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="279.53, 322.8362, 710.9025" /> <!-- Rawkin -->
                     <TurnIn QuestId="68395" NpcId="1020896" XYZ="279.53, 322.8362, 710.9025" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16736,6 +17068,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="304.921, 322.8905, 741.0543" /> <!-- Papin -->
                     <TurnIn QuestId="68394" ItemId="2002357" NpcId="1020895" XYZ="304.921, 322.8905, 741.0543" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16778,6 +17111,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="318.1658, 324.3033, 376.8824" /> <!-- M'naago -->
                     <TurnIn QuestId="68082" NpcId="1020660" XYZ="318.1658, 324.3033, 376.8824" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16857,6 +17191,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="283.772, 322.8715, 752.3461" /> <!-- Sagar -->
                     <TurnIn QuestId="68396" NpcId="1020893" XYZ="283.772, 322.8715, 752.3461" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16925,6 +17260,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="315.5413, 322.7993, 717.2502" /> <!-- Berehta -->
                     <TurnIn QuestId="68397" NpcId="1023268" XYZ="315.5413, 322.7993, 717.2502" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -16986,6 +17322,7 @@
                     <!-- </If>
                     <ExFlyTo Name="Able Ant" XYZ="335.8969, 324.5123, 380.0564" />
                     <TurnIn QuestId="68403" NpcId="1021581" XYZ="335.8969, 324.5123, 380.0564" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -17030,6 +17367,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="295.2468, 322.9303, 240.2227" /> <!-- Golden-locked Lieutenant -->
                     <TurnIn QuestId="68398" NpcId="1023270" XYZ="295.2468, 322.9303, 240.2227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17093,6 +17431,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="315.5413, 322.7993, 717.2502" /> <!-- Berehta -->
                     <TurnIn QuestId="68399" ItemId="2002330" NpcId="1023268" XYZ="315.5413, 322.7993, 717.2502" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17144,6 +17483,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="315.5413, 322.7993, 717.2502" /> <!-- Berehta -->
                     <TurnIn QuestId="68400" NpcId="1023268" XYZ="315.5413, 322.7993, 717.2502" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17231,6 +17571,7 @@
                 <If Condition="GetQuestStep(68401) == 255">
                     <GetTo ZoneId="620" XYZ="-293.4158, 258.9065, 788.632" /> <!-- J'dyalani -->
                     <TurnIn QuestId="68401" NpcId="1023259" XYZ="-293.4158, 258.9065, 788.632" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17262,6 +17603,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="347.5242, 324.5123, 378.0117" /> <!-- Dainty Damsel -->
                     <TurnIn QuestId="68402" ItemId="2002358" NpcId="1023340" XYZ="347.5242, 324.5123, 378.0117" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17282,6 +17624,7 @@
                 <If Condition="GetQuestStep(68083) == 255">
                     <GetTo ZoneId="635" XYZ="-53.42188, -0.1167764, -28.61072" /> <!-- Lyse -->
                     <TurnIn QuestId="68083" NpcId="1020665" XYZ="-53.42188, -0.1167764, -28.61072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17358,6 +17701,7 @@
                 <If Condition="GetQuestStep(68405) == 255">
                     <GetTo ZoneId="612" XYZ="-650.1717, 130.1255, -555.4437" /> <!-- Serpent Recruit -->
                     <TurnIn QuestId="68405" NpcId="1023343" XYZ="-650.1717, 130.1255, -555.4437" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17434,6 +17778,7 @@
                 <If Condition="GetQuestStep(68407) == 255">
                     <GetTo ZoneId="612" XYZ="-601.1292, 130, -487.48" /> <!-- Kakalai -->
                     <TurnIn QuestId="68407" ItemId="2002092" NpcId="1019518" XYZ="-601.1292, 130, -487.48" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17443,6 +17788,7 @@
                 <If Condition="GetQuestStep(68408) == 255">
                     <GetTo ZoneId="612" XYZ="-613.1228, 130, -529.839" /> <!-- Serpent Marshal Brookstone -->
                     <TurnIn QuestId="68408" NpcId="1019519" XYZ="-613.1228, 130, -529.839" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17488,6 +17834,7 @@
                 <If Condition="GetQuestStep(68404) == 255">
                     <GetTo ZoneId="635" XYZ="78.93494, 0.04551732, -25.46735" /> <!-- Ranulf -->
                     <TurnIn QuestId="68404" ItemId="2002092" NpcId="1019477" XYZ="78.93494, 0.04551732, -25.46735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17497,6 +17844,7 @@
                 <If Condition="GetQuestStep(68409) == 255">
                     <GetTo ZoneId="635" XYZ="-155.3217, -4.533847, -158.2513" /> <!-- Somber Sibling -->
                     <TurnIn QuestId="68409" NpcId="1021237" XYZ="-155.3217, -4.533847, -158.2513" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17528,6 +17876,7 @@
                 <If Condition="GetQuestStep(68406) == 255">
                     <GetTo ZoneId="620" XYZ="13.53473, 114.3907, -761.4404" /> <!-- Stonemason -->
                     <TurnIn QuestId="68406" ItemId="2002312" NpcId="1023173" XYZ="13.53473, 114.3907, -761.4404" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17615,6 +17964,7 @@
                 <!-- <If Condition="GetQuestStep(68410) == 255">
                     <GetTo ZoneId="620" XYZ="109.9413, 133.8152, -823.9719" /> --> <!-- Gerbert -->
                     <!-- <TurnIn QuestId="68410" NpcId="1021544" XYZ="109.9413, 133.8152, -823.9719" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>
@@ -17627,6 +17977,7 @@
                 <If Condition="GetQuestStep(68411) == 255">
                     <GetTo ZoneId="620" XYZ="48.8136, 117.147, -677.6074" /> <!-- Kindly Qiqirn -->
                     <TurnIn QuestId="68411" NpcId="1023362" XYZ="48.8136, 117.147, -677.6074" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17687,6 +18038,7 @@
                 <If Condition="GetQuestStep(68412) == 255">
                     <GetTo ZoneId="635" XYZ="115.9227, 0.6520415, -9.475891" /> <!-- Gilow -->
                     <TurnIn QuestId="68412" ItemId="2002287" NpcId="1019478" XYZ="115.9227, 0.6520415, -9.475891" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17706,6 +18058,7 @@
                 <If Condition="GetQuestStep(68084) == 255">
                     <GetTo ZoneId="621" XYZ="-651.5145, 50.00002, -3.128174" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68084" NpcId="1021704" XYZ="-651.5145, 50.00002, -3.128174" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17763,6 +18116,7 @@
                 <If Condition="GetQuestStep(68085) == 255">
                     <GetTo ZoneId="621" XYZ="66.54456, 45.41022, 766.476" /> <!-- Lyse -->
                     <TurnIn QuestId="68085" NpcId="1021710" XYZ="66.54456, 45.41022, 766.476" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -17936,6 +18290,7 @@
                 <If Condition="GetQuestStep(68086) == 255">
                     <GetTo ZoneId="621" XYZ="756.9542, 70, 445.4565" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68086" NpcId="1021717" XYZ="756.9542, 70, 445.4565" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18027,6 +18382,7 @@
                 <If Condition="GetQuestStep(68087) == 255">
                     <GetTo ZoneId="621" XYZ="-672.694, 49.99973, 14.99957" /> <!-- Raubahn -->
                     <TurnIn QuestId="68087" NpcId="1021698" XYZ="-672.694, 49.99973, 14.99957" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18082,6 +18438,7 @@
                 <If Condition="GetQuestStep(68419) == 255">
                     <GetTo ZoneId="621" XYZ="-539.6353, 7.611982, 52.14001" /> <!-- J'zula Tia -->
                     <TurnIn QuestId="68419" ItemId="2002316" NpcId="1022991" XYZ="-539.6353, 7.611982, 52.14001" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18205,6 +18562,7 @@
                 <If Condition="GetQuestStep(68416) == 255">
                     <GetTo ZoneId="621" XYZ="-524.59, 8.688546, -19.4248" /> <!-- Betha -->
                     <TurnIn QuestId="68416" NpcId="1022990" XYZ="-524.59, 8.688546, -19.4248" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18214,6 +18572,7 @@
                 <If Condition="GetQuestStep(68413) == 255">
                     <GetTo ZoneId="621" XYZ="-506.6148, 8.7, -40.29907" /> <!-- Munifrid -->
                     <TurnIn QuestId="68413" NpcId="1022992" XYZ="-506.6148, 8.7, -40.29907" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18223,6 +18582,7 @@
                 <If Condition="GetQuestStep(68414) == 255">
                     <GetTo ZoneId="621" XYZ="-657.0687, 50.00002, -23.20898" /> <!-- Dantounuel -->
                     <TurnIn QuestId="68414" NpcId="1023018" XYZ="-657.0687, 50.00002, -23.20898" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18232,6 +18592,7 @@
                 <If Condition="GetQuestStep(68415) == 255">
                     <GetTo ZoneId="621" XYZ="-631.4031, 53.75, -45.48718" /> <!-- Supriya -->
                     <TurnIn QuestId="68415" ItemId="2002361" NpcId="1023020" XYZ="-631.4031, 53.75, -45.48718" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18268,6 +18629,7 @@
                 <If Condition="GetQuestStep(68420) == 255">
                     <GetTo ZoneId="621" XYZ="-507.3777, 8.7, 0.01519775" /> <!-- Topher -->
                     <TurnIn QuestId="68420" NpcId="1022989" XYZ="-507.3777, 8.7, 0.01519775" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18280,6 +18642,7 @@
                 <If Condition="GetQuestStep(68418) == 255">
                     <GetTo ZoneId="621" XYZ="-669.4896, 50.01252, -42.06915" /> <!-- Pamisolaux -->
                     <TurnIn QuestId="68418" ItemId="2002314" NpcId="1022988" XYZ="-669.4896, 50.01252, -42.06915" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18340,6 +18703,7 @@
                 <If Condition="GetQuestStep(68417) == 255">
                     <GetTo ZoneId="621" XYZ="-662.1348, 49.99979, -48.87469" /> <!-- Dorothe -->
                     <TurnIn QuestId="68417" NpcId="1022987" XYZ="-662.1348, 49.99979, -48.87469" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18451,6 +18815,7 @@
                 <If Condition="GetQuestStep(68088) == 255">
                     <GetTo ZoneId="621" XYZ="560.0519, 162, 72.28198" /> <!-- Pipin -->
                     <TurnIn QuestId="68088" NpcId="1021724" XYZ="560.0519, 162, 72.28198" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -18507,6 +18872,7 @@
                 <If Condition="GetQuestStep(68089) == 255">
                     <GetTo ZoneId="635" XYZ="65.38477, -0.4161447, -80.24719" /> <!-- Lyse -->
                     <TurnIn QuestId="68089" NpcId="1021728" XYZ="65.38477, -0.4161447, -80.24719" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] [MSQ] A Realm Reborn (Immortal Flames).xml
+++ b/Questing/[O] [MSQ] A Realm Reborn (Immortal Flames).xml
@@ -45,6 +45,7 @@
                     <If Condition="GetQuestStep(65575) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65575" NpcId="1001140" XYZ="23.78882, -8, 115.8617" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -79,6 +80,7 @@
                         <If Condition="GetQuestStep(65659) == 255">
                             <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                             <TurnIn QuestId="65659" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -118,6 +120,7 @@
                         <If Condition="GetQuestStep(65557) == 255">
                             <GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
                             <TurnIn QuestId="65557" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -154,6 +157,7 @@
                         <If Condition="GetQuestStep(65660) == 255">
                             <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                             <TurnIn QuestId="65660" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -193,6 +197,7 @@
                         <If Condition="GetQuestStep(65558) == 255">
                             <GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
                             <TurnIn QuestId="65558" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -229,6 +234,7 @@
                         <If Condition="GetQuestStep(65621) == 255">
                             <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                             <TurnIn QuestId="65621" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -268,6 +274,7 @@
                         <If Condition="GetQuestStep(65559) == 255">
                             <GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
                             <TurnIn QuestId="65559" NpcId="1000254" ItemId="2000074" XYZ="157.7019, 15.90038, -270.3442" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
                     </If>
 				</If>
@@ -300,6 +307,7 @@
                     <If Condition="GetQuestStep(65564) == 255">
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65564" NpcId="1000421" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -355,6 +363,7 @@
                         <WaitTimer WaitTime="20" />
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65737" NpcId="1000421" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -392,6 +401,7 @@
                     <If Condition="GetQuestStep(65981) == 255">
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65981" NpcId="1000421" ItemId="2000229" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -419,6 +429,7 @@
                     <If Condition="GetQuestStep(65732) == 255">
                         <GetTo ZoneId="148" XYZ="98.25281, -8, -78.44666" /> <!-- Galfrid -->
                         <TurnIn QuestId="65732" NpcId="1000421" XYZ="98.25281, -8, -78.44666" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -453,6 +464,7 @@
                     <If Condition="GetQuestStep(65664) == 255">
                         <GetTo ZoneId="148" XYZ="201.8309, -5.541967, -107.2557" /> <!-- Monranguin -->
                         <TurnIn QuestId="65664" NpcId="1000449" ItemId="2000062" XYZ="201.8309, -5.541967, -107.2557" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -502,6 +514,7 @@
                     <If Condition="GetQuestStep(65711) == 255">
                         <GetTo ZoneId="148" XYZ="287.9224, -3.296992, -32.6391" /> <!-- Pauline -->
                         <TurnIn QuestId="65711" NpcId="1000685" ItemId="2000141,2000146,2000147" XYZ="287.9224, -3.296992, -32.6391" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -536,6 +549,7 @@
                     <If Condition="GetQuestStep(65734) == 255">
                         <GetTo ZoneId="148" XYZ="287.9224, -3.296992, -32.6391" /> <!-- Pauline -->
                         <TurnIn QuestId="65734" NpcId="1000685" XYZ="287.9224, -3.296992, -32.6391" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -576,6 +590,7 @@
                     <If Condition="GetQuestStep(65661) == 255">
                         <GetTo ZoneId="148" XYZ="106.8589, -8, -75.66956" /> <!-- Tsubh Khamazom -->
                         <TurnIn QuestId="65661" NpcId="1000408" ItemId="2000071" XYZ="106.8589, -8, -75.66956" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -623,6 +638,7 @@
                     <If Condition="GetQuestStep(65665) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65665" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -665,6 +681,7 @@
                     <If Condition="GetQuestStep(65712) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65712" NpcId="1000470" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -696,6 +713,7 @@
                     <If Condition="GetQuestStep(65910) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65910" NpcId="1000470" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -721,6 +739,7 @@
                     <If Condition="GetQuestStep(65912) == 255">
                         <GetTo ZoneId="148" XYZ="-125.2308, 4.157372, -43.59509" /> <!-- Roseline -->
                         <TurnIn QuestId="65912" NpcId="1000748" XYZ="-125.2308, 4.157372, -43.59509" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -763,6 +782,7 @@
                     <If Condition="GetQuestStep(65913) == 255">
                         <GetTo ZoneId="148" XYZ="-193.225, 56.26458, -116.4721" /> <!-- Theodore -->
                         <TurnIn QuestId="65913" NpcId="1000436" XYZ="-193.225, 56.26458, -116.4721" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -788,6 +808,7 @@
                     <If Condition="GetQuestStep(65915) == 255">
                         <GetTo ZoneId="148" XYZ="-125.2308, 4.157372, -43.59509" /> <!-- Roseline -->
                         <TurnIn QuestId="65915" NpcId="1000748" ItemId="2000191" XYZ="-125.2308, 4.157372, -43.59509" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -813,6 +834,7 @@
                     <If Condition="GetQuestStep(65916) == 255">
                         <GetTo ZoneId="148" XYZ="-66.7583, 0.2, 11.36792" /> <!-- Eylgar -->
                         <TurnIn QuestId="65916" NpcId="1000741" ItemId="2000188" XYZ="-66.7583, 0.2, 11.36792" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -840,6 +862,7 @@
                     <If Condition="GetQuestStep(65692) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65692" NpcId="1000470" ItemId="2000092" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -861,6 +884,7 @@
                     <If Condition="GetQuestStep(65917) == 255">
                         <GetTo ZoneId="148" XYZ="47.95898, -24, 228.5343" /> <!-- Lothaire -->
                         <TurnIn QuestId="65917" NpcId="1000491" XYZ="47.95898, -24, 228.5343" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -888,6 +912,7 @@
                     <If Condition="GetQuestStep(65918) == 255">
                         <GetTo ZoneId="148" XYZ="47.95898, -24, 228.5343" /> <!-- Lothaire -->
                         <TurnIn QuestId="65918" NpcId="1000491" XYZ="47.95898, -24, 228.5343" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -909,6 +934,7 @@
                     <If Condition="GetQuestStep(65920) == 255">
                         <GetTo ZoneId="148" XYZ="178.3322, -32.01522, 333.3027" /> <!-- Armelle -->
                         <TurnIn QuestId="65920" NpcId="1000503" XYZ="178.3322, -32.01522, 333.3027" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -930,6 +956,7 @@
                     <If Condition="GetQuestStep(65695) == 255">
                         <GetTo ZoneId="148" XYZ="178.3322, -32.01522, 333.3027" /> <!-- Armelle -->
                         <TurnIn QuestId="65695" NpcId="1000503" XYZ="178.3322, -32.01522, 333.3027" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -956,6 +983,7 @@
                     <If Condition="GetQuestStep(65923) == 255">
                         <GetTo ZoneId="148" XYZ="-59.00665, -0.01083579, 26.41333" /> <!-- Keitha -->
                         <TurnIn QuestId="65923" NpcId="1000470" ItemId="2000237" XYZ="-59.00665, -0.01083579, 26.41333" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1016,6 +1044,7 @@
                     <If Condition="GetQuestStep(65697) == 255">
                         <GetTo ZoneId="148" XYZ="-60.47156, 0.2, 6.301941" /> <!-- Luquelot -->
                         <TurnIn QuestId="65697" NpcId="1000471" XYZ="-60.47156, 0.2, 6.301941" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1033,6 +1062,7 @@
                     <If Condition="GetQuestStep(65982) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65982" NpcId="1000100" ItemId="2000240" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1086,6 +1116,7 @@
                         </If>
                         <MoveTo Name="Lewin" XYZ="2.869185, 0.5000247, -3.373355" />
                         <TurnIn QuestId="65983" NpcId="1003061" XYZ="-0.01531982, 0.500025, -4.379395" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1120,6 +1151,7 @@
                     <If Condition="GetQuestStep(65984) == 255">
                         <GetTo ZoneId="132" XYZ="25.30511, -8, 113.7628" /> <!-- Mother Miounne -->
                         <TurnIn QuestId="65984" NpcId="1000100" ItemId="2000250" XYZ="23.81927, -8, 115.9227" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1154,6 +1186,7 @@
                         </If>
 					    <MoveTo Name="Kan-E-Senna" XYZ="4.898132, -1.92944, -0.1983643" />
                         <TurnIn QuestId="65985" NpcId="1003027" XYZ="4.898132, -1.92944, -0.1983643" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1308,6 +1341,7 @@
                         </If>
                         <GetTo ZoneId="131" XYZ="-24.12457, 38, 85.31323" /> <!-- Bartholomew -->
                         <TurnIn QuestId="66043" NpcId="1001821" ItemId="2000457" XYZ="-24.12457, 38, 85.31323" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -1325,6 +1359,7 @@
                     <If Condition="GetQuestStep(66210) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66210" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -1352,6 +1387,7 @@
                     <If Condition="GetQuestStep(65643) == 255">
                         <GetTo ZoneId="128" XYZ="18.00043, 40.21601, -5.336614" /> <!-- Baderon -->
                         <TurnIn QuestId="65643" NpcId="1002697" XYZ="18.00043, 40.21601, -5.336614" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1391,6 +1427,7 @@
                         <If Condition="GetQuestStep(65645) == 255">
                             <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                             <TurnIn QuestId="65645" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -1430,6 +1467,7 @@
                         <If Condition="GetQuestStep(65989) == 255">
                             <GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
                             <TurnIn QuestId="65989" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -1471,6 +1509,7 @@
                         <If Condition="GetQuestStep(65644) == 255">
                             <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                             <TurnIn QuestId="65644" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -1510,6 +1549,7 @@
                         <If Condition="GetQuestStep(65847) == 255">
                             <GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
                             <TurnIn QuestId="65847" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -1542,6 +1582,7 @@
                     <If Condition="GetQuestStep(65998) == 255">
                         <GetTo ZoneId="134" XYZ="205.4218, 112.7266, -223.7576" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="65998" NpcId="1002626" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1595,6 +1636,7 @@
                         <WaitTimer WaitTime="20" />
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="65999" NpcId="1002626" XYZ="205.052, 112.6122, -222.6982" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1631,6 +1673,7 @@
                     <If Condition="GetQuestStep(66079) == 255">
                         <GetTo ZoneId="134" XYZ="207.2633, 112.8604, -222.4308" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66079" NpcId="1002626" ItemId="2000522" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1658,6 +1701,7 @@
                     <If Condition="GetQuestStep(66000) == 255">
                         <GetTo ZoneId="134" XYZ="203.3827, 111.9367, -215.7475" /> <!-- Gurcant -->
                         <TurnIn QuestId="66000" NpcId="1002627" XYZ="203.3264, 111.7238, -213.9163" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
             </If>
@@ -1689,6 +1733,7 @@
                     <If Condition="GetQuestStep(66001) == 255">
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66001" NpcId="1002626" XYZ="207.2633, 112.8604, -222.4308" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1734,6 +1779,7 @@
                     <If Condition="GetQuestStep(66002) == 255">
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66002" NpcId="1002626" ItemId="2000357" XYZ="205.052, 112.6122, -222.6982" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1771,6 +1817,7 @@
                     <If Condition="GetQuestStep(66003) == 255">
                         <GetTo ZoneId="134" XYZ="0.04577637, 57.85028, -308.7664" /> <!-- Pfrewahl -->
                         <TurnIn QuestId="66003" NpcId="1002631" ItemId="2000347" XYZ="0.04577637, 57.85028, -308.7664" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1796,6 +1843,7 @@
                     <If Condition="GetQuestStep(66004) == 255">
                         <GetTo ZoneId="134" XYZ="205.052, 112.6122, -222.6982" /> <!-- Staelwyrn -->
                         <TurnIn QuestId="66004" NpcId="1002626" XYZ="205.052, 112.6122, -222.6982" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1847,6 +1895,7 @@
                     <If Condition="GetQuestStep(66005) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66005" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1886,6 +1935,7 @@
                     <If Condition="GetQuestStep(65933) == 255">
                         <GetTo ZoneId="134" XYZ="-283.6805, 10.59338, -249.3478" /> <!-- Wyrkrhit -->
                         <TurnIn QuestId="65933" NpcId="1003239" XYZ="-283.6805, 10.59338, -249.3478" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
                 </If>
 			</If>
@@ -1913,6 +1963,7 @@
                     <If Condition="GetQuestStep(65934) == 255">
                         <GetTo ZoneId="134" XYZ="-283.6805, 10.59338, -249.3478" /> <!-- Wyrkrhit -->
                         <TurnIn QuestId="65934" NpcId="1003239" XYZ="-283.6805, 10.59338, -249.3478" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1940,6 +1991,7 @@
                     <If Condition="GetQuestStep(65940) == 255">
                         <GetTo ZoneId="138" XYZ="650.7209, 7.856782, 527.2144" /> <!-- Lyulf -->
                         <TurnIn QuestId="65940" NpcId="1003244" ItemId="2000345" XYZ="650.7209, 7.856782, 527.2144" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1979,6 +2031,7 @@
                     <If Condition="GetQuestStep(65939) == 255">
                         <GetTo ZoneId="128" XYZ="-32.02869, 41.49999, 208.3923" /> <!-- H'naanza -->
                         <TurnIn QuestId="65939" NpcId="1001000" XYZ="-32.02869, 41.49999, 208.3923" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -1996,6 +2049,7 @@
                     <If Condition="GetQuestStep(65942) == 255">
                         <GetTo ZoneId="135" XYZ="247.364, 14.02301, 611.9325" /> <!-- Ahtbyrm -->
                         <TurnIn QuestId="65942" NpcId="1002238" ItemId="2000217" XYZ="247.364, 14.02301, 611.9325" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2021,6 +2075,7 @@
                         <SendChat Message="/targetnpc" />
                         <SendChat Message="/doubt" />
                         <TurnIn QuestId="65948" NpcId="1002274" XYZ="-34.65332, 8.921356, 861.4479" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2060,6 +2115,7 @@
                     <If Condition="GetQuestStep(65951) == 255">
                         <GetTo ZoneId="135" XYZ="247.364, 14.02301, 611.9325" /> <!-- Ahtbyrm -->
                         <TurnIn QuestId="65951" NpcId="1002238" XYZ="247.364, 14.02301, 611.9325" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2095,6 +2151,7 @@
                     <If Condition="GetQuestStep(65949) == 255">
                         <GetTo ZoneId="135" XYZ="167.5593, 14.09592, 683.9244" /> <!-- Ghimthota -->
                         <TurnIn QuestId="65949" NpcId="1002237" XYZ="167.5593, 14.09592, 683.9244" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2152,6 +2209,7 @@
                     <If Condition="GetQuestStep(65950) == 255">
                         <GetTo ZoneId="135" XYZ="167.5593, 14.09592, 683.9244" /> <!-- Ghimthota -->
                         <TurnIn QuestId="65950" NpcId="1002237" XYZ="167.5593, 14.09592, 683.9244" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2169,6 +2227,7 @@
                     <If Condition="GetQuestStep(66225) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66225" NpcId="1000972" ItemId="2000520" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
 					</If>
 				</If>
 			</If>
@@ -2211,6 +2270,7 @@
                     <If Condition="GetQuestStep(66080) == 255">
                         <GetTo ZoneId="128" XYZ="-3.03656, 48.168, -261.7075" /> <!-- Reyner -->
                         <TurnIn QuestId="66080" NpcId="1003282" XYZ="-3.03656, 48.168, -261.7075" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2236,6 +2296,7 @@
                     <If Condition="GetQuestStep(66226) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66226" NpcId="1000972" ItemId="2000523" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2271,6 +2332,7 @@
                         </If>
 					    <MoveTo Name="Merlwyb" XYZ="-0.04577637, 1.600142, -7.003906" />
                         <TurnIn QuestId="66081" NpcId="1002694" XYZ="-0.04577637, 1.600142, -7.003906" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2412,6 +2474,7 @@
                         </If>
                         <GetTo ZoneId="131" XYZ="-24.12457, 38, 85.31323" /> <!-- Bartholomew -->
                         <TurnIn QuestId="66082" NpcId="1001821" ItemId="2000459" XYZ="-24.12457, 38, 85.31323" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2429,6 +2492,7 @@
                     <If Condition="GetQuestStep(66210) == 255">
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66210" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2452,6 +2516,7 @@
                     <If Condition="GetQuestStep(66130) == 255">
                         <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                         <TurnIn QuestId="66130" NpcId="1003988" XYZ="21.07263, 7.45, -78.84338" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2486,6 +2551,7 @@
                         <If Condition="GetQuestStep(66104) == 255">
                             <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi-->
                             <TurnIn QuestId="66104" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2525,6 +2591,7 @@
                         <If Condition="GetQuestStep(65789) == 255">
                             <GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
                             <TurnIn QuestId="65789" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
                     </If>
                 </If>
@@ -2561,6 +2628,7 @@
                         <If Condition="GetQuestStep(66105) == 255">
                             <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                             <TurnIn QuestId="66105" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2600,6 +2668,7 @@
                         <If Condition="GetQuestStep(66069) == 255">
                             <GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
                             <TurnIn QuestId="66069" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2636,6 +2705,7 @@
                         <If Condition="GetQuestStep(66106) == 255">
                             <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                             <TurnIn QuestId="66106" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2675,6 +2745,7 @@
                         <If Condition="GetQuestStep(65881) == 255">
                             <GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
                             <TurnIn QuestId="65881" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+                            <WaitTimer WaitTime="2"/>
                         </If>
 					</If>
 				</If>
@@ -2700,6 +2771,7 @@
                     <If Condition="GetQuestStep(66131) == 255">
                         <GetTo ZoneId="141" XYZ="75.33374, 2.135708, 316.3347" /> <!-- Papashan -->
                         <TurnIn QuestId="66131" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2741,6 +2813,7 @@
                     <If Condition="GetQuestStep(66207) == 255">
                         <GetTo ZoneId="141" XYZ="75.33374, 2.135708, 316.3347" /> <!-- Papashan -->
                         <TurnIn QuestId="66207" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2774,6 +2847,7 @@
                     <If Condition="GetQuestStep(66086) == 255">
                         <GetTo ZoneId="141" XYZ="75.33374, 2.135708, 316.3347" /> <!-- Papashan -->
                         <TurnIn QuestId="66086" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2800,6 +2874,7 @@
 				<If Condition="GetQuestStep(65839) == 255">
                     <GetTo ZoneId="141" XYZ="-99.4126, -11.39856, -41.73346" /> <!-- Roger -->
 					<TurnIn QuestId="65839" NpcId="1001541" ItemId="2000238" XYZ="-99.4126, -11.39856, -41.73346" />
+					<WaitTimer WaitTime="2"/>
 				</If>
 			</If>
 
@@ -2829,6 +2904,7 @@
                     <If Condition="GetQuestStep(65860) == 255">
                         <GetTo ZoneId="141" XYZ="-96.84007, -11.35, -42.03054" /> <!-- Roger -->
                         <TurnIn QuestId="65860" NpcId="1001541" ItemId="2000234" XYZ="-99.4126, -11.39856, -41.73346" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2856,6 +2932,7 @@
                     <If Condition="GetQuestStep(65841) == 255">
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65841" NpcId="1001447" ItemId="2000168" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2894,6 +2971,7 @@
                         <WaitTimer WaitTime="20" />
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65842" NpcId="1001447" ItemId="2000410" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2921,6 +2999,7 @@
                     <If Condition="GetQuestStep(65843) == 255">
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65843" NpcId="1001447" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2949,6 +3028,7 @@
                     <If Condition="GetQuestStep(65863) == 255">
                         <GetTo ZoneId="141" XYZ="-32.6391, -1.033258, -148.5161" /> <!-- Warin -->
                         <TurnIn QuestId="65863" NpcId="1001447" XYZ="-32.6391, -1.033258, -148.5161" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -2999,6 +3079,7 @@
                     <If Condition="GetQuestStep(65856) == 255">
                         <GetTo ZoneId="130" XYZ="21.69085, 6.999996, -80.55646" /> <!-- Momodi -->
                         <TurnIn QuestId="65856" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3034,6 +3115,7 @@
                     <If Condition="GetQuestStep(66159) == 255">
                         <GetTo ZoneId="140" XYZ="60.9292, 45.14532, -205.005" /> <!-- Dadanen -->
                         <TurnIn QuestId="66159" NpcId="1002065" XYZ="60.9292, 45.14532, -205.005" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3051,6 +3133,7 @@
                     <If Condition="GetQuestStep(65864) == 255">
                         <GetTo ZoneId="140" XYZ="240.9857, 58.35799, -160.998" /> <!-- Drunken Stag -->
                         <TurnIn QuestId="65864" NpcId="1002061" ItemId="2000368" XYZ="240.9857, 58.35799, -160.998" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3078,6 +3161,7 @@
                     <If Condition="GetQuestStep(66039) == 255">
                         <GetTo ZoneId="140" XYZ="240.9857, 58.35799, -160.998" /> <!-- Drunken Stag -->
                         <TurnIn QuestId="66039" NpcId="1002061" ItemId="2000369" XYZ="240.9857, 58.35799, -160.998" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3105,6 +3189,7 @@
                     <If Condition="GetQuestStep(65865) == 255">
                         <GetTo ZoneId="140" XYZ="59.61694, 45.14532, -215.9" /> <!-- Fufulupa -->
                         <TurnIn QuestId="65865" NpcId="1002058" XYZ="59.61694, 45.14532, -215.9" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3126,6 +3211,7 @@
                     <If Condition="GetQuestStep(65866) == 255">
                         <GetTo ZoneId="141" XYZ="94.46863, 0.3407532, -272.6024" /> <!-- Leofric -->
                         <TurnIn QuestId="65866" NpcId="1001605" ItemId="2000377" XYZ="94.46863, 0.3407532, -272.6024" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3163,6 +3249,7 @@
                     <If Condition="GetQuestStep(65867) == 255">
                         <GetTo ZoneId="141" XYZ="94.46863, 0.3407532, -272.6024" /> <!-- Leofric -->
                         <TurnIn QuestId="65867" NpcId="1001605" XYZ="94.46863, 0.3407532, -272.6024" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3183,6 +3270,7 @@
                         <!-- Maybe set Horizon as the home point here? -->
 
                         <TurnIn QuestId="65868" NpcId="1002058" ItemId="2000381" XYZ="59.61694, 45.14532, -215.9" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3206,6 +3294,7 @@
                     <If Condition="GetQuestStep(65869) == 255">
                         <GetTo ZoneId="140" XYZ="-176.9589, 15.65209, -270.985" /> <!-- Totoruna -->
                         <TurnIn QuestId="65869" NpcId="1002066" XYZ="-176.9589, 15.65209, -270.985" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3223,6 +3312,7 @@
                     <If Condition="GetQuestStep(65870) == 255">
                         <GetTo ZoneId="140" XYZ="-284.5045, 13.48067, -144.9455" /> <!-- Raffe -->
                         <TurnIn QuestId="65870" NpcId="1002068" XYZ="-284.5045, 13.48067, -144.9455" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3254,6 +3344,7 @@
                     <If Condition="GetQuestStep(65871) == 255">
                         <GetTo ZoneId="140" XYZ="-324.7883, 17.58331, -127.6113" /> <!-- Merilda -->
                         <TurnIn QuestId="65871" NpcId="1002071" ItemId="2000382,2000383,2000384" XYZ="-324.7883, 17.58331, -127.6113" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3301,6 +3392,7 @@
                     <If Condition="GetQuestStep(65872) == 255">
                         <GetTo ZoneId="140" XYZ="59.61694, 45.14532, -215.9" /> <!-- Fufulupa -->
                         <TurnIn QuestId="65872" NpcId="1002058" XYZ="59.61694, 45.14532, -215.9" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3318,6 +3410,7 @@
                     <If Condition="GetQuestStep(66164) == 255">
                         <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                         <TurnIn QuestId="66164" NpcId="1001353" ItemId="2000396" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3372,6 +3465,7 @@
                         </If>
 					    <MoveTo Name="Papashan" XYZ="0.01519775, 0.01480777, -1.693787" />
                         <TurnIn QuestId="66087" NpcId="1004003" XYZ="0.01519775, 0.01480777, -1.693787" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3406,6 +3500,7 @@
                     <If Condition="GetQuestStep(66177) == 255">
                         <GetTo ZoneId="130" XYZ="21.75308, 6.999996, -80.53974" /> <!-- Momodi -->
                         <TurnIn QuestId="66177" NpcId="1001353" ItemId="2000405" XYZ="21.07263, 7.45, -78.78235" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3438,6 +3533,7 @@
                         </If>
                         <GetTo ZoneId="130" XYZ="-139.2996, 4.1, -113.4814" /> <!-- Raubahn -->
                         <TurnIn QuestId="66088" NpcId="1004004" XYZ="-139.2996, 4.1, -113.4814" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3582,6 +3678,7 @@
                         </If>
                         <GetTo ZoneId="133" XYZ="-159.411, 4.054098, -4.104736" /> <!-- Silent Conjurer -->
                         <TurnIn QuestId="66064" NpcId="1000460" ItemId="2000446" XYZ="-159.411, 4.054098, -4.104736" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3608,6 +3705,7 @@
                         </If>
                         <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                         <TurnIn QuestId="66209" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                        <WaitTimer WaitTime="2"/>
                     </If>
 				</If>
 			</If>
@@ -3643,6 +3741,7 @@
                 <If Condition="GetQuestStep(65781) == 255">
                     <GetTo ZoneId="128" XYZ="17.79586, 40.21601, -5.386823" /> <!-- Baderon -->
                     <TurnIn QuestId="65781" NpcId="1000972" XYZ="17.79586, 40.21601, -5.386823" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3660,6 +3759,7 @@
                 <If Condition="GetQuestStep(66212) == 255">
                     <GetTo ZoneId="132" XYZ="25.54354, -8, 115.3249" /> <!-- Mother Miounne -->
                     <TurnIn QuestId="66212" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3691,6 +3791,7 @@
                 <If Condition="GetQuestStep(66213) == 255">
                     <GetTo ZoneId="132" XYZ="25.54354, -8, 115.3249" /> <!-- Mother Miounne -->
                     <TurnIn QuestId="66213" NpcId="1000100" XYZ="23.81927, -8, 115.9227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3708,6 +3809,7 @@
                 <If Condition="GetQuestStep(66214) == 255">
                     <GetTo ZoneId="130" XYZ="21.73813, 6.999996, -80.83638" /> <!-- Momodi -->
                     <TurnIn QuestId="66214" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3759,6 +3861,7 @@
                 <If Condition="GetQuestStep(66196) == 255">
                     <GetTo ZoneId="130" XYZ="21.54825, 6.999996, -80.60168" /> <!-- Momodi -->
                     <TurnIn QuestId="66196" NpcId="1001353" XYZ="21.07263, 7.45, -78.78235" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3789,6 +3892,7 @@
                     </If>
                     <MoveTo Name="Scion Of The Seventh Dawn" XYZ="22.50702, 0.9999986, -2.02948" />
                     <TurnIn QuestId="66045" NpcId="1005012" XYZ="22.50702, 0.9999986, -2.02948" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3828,6 +3932,7 @@
                 <If Condition="GetQuestStep(66046) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66046" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3855,6 +3960,7 @@
                 <If Condition="GetQuestStep(66154) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66154" NpcId="1003929" ItemId="2000399" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3892,6 +3998,7 @@
                 <If Condition="GetQuestStep(66155) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66155" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3929,6 +4036,7 @@
                 <If Condition="GetQuestStep(66156) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66156" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3960,6 +4068,7 @@
                 <If Condition="GetQuestStep(66157) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66157" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3997,6 +4106,7 @@
                 <If Condition="GetQuestStep(66158) == 255">
                     <GetTo ZoneId="145" XYZ="-378.6526, -55.75492, 106.7979" /> <!-- Isembard -->
                     <TurnIn QuestId="66158" NpcId="1003929" XYZ="-378.6526, -55.75492, 106.7979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4046,6 +4156,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66110" NpcId="1005116" ItemId="2001110" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4085,6 +4196,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="65808" NpcId="1005116" ItemId="2000462" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4186,6 +4298,7 @@
                     </If>
                     <MoveTo Name="Scion Of The Seventh Dawn" XYZ="22.50702, 0.9999986, -2.02948" />
                     <TurnIn QuestId="65879" NpcId="1005012" ItemId="2001110" XYZ="22.50702, 0.9999986, -2.02948" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4253,6 +4366,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66047" NpcId="1005122" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4304,6 +4418,7 @@
                 <If Condition="GetQuestStep(66218) == 255">
                     <GetTo ZoneId="130" XYZ="-142.8694, 4.1, -106.2359" /> --> <!-- Flame Personnel Officer -->
                     <!-- <TurnIn QuestId="66218" NpcId="1002391" XYZ="-144.3962, 4.1, -107.2252" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -4349,6 +4464,7 @@
                 <If Condition="GetQuestStep(66218) == 255">
                     <GetTo ZoneId="130" XYZ="-142.8694, 4.1, -106.2359" /> --> <!-- Flame Personnel Officer -->
                     <!-- <TurnIn QuestId="66218" NpcId="1002391" XYZ="-144.3962, 4.1, -107.2252" />
+ <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If> -->
@@ -4394,6 +4510,7 @@
                 <If Condition="GetQuestStep(66218) == 255">
                     <GetTo ZoneId="130" XYZ="-142.8694, 4.1, -106.2359" /> <!-- Flame Personnel Officer -->
                     <TurnIn QuestId="66218" NpcId="1002391" XYZ="-144.3962, 4.1, -107.2252" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4420,6 +4537,7 @@
                     </If>
                     <MoveTo Name="Scion Of The Seventh Dawn" XYZ="22.50702, 0.9999986, -2.02948" />
                     <TurnIn QuestId="66221" NpcId="1005012" ItemId="2001110" XYZ="22.50702, 0.9999986, -2.02948" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4446,6 +4564,7 @@
                 <If Condition="GetQuestStep(66049) == 255">
                     <GetTo ZoneId="132" XYZ="-75.48645, -0.5013741, -5.081299" /> <!-- Vorsaile Heuloix -->
                     <TurnIn QuestId="66049" NpcId="1000168" XYZ="-75.48645, -0.5013741, -5.081299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4475,6 +4594,7 @@
                 <If Condition="GetQuestStep(65698) == 255">
                     <GetTo ZoneId="133" XYZ="-24.24664, 10.04002, -262.7451" /> <!-- Millith Ironheart -->
                     <TurnIn QuestId="65698" NpcId="1009297" XYZ="-24.24664, 10.04002, -262.7451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4517,6 +4637,7 @@
                 <If Condition="GetQuestStep(66244) == 255">
                     <GetTo ZoneId="152" XYZ="-236.9269, 3.543579, 283.4973" /> <!-- Amelain -->
                     <TurnIn QuestId="66244" NpcId="1006188" ItemId="2000826" XYZ="-236.9269, 3.543579, 283.4973" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4548,6 +4669,7 @@
                 <If Condition="GetQuestStep(66245) == 255">
                     <GetTo ZoneId="152" XYZ="-238.1782, 3.543561, 283.7109" /> <!-- Rolfe Hawthorne -->
                     <TurnIn QuestId="66245" NpcId="1000540" XYZ="-238.1782, 3.543561, 283.7109" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4573,6 +4695,7 @@
                 <If Condition="GetQuestStep(66246) == 255">
                     <GetTo ZoneId="152" XYZ="-238.1782, 3.543561, 283.7109" /> <!-- Rolfe Hawthorne -->
                     <TurnIn QuestId="66246" NpcId="1000540" ItemId="2000831" XYZ="-238.1782, 3.543561, 283.7109" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4608,6 +4731,7 @@
                 <If Condition="GetQuestStep(66251) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66251" NpcId="1000580" ItemId="2000573,2000574" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4640,6 +4764,7 @@
                 <If Condition="GetQuestStep(66253) == 255">
                     <GetTo ZoneId="152" XYZ="21.98816, -3.766478, 209.9794" /> <!-- Yda -->
                     <TurnIn QuestId="66253" NpcId="1006674" XYZ="21.98816, -3.766478, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4683,6 +4808,7 @@
                 <If Condition="GetQuestStep(66254) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66254" NpcId="1000580" ItemId="2000577" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4715,6 +4841,7 @@
                 <If Condition="GetQuestStep(66255) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66255" NpcId="1000580" ItemId="2000578" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4761,6 +4888,7 @@
                 <If Condition="GetQuestStep(66260) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn NpcId="1000580" QuestId="66260" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4786,6 +4914,7 @@
                 <If Condition="GetQuestStep(66261) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66261" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4823,6 +4952,7 @@
                 <If Condition="GetQuestStep(66262) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66262" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4866,6 +4996,7 @@
                 <If Condition="GetQuestStep(66269) == 255">
                     <GetTo ZoneId="139" XYZ="-334.0658, -0.813661, 148.9127" /> <!-- Teteroon -->
                     <TurnIn QuestId="66269" NpcId="1006193" ItemId="2000587" XYZ="-334.0658, -0.813661, 148.9127" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4893,6 +5024,7 @@
                 <If Condition="GetQuestStep(66270) == 255">
                     <GetTo ZoneId="139" XYZ="-334.0658, -0.813661, 148.9127" /> <!-- Teteroon -->
                     <TurnIn QuestId="66270" NpcId="1006193" ItemId="2000589,2000590" XYZ="-334.0658, -0.813661, 148.9127" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4910,6 +5042,7 @@
                 <If Condition="GetQuestStep(66273) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66273" NpcId="1000590" ItemId="2000594" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4938,6 +5071,7 @@
                 <If Condition="GetQuestStep(66274) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66274" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4991,6 +5125,7 @@
                 <If Condition="GetQuestStep(66276) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66276" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5022,6 +5157,7 @@
                 <If Condition="GetQuestStep(66050) == 255">
                     <GetTo ZoneId="153" XYZ="-167.4839, 9.869229, -80.15215" /> <!-- Buscarron -->
                     <TurnIn QuestId="66050" NpcId="1000590" XYZ="-165.9419, 9.869228, -81.34589" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5048,6 +5184,7 @@
                 <If Condition="GetQuestStep(66278) == 255">
                     <GetTo ZoneId="153" XYZ="-170.8248, 9.964111, -84.15356" /> <!-- Auphiliot -->
                     <TurnIn QuestId="66278" NpcId="1000598" XYZ="-170.8248, 9.964111, -84.15356" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5065,6 +5202,7 @@
                 <If Condition="GetQuestStep(66279) == 255">
                     <GetTo ZoneId="152" XYZ="21.46942, -4.575078, 221.7593" /> <!-- Knolexia -->
                     <TurnIn QuestId="66279" NpcId="1000576" ItemId="2000595" XYZ="21.46942, -4.575078, 221.7593" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5086,6 +5224,7 @@
                 <If Condition="GetQuestStep(66280) == 255">
                     <GetTo ZoneId="132" XYZ="-75.48645, -0.5013741, -5.081299" /> <!-- Vorsaile Heuloix -->
                     <TurnIn QuestId="66280" NpcId="1000168" ItemId="2000596" XYZ="-75.48645, -0.5013741, -5.081299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5128,6 +5267,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66282" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5158,6 +5298,7 @@
                 <If Condition="GetQuestStep(66283) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66283" NpcId="1006196" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5181,6 +5322,7 @@
                 <If Condition="GetQuestStep(66284) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66284" NpcId="1006196" ItemId="2000602" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5202,6 +5344,7 @@
                 <If Condition="GetQuestStep(66288) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66288" NpcId="1006196" ItemId="2000601" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5261,6 +5404,7 @@
                 <If Condition="GetQuestStep(66292) == 255">
                     <GetTo ZoneId="145" XYZ="-63.98114, -20.29624, -5.142395" /> <!-- Hihibaru -->
                     <TurnIn QuestId="66292" NpcId="1006196" ItemId="2000935" XYZ="-63.98114, -20.29624, -5.142395" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5282,6 +5426,7 @@
                 <If Condition="GetQuestStep(66293) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66293" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5305,6 +5450,7 @@
                 <If Condition="GetQuestStep(66297) == 255">
                     <GetTo ZoneId="146" XYZ="-181.0483, 28.21407, -402.0295" /> <!-- Gisilbehrt -->
                     <TurnIn QuestId="66297" NpcId="1006217" XYZ="-181.0483, 28.21407, -402.0295" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5331,6 +5477,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66298" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5376,6 +5523,7 @@
                 <If Condition="GetQuestStep(66299) == 255">
                     <GetTo ZoneId="153" XYZ="193.5302, 7.855128, -25.86407" /> <!-- Albreda -->
                     <TurnIn QuestId="66299" NpcId="1006219" XYZ="193.5302, 7.855128, -25.86407" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5401,6 +5549,7 @@
                 <If Condition="GetQuestStep(66301) == 255">
                     <GetTo ZoneId="153" XYZ="207.7821, 6.103813, -39.53619" /> <!-- Meffrid -->
                     <TurnIn QuestId="66301" NpcId="1000332" XYZ="207.7821, 6.103813, -39.53619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5443,6 +5592,7 @@
                 <If Condition="GetQuestStep(66310) == 255">
                     <GetTo ZoneId="153" XYZ="209.308, 6.104166, -39.93292" /> <!-- Faramund -->
                     <TurnIn QuestId="66310" NpcId="1006680" ItemId="2000613" XYZ="209.308, 6.104166, -39.93292" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5477,6 +5627,7 @@
                 <If Condition="GetQuestStep(66311) == 255">
                     <GetTo ZoneId="153" XYZ="207.7821, 6.103813, -39.53619" /> <!-- Meffrid -->
                     <TurnIn QuestId="66311" NpcId="1000332" XYZ="207.7821, 6.103813, -39.53619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5494,6 +5645,7 @@
                 <If Condition="GetQuestStep(66312) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66312" NpcId="1006215" ItemId="2000614" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5518,6 +5670,7 @@
                 <If Condition="GetQuestStep(66313) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66313" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5544,6 +5697,7 @@
                 <If Condition="GetQuestStep(66314) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66314" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5589,6 +5743,7 @@
                 <If Condition="GetQuestStep(66318) == 255">
                     <GetTo ZoneId="146" XYZ="-227.3442, 26.16842, -352.9869" /> <!-- Gundobald -->
                     <TurnIn QuestId="66318" NpcId="1006215" XYZ="-227.3442, 26.16842, -352.9869" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5615,6 +5770,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66319" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5671,6 +5827,7 @@
                     <GetTo ZoneId="154" XYZ="13.93146, -44.8656, 257.9537" /> <!-- Medrod -->
                     <RunCode Name="Terror_at_Fallgourd" />
                     <TurnIn QuestId="66320" NpcId="1006240" XYZ="13.93146, -44.8656, 257.9537" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5705,6 +5862,7 @@
                 <If Condition="GetQuestStep(66321) == 255">
                     <GetTo ZoneId="154" XYZ="15.3963, -44.8656, 259.327" /> <!-- Aideen -->
                     <TurnIn QuestId="66321" NpcId="1006241" XYZ="15.3963, -44.8656, 259.327" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5726,6 +5884,7 @@
                 <If Condition="GetQuestStep(66322) == 255">
                     <GetTo ZoneId="154" XYZ="13.96191, -44.8656, 255.1461" /> <!-- Ivaurault -->
                     <TurnIn QuestId="66322" NpcId="1006242" XYZ="13.96191, -44.8656, 255.1461" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5759,6 +5918,7 @@
                 <If Condition="GetQuestStep(66323) == 255">
                     <GetTo ZoneId="154" XYZ="15.3963, -44.8656, 259.327" /> <!-- Aideen -->
                     <TurnIn QuestId="66323" NpcId="1006241" ItemId="2000617" XYZ="15.3963, -44.8656, 259.327" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5780,6 +5940,7 @@
                 <If Condition="GetQuestStep(66335) == 255">
                     <GetTo ZoneId="154" XYZ="-89.22339, -45.33137, 197.5893" /> <!-- Aethelmaer -->
                     <TurnIn QuestId="66335" NpcId="1002780" ItemId="2000861" XYZ="-89.79938, -45.33138, 195.88" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5809,6 +5970,7 @@
                 <If Condition="GetQuestStep(66336) == 255">
                     <GetTo ZoneId="133" XYZ="36.81995, 16.35147, -334.5846" /> <!-- Ursandel -->
                     <TurnIn QuestId="66336" NpcId="1006263" ItemId="2000630" XYZ="36.81995, 16.35147, -334.5846" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5847,6 +6009,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.29187, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66337" NpcId="1006688" XYZ="39.29187, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5944,6 +6107,7 @@
                 <If Condition="GetQuestStep(66238) == 255">
                     <GetTo ZoneId="130" XYZ="55.34448, 4.124078, -143.9079" /> <!-- Mimigun -->
                     <TurnIn QuestId="66238" NpcId="1001978" XYZ="55.34448, 4.124078, -143.9079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5989,6 +6153,7 @@
                 <If Condition="GetQuestStep(66698) == 255">
                     <GetTo ZoneId="148" XYZ="-60.47156, 0.2, 6.301941" /> <!-- Luquelot -->
                     <TurnIn QuestId="66698" NpcId="1000471" XYZ="-60.47156, 0.2, 6.301941" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6019,6 +6184,7 @@
                 <If Condition="GetQuestStep(66052) == 255">
                     <GetTo ZoneId="135" XYZ="710.9025, 66.027, -277.6685" /> <!-- Trachtoum -->
                     <TurnIn QuestId="66052" NpcId="1006264" XYZ="710.9025, 66.027, -277.6685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6040,6 +6206,7 @@
                 <If Condition="GetQuestStep(66345) == 255">
                     <GetTo ZoneId="135" XYZ="710.9025, 66.027, -277.6685" /> <!-- Trachtoum -->
                     <TurnIn QuestId="66345" NpcId="1006264" XYZ="710.9025, 66.027, -277.6685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6061,6 +6228,7 @@
                 <If Condition="GetQuestStep(66346) == 255">
                     <GetTo ZoneId="135" XYZ="710.9025, 66.027, -277.6685" /> <!-- Trachtoum -->
                     <TurnIn QuestId="66346" NpcId="1006264" XYZ="710.9025, 66.027, -277.6685" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6107,6 +6275,7 @@
                 <If Condition="GetQuestStep(66347) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66347" NpcId="1006266" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6133,6 +6302,7 @@
                 <If Condition="GetQuestStep(66348) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66348" NpcId="1006266" ItemId="2000637" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6150,6 +6320,7 @@
                 <If Condition="GetQuestStep(66350) == 255">
                     <GetTo ZoneId="153" XYZ="-231.4336, 21.51271, 339.4979" /> <!-- Landenel -->
                     <TurnIn QuestId="66350" NpcId="1006279" XYZ="-231.4336, 21.51271, 339.4979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6177,6 +6348,7 @@
                 <If Condition="GetQuestStep(66351) == 255">
                     <GetTo ZoneId="153" XYZ="-231.4336, 21.51271, 339.4979" /> <!-- Landenel -->
                     <TurnIn QuestId="66351" NpcId="1006279" ItemId="2000638" XYZ="-231.4336, 21.51271, 339.4979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6200,6 +6372,7 @@
                 <If Condition="GetQuestStep(66352) == 255">
                     <GetTo ZoneId="153" XYZ="-231.4336, 21.51271, 339.4979" /> <!-- Landenel -->
                     <TurnIn QuestId="66352" NpcId="1006279" XYZ="-231.4336, 21.51271, 339.4979" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6229,6 +6402,7 @@
                 <If Condition="GetQuestStep(66355) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66355" NpcId="1004917" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6263,6 +6437,7 @@
                 <If Condition="GetQuestStep(66356) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66356" NpcId="1004917" ItemId="2000642" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6288,6 +6463,7 @@
                 <If Condition="GetQuestStep(66357) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66357" NpcId="1004917" ItemId="2000644" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6317,6 +6493,7 @@
                 <If Condition="GetQuestStep(66358) == 255">
                     <GetTo ZoneId="146" XYZ="-358.6328, 8.469424, 422.4154" /> <!-- U'odh Nunh -->
                     <TurnIn QuestId="66358" NpcId="1004917" ItemId="2000833" XYZ="-358.6328, 8.469424, 422.4154" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6334,6 +6511,7 @@
                 <If Condition="GetQuestStep(66367) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66367" NpcId="1006266" ItemId="2000649" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6380,6 +6558,7 @@
                 <If Condition="GetQuestStep(66368) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66368" NpcId="1006266" ItemId="2000864" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6401,6 +6580,7 @@
                 <If Condition="GetQuestStep(66375) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66375" NpcId="1006305" ItemId="2000653" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6422,6 +6602,7 @@
                 <If Condition="GetQuestStep(66376) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66376" NpcId="1006305" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6444,6 +6625,7 @@
                 <If Condition="GetQuestStep(66379) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66379" NpcId="1006305" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6478,6 +6660,7 @@
                 <If Condition="GetQuestStep(66381) == 255">
                     <GetTo ZoneId="137" XYZ="-369.0395, 54.28072, 441.2451" /> <!-- Drest -->
                     <TurnIn QuestId="66381" NpcId="1006312" ItemId="2000655" XYZ="-369.0395, 54.28072, 441.2451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6499,6 +6682,7 @@
                 <If Condition="GetQuestStep(66382) == 255">
                     <GetTo ZoneId="137" XYZ="-369.0395, 54.28072, 441.2451" /> <!-- Drest -->
                     <TurnIn QuestId="66382" NpcId="1006312" XYZ="-369.0395, 54.28072, 441.2451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6520,6 +6704,7 @@
                 <If Condition="GetQuestStep(66383) == 255">
                     <GetTo ZoneId="137" XYZ="-369.0395, 54.28072, 441.2451" /> <!-- Drest -->
                     <TurnIn QuestId="66383" NpcId="1006312" ItemId="2000656" XYZ="-369.0395, 54.28072, 441.2451" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6548,6 +6733,7 @@
                 <If Condition="GetQuestStep(66384) == 255">
                     <GetTo ZoneId="137" XYZ="10.60498, 71.47817, -16.61713" /> <!-- Shamani Lohmani -->
                     <TurnIn QuestId="66384" NpcId="1006305" ItemId="2000657" XYZ="10.60498, 71.47817, -16.61713" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6577,6 +6763,7 @@
                 <If Condition="GetQuestStep(66386) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66386" NpcId="1006266" ItemId="2000659" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6616,6 +6803,7 @@
                 <If Condition="GetQuestStep(66390) == 255">
                     <GetTo ZoneId="137" XYZ="560.3571, 20.75329, 455.8937" /> <!-- Wheiskaet -->
                     <TurnIn QuestId="66390" NpcId="1006266" XYZ="560.3571, 20.75329, 455.8937" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6649,6 +6837,7 @@
                 <If Condition="GetQuestStep(66391) == 255">
                     <GetTo ZoneId="137" XYZ="558.9838, 20.70648, 451.1329" /> <!-- Y'shtola -->
                     <TurnIn QuestId="66391" NpcId="1006676" XYZ="558.9838, 20.70648, 451.1329" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6676,6 +6865,7 @@
                 <If Condition="GetQuestStep(66392) == 255">
                     <GetTo ZoneId="139" XYZ="479.3926, 16.2587, 128.3741" /> <!-- Riol -->
                     <TurnIn QuestId="66392" NpcId="1006341" XYZ="479.3926, 16.2587, 128.3741" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6714,6 +6904,7 @@
                 <If Condition="GetQuestStep(66393) == 255">
                     <GetTo ZoneId="139" XYZ="427.634, 4.115109, 85.92346" /> <!-- Y'shtola -->
                     <TurnIn QuestId="66393" NpcId="1006343" XYZ="427.634, 4.115109, 85.92346" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6763,6 +6954,7 @@
 
                     <GetTo ZoneId="145" XYZ="-512.4742, -16.42, -7.522766" /> <!-- Iliud -->
                     <TurnInPlus QuestId="66053" NpcId="1006355" XYZ="-512.4742, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6840,6 +7032,7 @@
                 <If Condition="GetQuestStep(66408) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66408" NpcId="1003958" ItemId="2000680" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6866,6 +7059,7 @@
                     </If>
                     <GetTo ZoneId="145" XYZ="-509.3614, -16.42, -7.522766" /> <!-- Marques -->
                     <TurnIn QuestId="66407" NpcId="1006672" ItemId="2394" XYZ="-509.3614, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6891,6 +7085,7 @@
                 <If Condition="GetQuestStep(66417) == 255">
                     <GetTo ZoneId="145" XYZ="-509.3614, -16.42, -7.522766" /> <!-- Marques -->
                     <TurnIn QuestId="66417" NpcId="1006672" ItemId="2000689" XYZ="-509.3614, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6942,6 +7137,7 @@
                 <If Condition="GetQuestStep(66412) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66412" NpcId="1003958" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6963,6 +7159,7 @@
                 <If Condition="GetQuestStep(66413) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66413" NpcId="1003958" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6984,6 +7181,7 @@
                 <If Condition="GetQuestStep(66414) == 255">
                     <GetTo ZoneId="145" XYZ="-497.7035, -19.6308, 39.9939" /> <!-- Eluned -->
                     <TurnIn QuestId="66414" NpcId="1003958" XYZ="-497.7035, -19.6308, 39.9939" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7009,6 +7207,7 @@
                 <If Condition="GetQuestStep(66054) == 255">
                     <GetTo ZoneId="145" XYZ="-512.4742, -16.42, -7.522766" /> <!-- Iliud -->
                     <TurnIn QuestId="66054" NpcId="1006355" ItemId="2000850" XYZ="-512.4742, -16.42, -7.522766" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7043,6 +7242,7 @@
                 <If Condition="GetQuestStep(66419) == 255">
                     <GetTo ZoneId="154" XYZ="-301.0452, -13.60442, 198.4435" /> <!-- Vortefaurt -->
                     <TurnIn QuestId="66419" NpcId="1006371" XYZ="-301.0452, -13.60442, 198.4435" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7060,6 +7260,7 @@
                 <If Condition="GetQuestStep(66420) == 255">
                     <GetTo ZoneId="155" XYZ="171.5266, 222.6926, 355.4894" /> <!-- Ludovoix -->
                     <TurnIn QuestId="66420" NpcId="1006372" XYZ="171.5266, 222.6926, 355.4894" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7091,6 +7292,7 @@
                 <If Condition="GetQuestStep(66422) == 255">
                     <GetTo ZoneId="155" XYZ="190.2479, 293.33, 415.5793" /> <!-- Forlemort -->
                     <TurnIn QuestId="66422" NpcId="1006377" XYZ="200.9766, 293.33, 420.3707" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7116,6 +7318,7 @@
                 <If Condition="GetQuestStep(66423) == 255">
                     <GetTo ZoneId="155" XYZ="169.4819, 223.0354, 366.2623" /> <!-- Portelaine -->
                     <TurnIn QuestId="66423" NpcId="1006380" XYZ="169.4819, 223.0354, 366.2623" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7143,6 +7346,7 @@
                 <If Condition="GetQuestStep(66425) == 255">
                     <GetTo ZoneId="155" XYZ="169.4819, 223.0354, 366.2623" /> <!-- Portelaine -->
                     <TurnIn QuestId="66425" NpcId="1006380" ItemId="2000693,2000694,2000695" XYZ="169.4819, 223.0354, 366.2623" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7164,6 +7368,7 @@
                 <If Condition="GetQuestStep(66426) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66426" NpcId="1006384" ItemId="2000697" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7199,6 +7404,7 @@
                 <If Condition="GetQuestStep(66432) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66432" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7230,6 +7436,7 @@
                 <If Condition="GetQuestStep(66433) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66433" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7275,6 +7482,7 @@
                 <If Condition="GetQuestStep(66446) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66446" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7314,6 +7522,7 @@
                 <If Condition="GetQuestStep(66447) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66447" NpcId="1006384" ItemId="2000711" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7356,6 +7565,7 @@
                 <If Condition="GetQuestStep(66448) == 255">
                     <GetTo ZoneId="155" XYZ="263.5996, 303.1, -199.9695" /> <!-- Haurchefant -->
                     <TurnIn QuestId="66448" NpcId="1006384" XYZ="263.5996, 303.1, -199.9695" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7393,6 +7603,7 @@
                 <If Condition="GetQuestStep(66453) == 255">
                     <GetTo ZoneId="155" XYZ="-478.2635, 211, -203.8148" /> <!-- Brunadier -->
                     <TurnIn QuestId="66453" NpcId="1006435" ItemId="2000721,2000722" XYZ="-478.2635, 211, -203.8148" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7435,6 +7646,7 @@
                 <If Condition="GetQuestStep(66460) == 255">
                     <GetTo ZoneId="155" XYZ="-439.604, 224.4, -194.886" /> <!-- Drillemont -->
                     <TurnIn QuestId="66460" NpcId="1006444" ItemId="2000856,2000858" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7460,6 +7672,7 @@
                 <If Condition="GetQuestStep(66462) == 255">
                     <GetTo ZoneId="155" XYZ="-439.292, 211, -210.7729" /> <!-- Nivie -->
                     <TurnIn QuestId="66462" NpcId="1006447" XYZ="-439.292, 211, -210.7729" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7496,6 +7709,7 @@
                 <If Condition="GetQuestStep(66463) == 255">
                     <GetTo ZoneId="155" XYZ="-411.6426, 225.0227, -304.036" /> <!-- Cenota -->
                     <TurnIn QuestId="66463" NpcId="1007567" ItemId="2000984" XYZ="-411.6426, 225.0227, -304.036" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7517,6 +7731,7 @@
                 <If Condition="GetQuestStep(66461) == 255">
                     <GetTo ZoneId="155" XYZ="-427.9088, 211, -199.7559" /> <!-- Clotairion -->
                     <TurnIn QuestId="66461" NpcId="1006446" XYZ="-427.9088, 211, -199.7559" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7538,6 +7753,7 @@
                 <If Condition="GetQuestStep(66473) == 255">
                     <GetTo ZoneId="155" XYZ="-415.9762, 225, -299.733" /> <!-- Cid -->
                     <TurnIn QuestId="66473" NpcId="1006461" ItemId="2000732" XYZ="-415.9762, 225, -299.733" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7608,6 +7824,7 @@
                 <If Condition="GetQuestStep(66474) == 255">
                     <GetTo ZoneId="155" XYZ="-437.9492, 211.17, -245.7771" /> <!-- Alphinaud -->
                     <TurnIn QuestId="66474" NpcId="1006467" XYZ="-437.9492, 211.17, -245.7771" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7634,6 +7851,7 @@
                 <If Condition="GetQuestStep(66475) == 255">
                     <GetTo ZoneId="155" XYZ="-437.9492, 211.17, -245.7771" /> <!-- Alphinaud -->
                     <TurnIn NpcId="1006467" ItemId="2000733" QuestId="66475" XYZ="-437.9492, 211.17, -245.7771" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7671,6 +7889,7 @@
                 <If Condition="GetQuestStep(66476) == 255">
                     <GetTo ZoneId="155" XYZ="-424.635, 233.4, -208.0638" /> <!-- Drillemont -->
                     <TurnIn QuestId="66476" NpcId="1006444" ItemId="2000866,2000945" XYZ="-432.9748, 233.4727, -199.6643" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7702,6 +7921,7 @@
                 <If Condition="GetQuestStep(66477) == 255">
                     <GetTo ZoneId="155" XYZ="-437.9492, 211.17, -245.7771" /> <!-- Alphinaud -->
                     <TurnIn NpcId="1006467" QuestId="66477" XYZ="-437.9492, 211.17, -245.7771" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7750,6 +7970,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="7.248047, -21.97092, 119.7374" />
                     <TurnIn QuestId="66488" NpcId="1006491" XYZ="7.248047, -21.97092, 119.7374" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7773,6 +7994,7 @@
                 <If Condition="GetQuestStep(66489) == 255">
                     <GetTo ZoneId="145" XYZ="-437.6746, -55.6945, 100.8773" /> <!-- Lamberteint -->
                     <TurnIn QuestId="66489" NpcId="1006493" XYZ="-437.6746, -55.6945, 100.8773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7794,6 +8016,7 @@
                 <If Condition="GetQuestStep(66490) == 255">
                     <GetTo ZoneId="145" XYZ="-437.6746, -55.6945, 100.8773" /> <!-- Lamberteint -->
                     <TurnIn QuestId="66490" NpcId="1006493" ItemId="2000740" XYZ="-437.6746, -55.6945, 100.8773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7811,6 +8034,7 @@
                 <If Condition="GetQuestStep(66491) == 255">
                     <GetTo ZoneId="145" XYZ="-2.273621, -17.54423, 24.73486" /> <!-- Hahasako -->
                     <TurnIn QuestId="66491" NpcId="1006495" ItemId="2000741" XYZ="-2.273621, -17.54423, 24.73486" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7840,6 +8064,7 @@
                 <If Condition="GetQuestStep(66492) == 255">
                     <GetTo ZoneId="145" XYZ="-437.6746, -55.6945, 100.8773" /> <!-- Lamberteint -->
                     <TurnIn QuestId="66492" NpcId="1006493" ItemId="2000838" XYZ="-437.6746, -55.6945, 100.8773" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7857,6 +8082,7 @@
                 <If Condition="GetQuestStep(66495) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66495" NpcId="1006497" ItemId="2000839" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7896,6 +8122,7 @@
                 <If Condition="GetQuestStep(66496) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66496" NpcId="1006497" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7925,6 +8152,7 @@
                 <If Condition="GetQuestStep(66497) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66497" NpcId="1006497" ItemId="2000843" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7956,6 +8184,7 @@
                 <If Condition="GetQuestStep(66498) == 255">
                     <GetTo ZoneId="138" XYZ="-266.5904, -40.04039, 461.7227" /> <!-- Davyd -->
                     <TurnIn QuestId="66498" NpcId="1006503" ItemId="2000840" XYZ="-266.5904, -40.04039, 461.7227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -7979,6 +8208,7 @@
                 <If Condition="GetQuestStep(66499) == 255">
                     <GetTo ZoneId="138" XYZ="-266.5904, -40.04039, 461.7227" /> <!-- Davyd -->
                     <TurnIn QuestId="66499" NpcId="1006503" XYZ="-266.5904, -40.04039, 461.7227" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8028,6 +8258,7 @@
                 <If Condition="GetQuestStep(66503) == 255">
                     <GetTo ZoneId="138" XYZ="321.1565, -18.1978, 276.5697" /> <!-- Ceana -->
                     <TurnIn QuestId="66503" NpcId="1006497" ItemId="2000841" XYZ="321.1565, -18.1978, 276.5697" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8062,6 +8293,7 @@
                 <If Condition="GetQuestStep(66504) == 255">
                     <GetTo ZoneId="152" XYZ="25.65039, -3.708008, 209.9794" /> <!-- Komuxio -->
                     <TurnIn QuestId="66504" NpcId="1000580" XYZ="25.65039, -3.708008, 209.9794" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8092,6 +8324,7 @@
                 <If Condition="GetQuestStep(66507) == 255">
                     <GetTo ZoneId="152" XYZ="-172.0455, 57.15228, -258.1064" /> <!-- Maerwynn -->
                     <TurnIn QuestId="66507" NpcId="1006716" XYZ="-172.0455, 57.15228, -258.1064" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8125,6 +8358,7 @@
                 <If Condition="GetQuestStep(66510) == 255">
                     <GetTo ZoneId="133" XYZ="-123.7355, 7.042648, -149.981" /> <!-- Hedyn -->
                     <TurnIn QuestId="66510" NpcId="1006710" ItemId="2000932" XYZ="-123.7355, 7.042648, -149.981" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8148,6 +8382,7 @@
                     </If>
                     <MoveTo Name="Cid" XYZ="7.339539, -21.97097, 121.9348" />
                     <TurnIn QuestId="66511" NpcId="1006492" ItemId="2000753" XYZ="7.339539, -21.97097, 121.9348" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8212,6 +8447,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-44.63269, 83.99996, -3.768982" />
                     <TurnIn QuestId="66055" NpcId="1006730" XYZ="-44.63269, 83.99996, -3.768982" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8247,6 +8483,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="22.81219, 0.9999986, 2.182007" />
                     <TurnIn QuestId="66056" NpcId="1007630" XYZ="22.81219, 0.9999986, 2.182007" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8273,6 +8510,7 @@
                 <If Condition="GetQuestStep(66514) == 255">
                     <GetTo ZoneId="155" XYZ="169.4819, 223.0354, 366.2623" /> <!-- Portelaine -->
                     <TurnIn QuestId="66514" NpcId="1006380" XYZ="169.4819, 223.0354, 366.2623" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8294,6 +8532,7 @@
                 <If Condition="GetQuestStep(66516) == 255">
                     <GetTo ZoneId="155" XYZ="-354.8486, 214.7912, 687.5867" /> <!-- Portelaine -->
                     <TurnIn QuestId="66516" NpcId="1006518" XYZ="-354.8486, 214.7912, 687.5867" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8335,6 +8574,7 @@
                 <If Condition="GetQuestStep(66517) == 255">
                     <GetTo ZoneId="155" XYZ="-697.0474, 242.184, 380.6362" /> <!-- Abelie -->
                     <TurnIn QuestId="66517" NpcId="1006521" XYZ="-697.0474, 242.184, 380.6362" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8360,6 +8600,7 @@
                 <If Condition="GetQuestStep(66518) == 255">
                     <GetTo ZoneId="155" XYZ="-699.5193, 242.184, 373.495" /> <!-- Wedge -->
                     <TurnIn QuestId="66518" NpcId="1006520" XYZ="-699.5193, 242.184, 373.495" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8396,6 +8637,7 @@
                 <If Condition="GetQuestStep(66519) == 255">
                     <GetTo ZoneId="155" XYZ="-699.5193, 242.184, 373.495" /> <!-- Wedge -->
                     <TurnIn QuestId="66519" NpcId="1006520" XYZ="-699.5193, 242.184, 373.495" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8417,6 +8659,7 @@
                 <If Condition="GetQuestStep(66520) == 255">
                     <GetTo ZoneId="156" XYZ="53.81848, 25.00952, -697.0779" /> <!-- Glaumunt -->
                     <TurnIn QuestId="66520" NpcId="1006531" XYZ="53.81848, 25.00952, -697.0779" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8446,6 +8689,7 @@
                 <If Condition="GetQuestStep(66522) == 255">
                     <GetTo ZoneId="156" XYZ="26.90161, 20.54392, -687.4037" /> <!-- Cid -->
                     <TurnIn QuestId="66522" NpcId="1006535" XYZ="26.90161, 20.54392, -687.4037" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8527,6 +8771,7 @@
                 <If Condition="GetQuestStep(66538) == 255">
                     <GetTo ZoneId="156" XYZ="53.81848, 25.00952, -697.0779" /> <!-- Glaumunt -->
                     <TurnIn QuestId="66538" NpcId="1006531" XYZ="53.81848, 25.00952, -697.0779" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8568,6 +8813,7 @@
                 <If Condition="GetQuestStep(66539) == 255">
                     <GetTo ZoneId="156" XYZ="54.79517, 25.54827, -698.0544" /> <!-- Sark Malark -->
                     <TurnIn QuestId="66539" NpcId="1006552" ItemId="2000769,2000770" XYZ="54.79517, 25.54827, -698.0544" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8599,6 +8845,7 @@
                 <If Condition="GetQuestStep(66537) == 255">
                     <GetTo ZoneId="156" XYZ="26.90161, 20.54392, -687.4037" /> <!-- Cid -->
                     <TurnIn QuestId="66537" NpcId="1006535" ItemId="2000766" XYZ="26.90161, 20.54392, -687.4037" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8645,6 +8892,7 @@
                     </If>
                     <MoveTo Name="Cid" XYZ="-2.761902, -158.5813, -1.632751" />
                     <TurnIn QuestId="66540" NpcId="1006555" XYZ="-2.761902, -158.5813, -1.632751" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8762,6 +9010,7 @@
                     </If>
                     <MoveTo Name="Cid" XYZ="-2.761902, -158.5813, -1.632751" />
                     <TurnIn QuestId="66541" NpcId="1006555" XYZ="-2.761902, -158.5813, -1.632751" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8850,6 +9099,7 @@
                     </If>
                     <NoCombatMoveTo Name="Minfilia" XYZ="-43.7171, 84, 2.151489" />
                     <TurnIn QuestId="66057" NpcId="1006573" XYZ="-43.7171, 84, 2.151489" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8901,6 +9151,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.26135, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66058" NpcId="1006690" XYZ="39.26135, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8962,6 +9213,7 @@
                 <If Condition="GetQuestStep(66572) == 255">
                     <GetTo ZoneId="140" XYZ="-467.277, 22.99698, -475.2117" /> <!-- Allied Communications Officer -->
                     <TurnIn QuestId="66572" NpcId="1006578" XYZ="-467.277, 22.99698, -475.2117" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -8979,6 +9231,7 @@
                 <If Condition="GetQuestStep(66573) == 255">
                     <GetTo ZoneId="147" XYZ="37.97961, 4.051331, 420.2792" /> <!-- Cracked Fist -->
                     <TurnIn QuestId="66573" NpcId="1006638" XYZ="37.97961, 4.051331, 420.2792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9018,6 +9271,7 @@
                 <If Condition="GetQuestStep(66575) == 255">
                     <GetTo ZoneId="147" XYZ="37.97961, 4.051331, 420.2792" /> <!-- Cracked Fist -->
                     <TurnIn QuestId="66575" NpcId="1006638" XYZ="37.97961, 4.051331, 420.2792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9045,6 +9299,7 @@
                 <If Condition="GetQuestStep(66578) == 255">
                     <GetTo ZoneId="147" XYZ="-29.95355, 46.99734, 32.5474" /> <!-- Edelstein -->
                     <TurnIn QuestId="66578" NpcId="1006646" XYZ="-29.95355, 46.99734, 32.54749" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9077,6 +9332,7 @@
                     <GetTo ZoneId="147" XYZ="-29.95355, 46.99734, 32.5474" /> <!-- Edelstein -->
                     <Dismount/>
                     <TurnInPlus QuestId="66579" NpcId="1006646" XYZ="-29.95355, 46.99734, 32.54749" />
+                    <WaitTimer WaitTime="2"/>
                 </While>
             </If>
         </If>
@@ -9104,6 +9360,7 @@
                 <If Condition="GetQuestStep(66582) == 255">
                     <GetTo ZoneId="147" XYZ="-294.8196, 88, -225.1774" /> <!-- Raubahn -->
                     <TurnIn QuestId="66582" NpcId="1006657" XYZ="-294.8196, 88, -225.1774" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9171,6 +9428,7 @@
                 <If Condition="GetQuestStep(66672) == 255">
                     <GetTo ZoneId="147" XYZ="-294.8196, 88, -225.1774" /> <!-- Raubahn -->
                     <TurnIn QuestId="66672" NpcId="1006657" XYZ="-294.8196, 88, -225.1774" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -9205,6 +9463,7 @@
                     </If>
                     <MoveTo Name="Minfilia" XYZ="39.26135, 1.214808, 0.8086548" />
                     <TurnIn QuestId="66060" NpcId="1006692" XYZ="39.26135, 1.214808, 0.8086548" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>

--- a/Questing/[O] [MSQ] Class and Job Quests.xml
+++ b/Questing/[O] [MSQ] Class and Job Quests.xml
@@ -4020,10 +4020,10 @@
 						</If>
 						<If Condition="GetQuestStep(67549) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67549" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67549" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4036,11 +4036,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 34">
 					<If Condition="not HasQuest(67550)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67550)">
-							 <PickupQuest NpcId="1012222" QuestId="67550" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67550" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67550)">
@@ -4081,10 +4081,10 @@
 						</If>
 						<If Condition="GetQuestStep(67550) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67550" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67550" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4097,11 +4097,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 39">
 					<If Condition="not HasQuest(67551)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67551)">
-							 <PickupQuest NpcId="1012222" QuestId="67551" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67551" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67551)">
@@ -4133,10 +4133,10 @@
 					<If Condition="HasQuest(67552)">
 						<If Condition="GetQuestStep(67552) == 1">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Leveva" XYZ="202.3804, -5.399966, -58.9151" />
-							<TalkTo NpcId="1012222" QuestId="67552" StepId="1" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Leveva" XYZ="198.9282, -5.399965, -59.27039" />
+							<TalkTo NpcId="1012222" QuestId="67552" StepId="1" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 						<If Condition="GetQuestStep(67552) == 2">
 							<If Condition="not IsOnMap(129)">
@@ -4202,10 +4202,10 @@
 						</If>
 						<If Condition="GetQuestStep(67552) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67552" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67552" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4218,11 +4218,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 44">
 					<If Condition="not HasQuest(67553)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67553)">
-							<PickupQuest NpcId="1012222" QuestId="67553" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67553" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67553)">
@@ -4235,10 +4235,10 @@
 						</If>
 						<If Condition="GetQuestStep(67553) == 2">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<HandOver ItemIds="2001819" QuestId="67553" StepId="2" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<HandOver ItemIds="2001819" QuestId="67553" StepId="2" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 						<If Condition="GetQuestStep(67553) == 3">
 							<If Condition="not IsOnMap(156)">
@@ -4265,10 +4265,10 @@
 						</If>
 						<If Condition="GetQuestStep(67553) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67553" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67553" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4281,11 +4281,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 49">
 					<If Condition="not HasQuest(67554)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67554)">
-							<PickupQuest NpcId="1012222" QuestId="67554" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67554" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67554)">
@@ -4317,10 +4317,10 @@
 					<If Condition="HasQuest(67555)">
 						<If Condition="GetQuestStep(67555) == 1">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TalkTo NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" QuestId="67555" StepId="1" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TalkTo NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" QuestId="67555" StepId="1" />
 						</If>
 						<If Condition="GetQuestStep(67555) == 2">
 							<If Condition="not IsOnMap(155)">
@@ -4410,10 +4410,10 @@
 						</While>
 						<If Condition="GetQuestStep(67556) == 2">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TalkTo NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" QuestId="67556" StepId="2" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TalkTo NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" QuestId="67556" StepId="2" />
 						</If>
 						<If Condition="GetQuestStep(67556) == 3">
 							<If Condition="not IsOnMap(419)">
@@ -4438,10 +4438,10 @@
 						</If>
 						<If Condition="GetQuestStep(67556) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67556" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67556" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4454,11 +4454,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 51">
 					<If Condition="not HasQuest(67557)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67557)">
-							 <PickupQuest NpcId="1012222" QuestId="67557" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67557" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67557)">
@@ -4520,10 +4520,10 @@
 						</If>
 						<If Condition="GetQuestStep(67557) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67557" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67557" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4536,11 +4536,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 53">
 					<If Condition="not HasQuest(67558)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67558)">
-							 <PickupQuest NpcId="1012222" QuestId="67558" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67558" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67558)">
@@ -4579,10 +4579,10 @@
 						</If>
 						<If Condition="GetQuestStep(67558) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67558" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67558" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4595,11 +4595,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 55">
 					<If Condition="not HasQuest(67559)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67559)">
-							 <PickupQuest NpcId="1012222" QuestId="67559" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67559" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67559)">
@@ -4647,10 +4647,10 @@
 						</If>
 						<If Condition="GetQuestStep(67559) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67559" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67559" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4666,11 +4666,11 @@
 				<!-- <If Condition="Core.Player.ClassLevel &gt; 57">
 					<If Condition="not HasQuest(67560)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67560)">
-							 <PickupQuest NpcId="1012222" QuestId="67560" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67560" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67560)">
@@ -4732,10 +4732,10 @@
 						</If>
 						<If Condition="GetQuestStep(67560) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67560" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67560" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4748,11 +4748,11 @@
 				<If Condition="Core.Player.ClassLevel &gt; 59">
 					<If Condition="not HasQuest(67561)">
 						<If Condition="not IsOnMap(419)">
-							<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+							<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
-						<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
+						<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
 						<If Condition="IsQuestAcceptQualified(67561)">
-							 <PickupQuest NpcId="1012222" QuestId="67561" XYZ="202.3804, -5.399966, -58.9151" />
+							 <PickupQuest NpcId="1012222" QuestId="67561" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67561)">
@@ -4802,10 +4802,10 @@
 						</If>
 						<If Condition="GetQuestStep(67561) == 255">
 							<If Condition="not IsOnMap(419)">
-								<GetTo ZoneId="419" XYZ="202.3804, -5.399966, -58.9151" />
+								<GetTo ZoneId="419" XYZ="198.9282, -5.399965, -59.27039" />
 							</If>
-							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
-							<TurnIn QuestId="67561" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<MoveTo Name="Jannequinard" XYZ="198.9282, -5.399965, -59.27039" />
+							<TurnIn QuestId="67561" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4819,7 +4819,7 @@
 					<If Condition="not HasQuest(67945)">
 						<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
 						<If Condition="IsQuestAcceptQualified(67945)">
-							<PickupQuest NpcId="1012222" QuestId="67945" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67945" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67945)">
@@ -4865,7 +4865,7 @@
 						</If>
 						<If Condition="GetQuestStep(67946) == 255">
 							<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
-							<TurnIn QuestId="67946" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<TurnIn QuestId="67946" NpcId="1012222" XYZ="198.9282, -5.399965, -59.27039" />
 							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
@@ -4879,7 +4879,7 @@
 					<If Condition="not HasQuest(67947)">
 						<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
 						<If Condition="IsQuestAcceptQualified(67947)">
-							<PickupQuest NpcId="1012222" QuestId="67947" XYZ="202.3804, -5.399966, -58.9151" />
+							<PickupQuest NpcId="1012222" QuestId="67947" XYZ="198.9282, -5.399965, -59.27039" />
 						</If>
 					</If>
 					<If Condition="HasQuest(67947)">

--- a/Questing/[O] [MSQ] Class and Job Quests.xml
+++ b/Questing/[O] [MSQ] Class and Job Quests.xml
@@ -62,6 +62,7 @@
 						<If Condition="GetQuestStep(65990) == 255">
 							<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 							<TurnIn QuestId="65990" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -102,6 +103,7 @@
 							<If Condition="GetQuestStep(65991) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim-->
 								<TurnIn QuestId="65991" NpcId="1000909" ItemId="2000796" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -155,6 +157,7 @@
 							<If Condition="GetQuestStep(65992) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65992" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -208,6 +211,7 @@
 							<If Condition="GetQuestStep(65993) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65993" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -234,6 +238,7 @@
 							<If Condition="GetQuestStep(66639) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="66639" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -282,6 +287,7 @@
 							<If Condition="GetQuestStep(65994) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65994" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -337,6 +343,7 @@
 							<If Condition="GetQuestStep(65995) == 255">
 								<GetTo ZoneId="129" XYZ="-326.3752, 12.89966, 9.994568" /> <!-- Thubyrgeim -->
 								<TurnIn QuestId="65995" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -465,6 +472,7 @@
 								</If>
 								<MoveTo Name="Thubyrgeim" XYZ="-326.3752, 12.89966, 9.994568" />
 								<TurnIn QuestId="65996" NpcId="1000909" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -580,6 +588,7 @@
 								</If>
 								<MoveTo Name="Thubyrgeim" XYZ="-326.3752, 12.89966, 9.994568" />
 								<TurnIn QuestId="65997" NpcId="1000909" ItemId="2000889" XYZ="-326.3752, 12.89966, 9.994568" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -648,6 +657,7 @@
 								</If>
 								<MoveTo Name="Alka Zolka" XYZ="-4.470947, 44.99989, -250.5685" />
 								<TurnIn QuestId="66633" NpcId="1006757" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -707,6 +717,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66627" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -773,6 +784,7 @@
 								</If>
 								<MoveTo Name="Alka Zolka" XYZ="-4.470947, 44.99989, -250.5685" />
 								<TurnIn NpcId="1006757" QuestId="66634" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -826,6 +838,7 @@
 								</If>
 								<MoveTo Name="Alka Zolka" XYZ="-4.470947, 44.99989, -250.5685" />
 								<TurnIn NpcId="1006757" QuestId="66635" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -895,6 +908,7 @@
 								<BotSettings AutoEquip="0" />
 								<RunCode Name="In_the_Image_of_the_Ancients" />
 								<TurnIn NpcId="1006757" QuestId="66636" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 								<BotSettings AutoEquip="1" />
 							</While>
 						</If>
@@ -956,6 +970,7 @@
 							<If Condition="GetQuestStep(66637) == 255">
 								<GetTo ZoneId="128" XYZ="-4.470947, 44.99989, -250.5685" /> <!-- Alka Zolka -->
 								<TurnIn NpcId="1006757" QuestId="66637" XYZ="-4.470947, 44.99989, -250.5685" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1027,6 +1042,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="231.7997, 5.184731, 61.14282" />
 								<TurnIn QuestId="66638" NpcId="1007849" XYZ="231.7997, 5.184731, 61.14282" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1079,6 +1095,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67207" ItemId="2001585" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1147,6 +1164,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67208" ItemId="2001586" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1217,6 +1235,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67209" ItemId="2001587" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1290,6 +1309,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="404.1962, -2.608213, 212.1156" />
 								<TurnIn QuestId="67210" NpcId="1013138" XYZ="404.1962, -2.608213, 212.1156" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1352,6 +1372,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="206.0426, -3.111818, 41.94702" />
 								<TurnIn QuestId="67211" ItemId="2001588" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -1443,6 +1464,7 @@
 								</If>
 								<NoCombatMoveTo Name="Surito Carito" XYZ="491.4778, 16.49544, 69.16907" />
 								<TurnIn QuestId="67212" NpcId="1013199" XYZ="491.4778, 16.49544, 69.16907" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1474,6 +1496,7 @@
 							<If Condition="GetQuestStep(68459) == 255">
 								<GetTo ZoneId="139" XYZ="206.0426, -3.111818, 41.94702" /> <!-- Surito Carito -->
 								<TurnIn QuestId="68459" NpcId="1013135" XYZ="206.0426, -3.111818, 41.94702" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1521,6 +1544,7 @@
 							<If Condition="GetQuestStep(68460) == 255">
 								<GetTo ZoneId="153" XYZ="-220.8439, 21.26176, 363.3936" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68460" NpcId="1021911" XYZ="-220.8439, 21.26176, 363.3936" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1574,6 +1598,7 @@
 							<If Condition="GetQuestStep(68461) == 255">
 								<GetTo ZoneId="153" XYZ="-220.8439, 21.26176, 363.3936" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68461" NpcId="1021911" XYZ="-220.8439, 21.26176, 363.3936" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1613,6 +1638,7 @@
 							<If Condition="GetQuestStep(68462) == 255">
 								<GetTo ZoneId="153" XYZ="-220.8439, 21.26176, 363.3936" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68462" NpcId="1021911" XYZ="-220.8439, 21.26176, 363.3936" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1681,6 +1707,7 @@
 							<If Condition="GetQuestStep(68463) == 255">
 								<GetTo ZoneId="139" XYZ="206.8054, -3.065021, 43.83911" /> <!-- Alka Zolka -->
 								<TurnIn QuestId="68463" NpcId="1021918" XYZ="206.8054, -3.065021, 43.83911" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1748,6 +1775,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66628" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1780,6 +1808,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66629" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1864,6 +1893,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66630" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1913,6 +1943,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66631" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -1977,6 +2008,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="66632" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2016,6 +2048,7 @@
 								</If>
 								<MoveTo Name="Y'mhitra" XYZ="-16.89185, 10.17425, -246.8757" />
 								<TurnIn QuestId="67636" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2071,6 +2104,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67637" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2123,6 +2157,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67638" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2176,6 +2211,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67639" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2237,6 +2273,7 @@
 								</If>
 								<MoveTo Name="Dancing Wolf" XYZ="-126.5736, 4.099995, -96.23871" />
 								<TurnIn QuestId="67640" NpcId="1014028" XYZ="-126.5736, 4.099995, -96.23871" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2286,6 +2323,7 @@
 								</If>
 								<NoCombatMoveTo Name="Y'mhitra" XYZ="264.515, 232.541, 728.8472" />
 								<TurnIn QuestId="67641" NpcId="1014044" XYZ="264.515, 232.541, 728.8472" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2322,6 +2360,7 @@
 							<If Condition="GetQuestStep(68161) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68161" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2364,6 +2403,7 @@
 							<If Condition="GetQuestStep(68162) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68162" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2422,6 +2462,7 @@
 							<If Condition="GetQuestStep(68163) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68163" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2457,6 +2498,7 @@
 							<If Condition="GetQuestStep(68164) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> <!-- Y'mhitra -->
 								<TurnIn QuestId="68164" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2528,6 +2570,7 @@
 							<If Condition="GetQuestStep(68165) == 255">
 								<GetTo ZoneId="133" XYZ="-16.89185, 10.17425, -246.8757" /> --> <!-- Y'mhitra -->
 								<!-- <TurnIn QuestId="68165" NpcId="1006756" XYZ="-16.89185, 10.17425, -246.8757" />
+ <WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -2572,6 +2615,7 @@
 						<If Condition="GetQuestStep(65755) == 255">
 							<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 							<TurnIn QuestId="65755" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -2619,6 +2663,7 @@
 							<If Condition="GetQuestStep(65582) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65582" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2673,6 +2718,7 @@
 							<If Condition="GetQuestStep(65603) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65603" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2730,6 +2776,7 @@
 							<If Condition="GetQuestStep(65670) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65670" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2791,6 +2838,7 @@
 							<If Condition="GetQuestStep(65604) == 255">
 								<GetTo ZoneId="132" XYZ="209.5521, 0.9999819, 35.01941" /> <!-- Luciane -->
 								<TurnIn QuestId="65604" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2867,6 +2915,7 @@
 								</If>
 								<MoveTo Name="Luciane" XYZ="209.5521, 0.9999819, 35.01941" />
 								<TurnIn QuestId="65606" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2928,6 +2977,7 @@
 								</If>
 								<MoveTo Name="Luciane" XYZ="209.5521, 0.9999819, 35.01941" />
 								<TurnIn QuestId="65607" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -2988,6 +3038,7 @@
 								</If>
 								<MoveTo Name="Luciane" XYZ="209.5521, 0.9999819, 35.01941" />
 								<TurnIn QuestId="65612" NpcId="1000200" XYZ="209.5521, 0.9999819, 35.01941" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3045,6 +3096,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66621" NpcId="1006750" ItemId="2000813" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3096,6 +3148,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66622" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3128,6 +3181,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66623" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3171,6 +3225,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66624" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3231,6 +3286,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="66625" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3275,6 +3331,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="70.17627, 226.7221, 381.3076" />
 								<TurnIn QuestId="66626" NpcId="1007891" XYZ="70.17627, 226.7221, 381.3076" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3356,6 +3413,7 @@
 								</If>
 								<MoveTo Name="Sanson" XYZ="-52.5368, 8.059148, 31.72351" />
 								<TurnIn QuestId="67249" NpcId="1014208" XYZ="-52.5368, 8.059148, 31.72351" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3409,6 +3467,7 @@
 								</If>
 								<NoCombatMoveTo Name="Sanson" XYZ="445.365, 212.5398, 699.7938" />
 								<TurnIn QuestId="67250" NpcId="1014216" XYZ="445.365, 212.5398, 699.7938" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3483,6 +3542,7 @@
 								</If>
 								<NoCombatMoveTo Name="Sanson" XYZ="544.976, -51.27571, 65.38477" />
 								<TurnIn QuestId="67251" NpcId="1014232" XYZ="544.976, -51.27571, 65.38477" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3532,6 +3592,7 @@
 								</If>
 								<NoCombatMoveTo Name="Sanson" XYZ="544.976, -51.27571, 65.38477" />
 								<TurnIn QuestId="67252" NpcId="1014231" XYZ="544.976, -51.27571, 65.38477" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3620,6 +3681,7 @@
 								</If>
 								<NoCombatMoveTo Name="Moglin" XYZ="381.7043, -66.84979, 700.8619" />
 								<TurnIn QuestId="67253" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3701,6 +3763,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jehantel" XYZ="16.46442, 6.750492, -7.339661" />
 								<TurnIn QuestId="67254" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -3732,6 +3795,7 @@
 							<If Condition="GetQuestStep(68426) == 255">
 								<GetTo ZoneId="612" XYZ="-653.132, 130, -523.827" /> <!-- Nourval -->
 								<TurnIn QuestId="68426" NpcId="1022511" XYZ="-653.132, 130, -523.827" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3763,6 +3827,7 @@
 							<If Condition="GetQuestStep(68427) == 255">
 								<GetTo ZoneId="612" XYZ="-650.9041, 130, -520.8667" /> <!-- Guydelot -->
 								<TurnIn QuestId="68427" NpcId="1022513" XYZ="-650.9041, 130, -520.8667" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3806,6 +3871,7 @@
 							<If Condition="GetQuestStep(68428) == 255">
 								<GetTo ZoneId="612" XYZ="-653.0403, 130, -522.179" /> <!-- Sanson -->
 								<TurnIn QuestId="68428" NpcId="1022523" XYZ="-653.0403, 130, -522.179" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3841,6 +3907,7 @@
 							<If Condition="GetQuestStep(68429) == 255">
 								<GetTo ZoneId="132" XYZ="-52.35376, -3.326972, 20.58435" /> <!-- Guydelot -->
 								<TurnIn QuestId="68429" NpcId="1022528" XYZ="-52.35376, -3.326972, 20.58435" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3900,6 +3967,7 @@
 							<If Condition="GetQuestStep(68430) == 255">
 								<GetTo ZoneId="153" XYZ="16.46442, 6.750492, -7.339661" /> <!-- Jehantel -->
 								<TurnIn QuestId="68430" NpcId="1006750" XYZ="16.46442, 6.750492, -7.339661" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -3956,6 +4024,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67549" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4016,6 +4085,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67550" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4041,6 +4111,7 @@
 							</If>
 							<MoveTo Name="Leveva" XYZ="199.9388, -0.899981, -48.72211" />
 							<TurnIn QuestId="67551" NpcId="1014944" XYZ="199.9388, -0.899981, -48.72211" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4135,6 +4206,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67552" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4197,6 +4269,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67553" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4222,6 +4295,7 @@
 							</If>
 							<MoveTo Name="Leveva" XYZ="199.9388, -0.899981, -48.72211" />
 							<TurnIn QuestId="67554" NpcId="1014944" XYZ="199.9388, -0.899981, -48.72211" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4306,6 +4380,7 @@
 							</If>
 							<NoCombatMoveTo Name="Destination" XYZ="205.9204, 307.8507, 412.2529" />
 							<TurnIn QuestId="67555" NpcId="2006367" XYZ="205.9204, 307.8507, 412.2529" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4367,6 +4442,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67556" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4448,6 +4524,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67557" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4506,6 +4583,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67558" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4573,6 +4651,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67559" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4657,6 +4736,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67560" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If> -->
@@ -4726,6 +4806,7 @@
 							</If>
 							<MoveTo Name="Jannequinard" XYZ="202.3804, -5.399966, -58.9151" />
 							<TurnIn QuestId="67561" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4753,6 +4834,7 @@
 						<If Condition="GetQuestStep(67945) == 255">
 							<GetTo ZoneId="419" XYZ="195.1781, -5.399962, -67.06348" /> <!-- Leveva -->
 							<TurnIn QuestId="67945" NpcId="1021191" XYZ="195.1781, -5.399962, -67.06348" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4784,6 +4866,7 @@
 						<If Condition="GetQuestStep(67946) == 255">
 							<GetTo ZoneId="419" XYZ="200.0353, -5.399966, -59.32621" /> <!-- Jannequinard -->
 							<TurnIn QuestId="67946" NpcId="1012222" XYZ="202.3804, -5.399966, -58.9151" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4849,6 +4932,7 @@
 						<If Condition="GetQuestStep(67947) == 255">
 							<GetTo ZoneId="628" XYZ="98.10022, 4.000001, 87.44946" /> <!-- Kyokuho -->
 							<TurnIn QuestId="67947" NpcId="1021262" XYZ="98.10022, 4.000001, 87.44946" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4884,6 +4968,7 @@
 						<If Condition="GetQuestStep(67948) == 255">
 							<GetTo ZoneId="628" XYZ="98.10022, 4.000001, 87.44946" /> <!-- Kyokuho -->
 							<TurnIn QuestId="67948" NpcId="1021262" XYZ="98.10022, 4.000001, 87.44946" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4938,6 +5023,7 @@
 						<If Condition="GetQuestStep(67949) == 255">
 							<GetTo ZoneId="628" XYZ="-47.50134, 16.62471, 9.719971" /> <!-- Kyokuho -->
 							<TurnIn QuestId="67949" NpcId="1021309" XYZ="-47.50134, 16.62471, 9.719971" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -4980,6 +5066,7 @@
 						<If Condition="GetQuestStep(65747) == 255">
 							<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 							<TurnIn QuestId="65747" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -5010,6 +5097,7 @@
 							<If Condition="GetQuestStep(65584) == 255">
 								<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65584" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5058,6 +5146,7 @@
 							<If Condition="GetQuestStep(65627) == 255">
 								<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65627" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5106,6 +5195,7 @@
 							<If Condition="GetQuestStep(65683) == 255">
 								<MoveTo XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65683" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5161,6 +5251,7 @@
 							<If Condition="GetQuestStep(65628) == 255">
 								<GetTo ZoneId="133" XYZ="-258.8083, -5.773526, -27.26788" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="65628" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5228,6 +5319,7 @@
 								</If>
 								<MoveTo Name="E-Sumi-Yan" XYZ="-258.8083, -5.773526, -27.26788" />
 								<TurnIn QuestId="65629" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5293,6 +5385,7 @@
 								</If>
 								<MoveTo Name="E-Sumi-Yan" XYZ="-258.8083, -5.773526, -27.26788" />
 								<TurnIn QuestId="65976" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5376,6 +5469,7 @@
 								</If>
 								<MoveTo Name="E-Sumi-Yan" XYZ="-258.8083, -5.773526, -27.26788" />
 								<TurnIn QuestId="65977" NpcId="1000692" XYZ="-258.8083, -5.773526, -27.26788" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5419,6 +5513,7 @@
 								</If>
 								<MoveTo Name="Braya" XYZ="-243.1525, -4.000004, -7.950012" />
 								<TurnIn QuestId="65730" NpcId="1000705" XYZ="-243.1525, -4.000004, -7.950012" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5478,6 +5573,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="66615" NpcId="1006751" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5533,6 +5629,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66616" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5580,6 +5677,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66617" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5672,6 +5770,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66618" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5735,6 +5834,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="66619" NpcId="1006751" ItemId="2000944" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5797,6 +5897,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn NpcId="1006751" QuestId="66620" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5870,6 +5971,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="-45.02942, -40.95, 174.3037" />
 								<TurnIn QuestId="67255" NpcId="1013609" XYZ="-45.02942, -40.95, 174.3037" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -5935,6 +6037,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="209.2164, 302, -204.8524" />
 								<TurnIn QuestId="67256" NpcId="1013610" XYZ="209.2164, 302, -204.8524" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6003,6 +6106,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="463.5232, 200.2377, 651.911" />
 								<TurnIn QuestId="67257" NpcId="1013614" XYZ="463.5232, 200.2377, 651.911" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6049,6 +6153,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="486.9305, -51.1414, 25.98608" />
 								<TurnIn QuestId="67258" NpcId="1013623" XYZ="486.9305, -51.1414, 25.98608" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6102,6 +6207,7 @@
 								</If>
 								<NoCombatMoveTo Name="Eschiva" XYZ="-679.9573, -100.524, 775.1736" />
 								<TurnIn QuestId="67259" NpcId="1013625" XYZ="-679.9573, -100.524, 775.1736" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6131,6 +6237,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="67260" NpcId="1006751" ItemId="2001688" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6227,6 +6334,7 @@
 								</If>
 								<NoCombatMoveTo Name="Raya-O-Senna" XYZ="-139.4522, 8.712891, 281.6968" />
 								<TurnIn QuestId="67261" NpcId="1006751" ItemId="2001688" XYZ="-139.4522, 8.712891, 281.6968" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6269,6 +6377,7 @@
 							<If Condition="GetQuestStep(67950) == 255">
 								<GetTo ZoneId="612" XYZ="-622.5834, 130.265, -473.7469" /> <!-- E-Sumi-Yan -->
 								<TurnIn QuestId="67950" NpcId="1018752" XYZ="-622.5834, 130.265, -473.7469" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6300,6 +6409,7 @@
 							<If Condition="GetQuestStep(67951) == 255">
 								<GetTo ZoneId="612" XYZ="-623.621, 130.2421, -474.7234" /> <!-- Sylphie -->
 								<TurnIn QuestId="67951" NpcId="1018753" XYZ="-623.621, 130.2421, -474.7234" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6348,6 +6458,7 @@
 							<If Condition="GetQuestStep(67952) == 255">
 								<GetTo ZoneId="612" XYZ="-623.621, 130.2421, -474.7234" /> <!-- Sylphie -->
 								<TurnIn QuestId="67952" NpcId="1018753" XYZ="-623.621, 130.2421, -474.7234" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6379,6 +6490,7 @@
 							<If Condition="GetQuestStep(67953) == 255">
 								<GetTo ZoneId="612" XYZ="-655.024, 40.43195, 375.967" /> <!-- Sylphie -->
 								<TurnIn QuestId="67953" NpcId="1019132" XYZ="-655.024, 40.43195, 375.967" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6437,6 +6549,7 @@
 							<If Condition="GetQuestStep(67954) == 255">
 								<GetTo ZoneId="612" XYZ="-382.7115, 40.27582, 484.3669" /> <!-- Gatty -->
 								<TurnIn QuestId="67954" NpcId="1019588" XYZ="-382.7115, 40.27582, 484.3669" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -6528,6 +6641,7 @@
 							</If>
 							<MoveTo Name="Fray" XYZ="43.38135, 16.0801, -86.04565" />
 							<TurnIn QuestId="67590" NpcId="1014889" XYZ="43.38135, 16.0801, -86.04565" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6602,6 +6716,7 @@
 							</If>
 							<NoCombatMoveTo Name="Fray" XYZ="-215.7168, 16.84427, -270.6493" />
 							<TurnIn QuestId="67591" NpcId="1014893" XYZ="-215.7168, 16.84427, -270.6493" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6693,6 +6808,7 @@
 							</If>
 							<NoCombatMoveTo Name="Fray" XYZ="-367.1473, -55.99894, 107.103" />
 							<TurnIn QuestId="67592" NpcId="1014895" XYZ="-367.1473, -55.99894, 107.103" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6762,6 +6878,7 @@
 							</If>
 							<NoCombatMoveTo Name="Fray" XYZ="235.6755, 7.999999, 698.207" />
 							<TurnIn QuestId="67593" NpcId="1014901" XYZ="235.6755, 7.999999, 698.207" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6834,6 +6951,7 @@
 							</If>
 							<NoCombatMoveTo Name="Untiring Knight" XYZ="-431.2657, 211, -251.2093" />
 							<TurnIn QuestId="67594" NpcId="1014908" XYZ="-431.2657, 211, -251.2093" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6874,6 +6992,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67595" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -6941,6 +7060,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67596" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7025,6 +7145,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67597" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7085,6 +7206,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67598" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7172,6 +7294,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67599" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7223,6 +7346,7 @@
 							</If>
 							<MoveTo Name="Sidurgu" XYZ="104.2344, 14.99999, 40.78735" />
 							<TurnIn QuestId="67600" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7274,6 +7398,7 @@
 						<If Condition="GetQuestStep(68451) == 255">
 							<GetTo ZoneId="397" XYZ="482.0782, 203.4332, 680.7506" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68451" NpcId="1022866" XYZ="482.0782, 203.4332, 680.7506" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7318,6 +7443,7 @@
 						<If Condition="GetQuestStep(68452) == 255">
 							<GetTo ZoneId="398" XYZ="461.4175, -51.1414, 43.4729" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68452" NpcId="1022885" XYZ="461.4175, -51.1414, 43.4729" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7386,6 +7512,7 @@
 						<If Condition="GetQuestStep(68453) == 255">
 							<GetTo ZoneId="400" XYZ="253.0708, -43.13636, 626.8864" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68453" NpcId="1022953" XYZ="253.0708, -43.13636, 626.8864" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7441,6 +7568,7 @@
 						<If Condition="GetQuestStep(68454) == 255">
 							<GetTo ZoneId="418" XYZ="104.2344, 14.99999, 40.78735" /> <!-- Sidurgu -->
 							<TurnIn QuestId="68454" NpcId="1013969" XYZ="104.2344, 14.99999, 40.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7514,6 +7642,7 @@
 						<If Condition="GetQuestStep(68455) == 255">
 							<GetTo ZoneId="419" XYZ="2.670288, 11.94781, 36.97253" /> <!-- Where It All Began -->
 							<TurnIn QuestId="68455" NpcId="2008885" XYZ="2.670288, 11.94781, 36.97253" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7556,6 +7685,7 @@
 						<If Condition="GetQuestStep(65822) == 255">
 							<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 							<TurnIn QuestId="65822" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -7610,6 +7740,7 @@
 							<If Condition="GetQuestStep(65792) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65792" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7658,6 +7789,7 @@
 							<If Condition="GetQuestStep(65797) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65797" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7706,6 +7838,7 @@
 							<If Condition="GetQuestStep(65824) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65824" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7751,6 +7884,7 @@
 							<If Condition="GetQuestStep(65798) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="65798" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7836,6 +7970,7 @@
 								</If>
 								<MoveTo Name="Mylla" XYZ="-94.52972, 6.500001, 39.81079" />
 								<TurnIn QuestId="65799" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7904,6 +8039,7 @@
 								</If>
 								<MoveTo Name="Mylla" XYZ="-94.52972, 6.500001, 39.81079" />
 								<TurnIn QuestId="65800" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -7986,6 +8122,7 @@
 								</If>
 								<MoveTo Name="Mylla" XYZ="-94.52972, 6.500001, 39.81079" />
 								<TurnIn QuestId="65801" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8043,6 +8180,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66591" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8089,6 +8227,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66592" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8121,6 +8260,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66593" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8163,6 +8303,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66594" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8204,6 +8345,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66595" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8259,6 +8401,7 @@
 								</If>
 								<MoveTo Name="Jenlyns" XYZ="-20.82861, 29.99996, -2.426208" />
 								<TurnIn QuestId="66596" NpcId="1006747" ItemId="2000822" XYZ="-20.82861, 29.99996, -2.426208" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8319,6 +8462,7 @@
 								</If>
 								<NoCombatMoveTo Name="Jenlyns" XYZ="75.33374, 2.135708, 316.3347" />
 								<TurnIn QuestId="67568" NpcId="1003995" XYZ="75.33374, 2.135708, 316.3347" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8367,6 +8511,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67569" NpcId="1014054" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8468,6 +8613,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67570" NpcId="1014065" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8514,6 +8660,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="51.13293, 124.9563, 178.6984" />
 								<TurnIn QuestId="67571" NpcId="1014068" XYZ="51.13293, 124.9563, 178.6984" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8595,6 +8742,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67572" NpcId="1015055" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8672,6 +8820,7 @@
 								</If>
 								<NoCombatMoveTo Name="Constaint" XYZ="509.1782, 212.5399, 695.796" />
 								<TurnIn QuestId="67573" NpcId="1014103" XYZ="509.1782, 212.5399, 695.796" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8703,6 +8852,7 @@
 							<If Condition="GetQuestStep(68107) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68107" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8756,6 +8906,7 @@
 							<If Condition="GetQuestStep(68108) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68108" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8797,6 +8948,7 @@
 							<If Condition="GetQuestStep(68109) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68109" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8847,6 +8999,7 @@
 							<If Condition="GetQuestStep(68110) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68110" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8886,6 +9039,7 @@
 							<If Condition="GetQuestStep(68111) == 255">
 								<GetTo ZoneId="131" XYZ="-94.52972, 6.500001, 39.81079" /> <!-- Mylla -->
 								<TurnIn QuestId="68111" NpcId="1001739" XYZ="-94.52972, 6.500001, 39.81079" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -8930,6 +9084,7 @@
 						<If Condition="GetQuestStep(65754) == 255">
 							<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 							<TurnIn QuestId="65754" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -8977,6 +9132,7 @@
 							<If Condition="GetQuestStep(65583) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65583" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9004,6 +9160,7 @@
 							<If Condition="GetQuestStep(65571) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65571" NpcId="1000254" ItemId="2000102" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9031,6 +9188,7 @@
 							<If Condition="GetQuestStep(65679) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65679" NpcId="1000254" ItemId="2000122" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9074,6 +9232,7 @@
 							<If Condition="GetQuestStep(65591) == 255">
 								<GetTo ZoneId="133" XYZ="157.7019, 15.90038, -270.3442" /> <!-- Ywain -->
 								<TurnIn QuestId="65591" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9153,6 +9312,7 @@
 								</If>
 								<NoCombatMoveTo Name="Ywain" XYZ="157.7019, 15.90038, -270.3442" />
 								<TurnIn QuestId="65592" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9248,6 +9408,7 @@
 								</If>
 								<NoCombatMoveTo Name="Ywain" XYZ="157.7019, 15.90038, -270.3442" />
 								<TurnIn QuestId="65974" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9303,6 +9464,7 @@
 								</If>
 								<NoCombatMoveTo Name="Ywain" XYZ="157.7019, 15.90038, -270.3442" />
 								<TurnIn QuestId="65975" NpcId="1000254" XYZ="157.7019, 15.90038, -270.3442" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9369,6 +9531,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66603" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9431,6 +9594,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66604" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9471,6 +9635,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66605" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9569,6 +9734,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66606" NpcId="1006748" ItemIds="2000814,2000815" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9601,6 +9767,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66607" NpcId="1006748" ItemId="2000824" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9641,6 +9808,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="66608" NpcId="1006748" ItemId="2000824" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9673,6 +9841,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67225" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9721,6 +9890,7 @@
 								</If>
 								<NoCombatMoveTo Name="Heustienne" XYZ="202.1973, 183.6595, -96.11658" />
 								<TurnIn QuestId="67226" NpcId="1013445" XYZ="202.1973, 183.6595, -96.11658" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9753,6 +9923,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67227" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9815,6 +9986,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67228" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9861,6 +10033,7 @@
 								</If>
 								<NoCombatMoveTo Name="Montorgains" XYZ="218.0056, 222, 346.4561" />
 								<TurnIn QuestId="67229" NpcId="1013470" XYZ="218.0056, 222, 346.4561" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9915,6 +10088,7 @@
 								</If>
 								<NoCombatMoveTo Name="Alberic" XYZ="217.8835, 222, 345.3269" />
 								<TurnIn QuestId="67230" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -9985,6 +10159,7 @@
 								</If>
 								<NoCombatMoveTo Name="Heustienne" XYZ="-505.3026, 120.6116, -311.3909" />
 								<TurnIn QuestId="67231" NpcId="1013494" XYZ="-505.3026, 120.6116, -311.3909" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10008,6 +10183,7 @@
 							<If Condition="GetQuestStep(68446) == 255">
 								<GetTo ZoneId="155" XYZ="217.8835, 222, 345.3269" /> <!-- Alberic -->
 								<TurnIn QuestId="68446" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10043,6 +10219,7 @@
 							<If Condition="GetQuestStep(68447) == 255">
 								<GetTo ZoneId="155" XYZ="217.8835, 222, 345.3269" /> <!-- Alberic -->
 								<TurnIn QuestId="68447" NpcId="1006748" XYZ="217.8835, 222, 345.3269" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10087,6 +10264,7 @@
 							<If Condition="GetQuestStep(68448) == 255">
 								<GetTo ZoneId="628" XYZ="-92.60706, 18.9999, -194.4152" /> <!-- Orn Khai -->
 								<TurnIn QuestId="68448" NpcId="1022553" XYZ="-92.60706, 18.9999, -194.4152" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10150,6 +10328,7 @@
 							<If Condition="GetQuestStep(68449) == 255">
 								<GetTo ZoneId="622" XYZ="528.4656, -19.45055, 273.3348" /> <!-- Orn Khai -->
 								<TurnIn QuestId="68449" NpcId="1022560" XYZ="528.4656, -19.45055, 273.3348" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10191,6 +10370,7 @@
 							<If Condition="GetQuestStep(68450) == 255">
 								<GetTo ZoneId="622" XYZ="-494.3466, 71.27808, -509.514" /> <!-- Orn Khai -->
 								<TurnIn QuestId="68450" NpcId="1022562" XYZ="-494.3466, 71.27808, -509.514" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -10247,6 +10427,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67233" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10335,6 +10516,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67234" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10360,6 +10542,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67235" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10441,6 +10624,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67236" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10466,6 +10650,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67237" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10531,6 +10716,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67238" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10595,6 +10781,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67239" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10659,6 +10846,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67240" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10698,6 +10886,7 @@
 							</If>
 							<MoveTo Name="Count Baurendouin De Haillenarte" XYZ="-152.8802, 17, -52.90308" />
 							<TurnIn QuestId="67241" NpcId="1014796" XYZ="-152.8802, 17, -52.90308" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10766,6 +10955,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67242" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10835,6 +11025,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67243" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10903,6 +11094,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67244" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10953,6 +11145,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67246" NpcId="1014577" ItemId="2001818" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -10992,6 +11185,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67247" NpcId="1014577" ItemId="2001818" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11062,6 +11256,7 @@
 							</If>
 							<MoveTo Name="Stephanivien" XYZ="-154.3146, 16.99999, -53.3609" />
 							<TurnIn QuestId="67248" NpcId="1014577" XYZ="-154.3146, 16.99999, -53.3609" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11095,6 +11290,7 @@
 						<If Condition="GetQuestStep(68441) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68441" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11134,6 +11330,7 @@
 						<If Condition="GetQuestStep(68442) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68442" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11174,6 +11371,7 @@
 						<If Condition="GetQuestStep(68443) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68443" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11214,6 +11412,7 @@
 						<If Condition="GetQuestStep(68444) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68444" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11253,6 +11452,7 @@
 						<If Condition="GetQuestStep(68445) == 255">
 							<GetTo ZoneId="418" XYZ="12.31396, -12.02088, 40.26843" /> <!-- Hilda -->
 							<TurnIn QuestId="68445" NpcId="1012251" XYZ="12.31396, -12.02088, 40.26843" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11295,6 +11495,7 @@
 						<If Condition="GetQuestStep(65848) == 255">
 							<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 							<TurnIn QuestId="65848" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -11367,6 +11568,7 @@
 							<If Condition="GetQuestStep(65849) == 255">
 								<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65849" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11398,6 +11600,7 @@
 							<If Condition="GetQuestStep(65850) == 255">
 								<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65850" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11429,6 +11632,7 @@
 							<If Condition="GetQuestStep(65851) == 255">
 								<GetTo ZoneId="128" XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65851" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11500,6 +11704,7 @@
 								</If>
 								<MoveTo XYZ="-1.205505, 44.99989, -255.8786" /> <!-- Wyrnzoen -->
 								<TurnIn QuestId="65852" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11586,6 +11791,7 @@
 								</If>
 								<MoveTo Name="Wyrnzoen" XYZ="-1.205505, 44.99989, -255.8786" />
 								<TurnIn QuestId="65853" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11636,6 +11842,7 @@
 								</If>
 								<MoveTo Name="Wyrnzoen" XYZ="-1.205505, 44.99989, -255.8786" />
 								<TurnIn QuestId="65854" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11734,6 +11941,7 @@
 								</If>
 								<MoveTo Name="Wyrnzoen" XYZ="-1.205505, 44.99989, -255.8786" />
 								<TurnIn QuestId="65855" NpcId="1000927" XYZ="-1.205505, 44.99989, -255.8786" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11807,6 +12015,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66585" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11868,6 +12077,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66586" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -11939,6 +12149,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66587" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12032,6 +12243,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66588" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12072,6 +12284,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66589" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12132,6 +12345,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="460.6545, 8.309061, 74.47925" />
 								<TurnIn QuestId="66590" NpcId="1006746" XYZ="460.6545, 8.309061, 74.47925" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12197,6 +12411,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66121" NpcId="1013279" ItemId="2001589" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12245,6 +12460,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66122" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12301,6 +12517,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66124" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>						
 						</If>
 					</If>
@@ -12410,6 +12627,7 @@
 								</If>
 								<NoCombatMoveTo Name="Storm Captain" XYZ="304.1886, -36.40591, 332.6923" />
 								<TurnIn QuestId="66132" NpcId="1013282" ItemId="2001662" XYZ="304.1886, -36.40591, 332.6923" />
+								<WaitTimer WaitTime="2"/>
 							</If> 
 						</If>
 					</If>
@@ -12458,6 +12676,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="67213" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12560,6 +12779,7 @@
 								</If>
 								<NoCombatMoveTo Name="Broken Mountain" XYZ="441.7028, 8.670496, 18.81433" />
 								<TurnIn QuestId="66134" NpcId="1013279" ItemId="2001662" XYZ="441.7028, 8.670496, 18.81433" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12644,6 +12864,7 @@
 								</If>
 								<NoCombatMoveTo Name="Curious Gorge" XYZ="-109.9718, -24.72433, 63.55383" />
 								<TurnIn QuestId="66137" NpcId="1013329" ItemId="2001886" XYZ="-109.9718, -24.72433, 63.55383" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12681,6 +12902,7 @@
 							<If Condition="GetQuestStep(68436) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68436" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12718,6 +12940,7 @@
 							<If Condition="GetQuestStep(68436) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68436" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12753,6 +12976,7 @@
 							<If Condition="GetQuestStep(68437) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68437" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12796,6 +13020,7 @@
 							<If Condition="GetQuestStep(68438) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68438" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12833,6 +13058,7 @@
 							<If Condition="GetQuestStep(68439) == 255">
 								<GetTo ZoneId="622" XYZ="525.1088, -19.50681, 403.3722" /> <!-- Curious Gorge -->
 								<TurnIn QuestId="68439" NpcId="1022836" XYZ="525.1088, -19.50681, 403.3722" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12896,6 +13122,7 @@
 							<If Condition="GetQuestStep(68440) == 255">
 								<GetTo ZoneId="135" XYZ="217.3036, 7.999984, 686.427" /> <!-- Broken Mountain -->
 								<TurnIn QuestId="68440" NpcId="1023885" XYZ="217.3036, 7.999984, 686.427" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -12940,6 +13167,7 @@
 						<If Condition="GetQuestStep(66089) == 255">
 							<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 							<TurnIn QuestId="66089" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -12986,6 +13214,7 @@
 							<If Condition="GetQuestStep(66090) == 255">
 								<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 								<TurnIn QuestId="66090" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13021,6 +13250,7 @@
 							<If Condition="GetQuestStep(66091) == 255">
 								<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 								<TurnIn QuestId="66091" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13056,6 +13286,7 @@
 							<If Condition="GetQuestStep(66234) == 255">
 								<GetTo ZoneId="130" XYZ="-74.57086, 2.000005, -42.40485" /> <!-- Hamon -->
 								<TurnIn QuestId="66234" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13110,6 +13341,7 @@
 							<If Condition="GetQuestStep(66094) == 255">
 								<GetTo ZoneId="130" XYZ="-65.65961, 0.9482077, -51.98755" /> <!-- Chuchuto -->
 								<TurnIn QuestId="66094" NpcId="1003827" XYZ="-65.65961, 0.9482077, -51.98755" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13175,6 +13407,7 @@
 								</If>
 								<MoveTo Name="Hamon" XYZ="-74.57086, 2.000005, -42.40485" />
 								<TurnIn QuestId="66098" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13246,6 +13479,7 @@
 								</If>
 								<MoveTo Name="Hamon" XYZ="-74.57086, 2.000005, -42.40485" />
 								<TurnIn QuestId="66102" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13318,6 +13552,7 @@
 								</If>
 								<MoveTo Name="Hamon" XYZ="-74.57086, 2.000005, -42.40485" />
 								<TurnIn QuestId="66103" NpcId="1003817" XYZ="-74.57086, 2.000005, -42.40485" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13378,6 +13613,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66597" NpcId="1006749" ItemId="2001061" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13437,6 +13673,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66598" NpcId="1006749" ItemId="2001062" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13483,6 +13720,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66599" NpcId="1006749" ItemId="2001063" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13522,6 +13760,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66600" NpcId="1006749" ItemId="2001064" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13607,6 +13846,7 @@
 								</If>
 								<MoveTo Name="Erik" XYZ="-30.47229, 13.59992, 95.26196" />
 								<TurnIn QuestId="66601" NpcId="1006749" ItemId="2001064" XYZ="-30.47229, 13.59992, 95.26196" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13653,6 +13893,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="104.7227, -4.938011, -533.5317" />
 								<TurnIn QuestId="66602" NpcId="1007899" XYZ="104.7227, -4.938011, -533.5317" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13729,6 +13970,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67562" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13810,6 +14052,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67563" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13857,6 +14100,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67564" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13903,6 +14147,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67565" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -13966,6 +14211,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="15.85406, 28.62082, -682.765" />
 								<TurnIn QuestId="67566" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If> -->
@@ -14014,6 +14260,7 @@
 								</If>
 								<NoCombatMoveTo Name="Widargelt" XYZ="-149.3401, 12.68588, -260.9141" />
 								<TurnIn QuestId="67567" NpcId="1014112" XYZ="-149.3401, 12.68588, -260.9141" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14045,6 +14292,7 @@
 							<If Condition="GetQuestStep(67962) == 255">
 								<GetTo ZoneId="156" XYZ="15.85406, 28.62082, -682.765" /> <!-- Widargelt -->
 								<TurnIn QuestId="67962" NpcId="1013971" XYZ="15.85406, 28.62082, -682.765" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14088,6 +14336,7 @@
 							<If Condition="GetQuestStep(67963) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67963" NpcId="1022390" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14131,6 +14380,7 @@
 							<If Condition="GetQuestStep(67964) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67964" NpcId="1023728" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14185,6 +14435,7 @@
 							<If Condition="GetQuestStep(67965) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67965" NpcId="1022390" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14240,6 +14491,7 @@
 							<If Condition="GetQuestStep(67966) == 255">
 								<GetTo ZoneId="620" XYZ="51.13293, 118.4443, -789.2729" /> <!-- Widargelt -->
 								<TurnIn QuestId="67966" NpcId="1022390" XYZ="51.13293, 118.4443, -789.2729" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -14297,6 +14549,7 @@
 						<If Condition="GetQuestStep(68113) == 255">
 							<GetTo ZoneId="145" XYZ="-496.7575, -17.41137, 28.0918" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68113" NpcId="1021447" XYZ="-496.7575, -17.41137, 28.0918" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14348,6 +14601,7 @@
 						<If Condition="GetQuestStep(68114) == 255">
 							<GetTo ZoneId="140" XYZ="-476.402, 23.2289, -430.7164" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68114" ItemId="2002181" NpcId="1021457" XYZ="-476.402, 23.2289, -430.7164" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14397,6 +14651,7 @@
 						<If Condition="GetQuestStep(68115) == 255">
 							<GetTo ZoneId="138" XYZ="307.3624, -36.40299, 309.9871" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68115" NpcId="1021462" XYZ="307.3624, -36.40299, 309.9871" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14458,6 +14713,7 @@
 						<If Condition="GetQuestStep(68116) == 255">
 							<GetTo ZoneId="138" XYZ="311.3907, -25.00225, 230.8231" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68116" NpcId="1021473" XYZ="311.3907, -25.00225, 230.8231" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14497,6 +14753,7 @@
 						<If Condition="GetQuestStep(68117) == 255">
 							<GetTo ZoneId="147" XYZ="-94.92645, 48.01958, -31.57098" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68117" NpcId="1021482" XYZ="-94.92645, 48.01958, -31.57098" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14561,6 +14818,7 @@
 						<If Condition="GetQuestStep(68118) == 255">
 							<GetTo ZoneId="156" XYZ="55.55798, 20.48517, -672.5719" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68118" NpcId="1021493" XYZ="55.55798, 20.48517, -672.5719" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14600,6 +14858,7 @@
 						<If Condition="GetQuestStep(68119) == 255">
 							<GetTo ZoneId="478" XYZ="-5.44751, 211, -39.6582" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68119" NpcId="1021779" XYZ="-5.44751, 211, -39.6582" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14655,6 +14914,7 @@
 						<If Condition="GetQuestStep(68120) == 255">
 							<GetTo ZoneId="478" XYZ="-4.135254, 211, -39.84137" /> <!-- Arya -->
 							<TurnIn QuestId="68120" NpcId="1021778" XYZ="-4.135254, 211, -39.84137" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14718,6 +14978,7 @@
 						<If Condition="GetQuestStep(68121) == 255">
 							<GetTo ZoneId="478" XYZ="-5.44751, 211, -39.6582" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68121" NpcId="1021779" XYZ="-5.44751, 211, -39.6582" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14771,6 +15032,7 @@
 						<If Condition="GetQuestStep(68122) == 255">
 							<GetTo ZoneId="419" XYZ="-19.63837, 15.96505, -37.24731" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68122" NpcId="1021795" XYZ="-19.63837, 15.96505, -37.24731" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14834,6 +15096,7 @@
 						<If Condition="GetQuestStep(68123) == 255">
 							<GetTo ZoneId="156" XYZ="55.55798, 20.41107, -675.5627" /> <!-- X'rhun Tia -->
 							<TurnIn QuestId="68123" NpcId="1021800" XYZ="55.55798, 20.41107, -675.5627" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14899,6 +15162,7 @@
 							</If>
 							<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 							<TurnIn QuestId="65640" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -14982,6 +15246,7 @@
 								</If>
 								<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 								<TurnIn QuestId="65646" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15088,6 +15353,7 @@
 								</If>
 								<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 								<TurnIn QuestId="65662" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15161,6 +15427,7 @@
 							<If Condition="GetQuestStep(65680) == 255">
 								<GetTo ZoneId="138" XYZ="319.4476, -36.35382, 346.7612" /> <!-- Jacke -->
 								<TurnIn QuestId="65680" NpcId="1010218" XYZ="319.4476, -36.35382, 346.7612" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15203,6 +15470,7 @@
 								</If>
 								<GetTo ZoneId="129" XYZ="-153.3685, -129.4397, 265.8884" /> <!-- Jacke -->
 								<TurnIn QuestId="65681" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15310,6 +15578,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65682" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15398,6 +15667,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65684" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15466,6 +15736,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65690" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15534,6 +15805,7 @@
 								</If>
 								<MoveTo Name="Jacke" XYZ="-153.3685, -129.4397, 265.8884" />
 								<TurnIn QuestId="65691" NpcId="1009943" XYZ="-153.3685, -129.4397, 265.8884" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15632,6 +15904,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65748" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15722,6 +15995,7 @@
 								</If>
 								<NoCombatMoveTo Name="Oboro" XYZ="-4.348877, 39.53194, 247.6387" />
 								<TurnIn QuestId="65749" NpcId="1010616" XYZ="-4.348877, 39.53194, 247.6387" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15756,6 +16030,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65750" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15868,6 +16143,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65751" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -15902,6 +16178,7 @@
 								</If>
 								<NoCombatMoveTo Name="Oboro" XYZ="473.1364, 16.49299, 67.33801" />
 								<TurnIn QuestId="65752" NpcId="1010619" XYZ="473.1364, 16.49299, 67.33801" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16009,6 +16286,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65753" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16127,6 +16405,7 @@
 								</If>
 								<NoCombatMoveTo Name="Destination" XYZ="-182.8184, 30.5332, -684.9318" />
 								<TurnIn QuestId="65768" NpcId="2004932" XYZ="-182.8184, 30.5332, -684.9318" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16198,6 +16477,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65769" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16293,6 +16573,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65770" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16375,6 +16656,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="65771" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16448,6 +16730,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="67220" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16550,6 +16833,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="67221" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16621,6 +16905,7 @@
 								</If>
 								<MoveTo Name="Oboro" XYZ="-33.21893, -24.67444, 257.9841" />
 								<TurnIn QuestId="67222" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16700,6 +16985,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="67223" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16806,6 +17092,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="67224" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16873,6 +17160,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="68484" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16939,6 +17227,7 @@
 							<If Condition="GetQuestStep(68485) == 255">
 								<GetTo ZoneId="628" XYZ="116.8077, 11.97827, -38.34595" /> <!-- Destination -->
 								<TurnIn QuestId="68485" NpcId="2008937" XYZ="116.8077, 11.97827, -38.34595" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -16999,6 +17288,7 @@
 							<If Condition="GetQuestStep(68486) == 255">
 								<GetTo ZoneId="614" XYZ="412.1614, 68.02851, -96.75751" /> <!-- Oboro -->
 								<TurnIn QuestId="68486" NpcId="1023570" XYZ="412.1614, 68.02851, -96.75751" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17058,6 +17348,7 @@
 							<If Condition="GetQuestStep(68487) == 255">
 								<GetTo ZoneId="614" XYZ="412.1614, 68.02851, -96.75751" /> <!-- Oboro -->
 								<TurnIn QuestId="68487" NpcId="1023570" XYZ="412.1614, 68.02851, -96.75751" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17098,6 +17389,7 @@
 								</If>
 								<GetTo ZoneId="137" XYZ="-33.21893, -24.67444, 257.9841" /> <!-- Oboro -->
 								<TurnIn QuestId="68488" NpcId="1010139" XYZ="-33.21893, -24.67444, 257.9841" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17144,6 +17436,7 @@
 						<If Condition="GetQuestStep(68096) == 255">
 							<GetTo ZoneId="130" XYZ="35.66028, 6.999999, -82.99384" /> <!-- Musosai -->
 							<TurnIn QuestId="68096" NpcId="1021835" XYZ="35.66028, 6.999999, -82.99384" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17189,6 +17482,7 @@
 						<If Condition="GetQuestStep(68097) == 255">
 							<GetTo ZoneId="128" XYZ="9.536865, 40.00023, -15.21332" /> <!-- Musosai -->
 							<TurnIn QuestId="68097" NpcId="1021858" XYZ="9.536865, 40.00023, -15.21332" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17242,6 +17536,7 @@
 						<If Condition="GetQuestStep(68098) == 255">
 							<GetTo ZoneId="132" XYZ="43.25928, -8, 99.19885" /> <!-- Musosai -->
 							<TurnIn QuestId="68098" NpcId="1021869" XYZ="43.25928, -8, 99.19885" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17291,6 +17586,7 @@
 						<If Condition="GetQuestStep(68099) == 255">
 							<GetTo ZoneId="418" XYZ="112.4132, 3.629973, 62.30261" /> <!-- Musosai -->
 							<TurnIn QuestId="68099" NpcId="1021878" XYZ="112.4132, 3.629973, 62.30261" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17336,6 +17632,7 @@
 						<If Condition="GetQuestStep(68100) == 255">
 							<GetTo ZoneId="418" XYZ="112.5048, 3.629974, 60.83765" /> <!-- Momozigo -->
 							<TurnIn QuestId="68100" NpcId="1021879" XYZ="112.5048, 3.629974, 60.83765" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17384,6 +17681,7 @@
 						<If Condition="GetQuestStep(68101) == 255">
 							<GetTo ZoneId="130" XYZ="36.85046, 6.999999, -83.78735" /> <!-- Momozigo -->
 							<TurnIn QuestId="68101" NpcId="1021836" XYZ="36.85046, 6.999999, -83.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17419,6 +17717,7 @@
 						<If Condition="GetQuestStep(68102) == 255">
 							<GetTo ZoneId="130" XYZ="36.85046, 6.999999, -83.78735" /> <!-- Momozigo -->
 							<TurnIn QuestId="68102" NpcId="1021836" XYZ="36.85046, 6.999999, -83.78735" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17450,6 +17749,7 @@
 						<If Condition="GetQuestStep(68103) == 255">
 							<GetTo ZoneId="628" XYZ="128.6183, 15, -158.0378" /> <!-- Soft-spoken Sekiseigumi -->
 							<TurnInPlus QuestId="68103" NpcId="1022190" XYZ="128.6183, 15, -158.0378" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17510,6 +17810,7 @@
 						<If Condition="GetQuestStep(68104) == 255">
 							<GetTo ZoneId="628" XYZ="128.5573, 15, -158.0988" /> <!-- Kongo -->
 							<TurnIn QuestId="68104" NpcId="1022203" XYZ="128.5573, 15, -158.0988" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17553,6 +17854,7 @@
 						<If Condition="GetQuestStep(68105) == 255">
 							<GetTo ZoneId="628" XYZ="129.7169, 15, -157.6105" /> <!-- Makoto -->
 							<TurnIn QuestId="68105" NpcId="1022184" XYZ="129.7169, 15, -157.6105" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17605,6 +17907,7 @@
 						<If Condition="GetQuestStep(68106) == 255">
 							<GetTo ZoneId="628" XYZ="129.7169, 15, -157.6105" /> <!-- Makoto -->
 							<TurnIn QuestId="68106" NpcId="1022184" XYZ="129.7169, 15, -157.6105" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17649,6 +17952,7 @@
 						<If Condition="GetQuestStep(65882) == 255">
 							<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 							<TurnIn QuestId="65882" NpcId="1001708" ItemId="2001545" XYZ="-250.3548, 18, 80.88806" />
+							<WaitTimer WaitTime="2"/>
 						</If>
 					</If>
 				</If>
@@ -17683,6 +17987,7 @@
 							<If Condition="GetQuestStep(65883) == 255">
 								<GetTo ZoneId="130" XYZ="-240.4975, 18.7, 85.58777" /> <!-- Cocobygo -->
 								<TurnIn QuestId="65883" NpcId="1001709" XYZ="-240.4975, 18.7, 85.58777" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17726,6 +18031,7 @@
 							<If Condition="GetQuestStep(65884) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65884" NpcId="1001708" ItemIds="2000418,2000419" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17765,6 +18071,7 @@
 							<If Condition="GetQuestStep(65885) == 255">
 								<GetTo ZoneId="130" XYZ="-240.2533, 18.8, 86.90002" /> <!-- Cocobani -->
 								<TurnIn QuestId="65885" NpcId="1001710" ItemIds="2000418,2000419" XYZ="-240.2533, 18.8, 86.90002" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17822,6 +18129,7 @@
 							<If Condition="GetQuestStep(65886) == 255">
 								<GetTo ZoneId="130" XYZ="-241.6266, 18.8, 83.32947" /> <!-- Cocobezi -->
 								<TurnIn QuestId="65886" NpcId="1001711" ItemId="2001545" XYZ="-241.6266, 18.8, 83.32947" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17890,6 +18198,7 @@
 							<If Condition="GetQuestStep(65887) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65887" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17940,6 +18249,7 @@
 							<If Condition="GetQuestStep(65888) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65888" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -17999,6 +18309,7 @@
 							<If Condition="GetQuestStep(65889) == 255">
 								<GetTo ZoneId="130" XYZ="-250.3548, 18, 80.88806" /> <!-- Cocobuki -->
 								<TurnIn QuestId="65889" NpcId="1001708" XYZ="-250.3548, 18, 80.88806" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18035,6 +18346,7 @@
 							<If Condition="GetQuestStep(66609) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="66609" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18076,6 +18388,7 @@
 							<If Condition="GetQuestStep(66610) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="66610" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18135,6 +18448,7 @@
 							<If Condition="GetQuestStep(66611) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66611" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18176,6 +18490,7 @@
 							<If Condition="GetQuestStep(66612) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66612" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18221,6 +18536,7 @@
 							<If Condition="GetQuestStep(66613) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66613" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18266,6 +18582,7 @@
 							<If Condition="GetQuestStep(66614) == 255">
 								<GetTo ZoneId="145" XYZ="325.063, 11.23651, -6.21051" /> <!-- Kazagg Chah -->
 								<TurnIn QuestId="66614" NpcId="1006753" XYZ="325.063, 11.23651, -6.21051" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18293,6 +18610,7 @@
 							<If Condition="GetQuestStep(67214) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67214" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18324,6 +18642,7 @@
 							<If Condition="GetQuestStep(67215) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67215" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18383,6 +18702,7 @@
 							<If Condition="GetQuestStep(67216) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67216" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18410,6 +18730,7 @@
 							<If Condition="GetQuestStep(67217) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67217" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 								<WaitWhile Condition="Managers.QuestLogManager.InCutscene" />
 							</If>
 						</If>
@@ -18472,6 +18793,7 @@
 							<If Condition="GetQuestStep(67218) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67218" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18532,6 +18854,7 @@
 							<If Condition="GetQuestStep(67219) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="67219" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18566,6 +18889,7 @@
 							<If Condition="GetQuestStep(68124) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68124" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18602,6 +18926,7 @@
 							<If Condition="GetQuestStep(68125) == 255">
 								<GetTo ZoneId="131" XYZ="87.47986, 18, 113.6949" /> <!-- Shatotto -->
 								<TurnIn QuestId="68125" NpcId="1020966" XYZ="87.47986, 18, 113.6949" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18641,6 +18966,7 @@
 							<If Condition="GetQuestStep(68126) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68126" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18680,6 +19006,7 @@
 							<If Condition="GetQuestStep(68127) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68127" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>
@@ -18728,6 +19055,7 @@
 							<If Condition="GetQuestStep(68128) == 255">
 								<GetTo ZoneId="131" XYZ="87.5105, 18, 113.7255" /> <!-- Lalai -->
 								<TurnIn QuestId="68128" NpcId="1006752" XYZ="87.5105, 18, 113.7255" />
+								<WaitTimer WaitTime="2"/>
 							</If>
 						</If>
 					</If>

--- a/Questing/[O] [MSQ] Heavensward.xml
+++ b/Questing/[O] [MSQ] Heavensward.xml
@@ -144,6 +144,7 @@
                     </If>
                     <GetTo ZoneId="419" XYZ="15.60992, 16.00967, -6.515625" /> <!-- Haurchefant -->
                     <TurnIn QuestId="67116" NpcId="1012313" XYZ="15.60992, 16.00967, -6.515625" />
+                    <WaitTimer WaitTime="2"/>
                     <WaitWhile Condition="not IsOnMap(433)" />
                 </If>
             </If>
@@ -194,10 +195,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67117" NpcId="1012323" XYZ="-50.21753, 8.05915, 15.45734" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67117" NpcId="1012323" XYZ="-50.21753, 8.05915, 15.45734" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -247,11 +250,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67118" NpcId="1013036" XYZ="-0.2289429, 0, 7.339539" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Alphinaud" XYZ="-0.2289429, 0, 7.339539" />
                     <TurnIn QuestId="67118" NpcId="1013036" XYZ="-0.2289429, 0, 7.339539" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -318,6 +323,7 @@
                     </If>
                     <NoCombatMoveTo Name="Redwald" XYZ="503.1051, 217.9515, 790.2189" />
                     <TurnIn QuestId="67119" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -363,10 +369,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67120" NpcId="1011236" XYZ="446.0059, 217.9514, 764.0649" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67120" NpcId="1011236" XYZ="446.0059, 217.9514, 764.0649" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -405,10 +413,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67121" NpcId="1011241" ItemId="2001572" XYZ="501.7318, 164.194, 301.1367" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67121" NpcId="1011241" ItemId="2001572" XYZ="501.7318, 164.194, 301.1367" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -444,10 +454,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67122" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67122" NpcId="1011231" XYZ="503.1051, 217.9515, 790.2189" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -494,10 +506,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67123" NpcId="1012340" XYZ="81.80359, 117.1982, 152.3002" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67123" NpcId="1012340" XYZ="81.80359, 117.1982, 152.3002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -535,6 +549,7 @@
                 <If Condition="GetQuestStep(67124) == 255">
                     <GetTo ZoneId="397" XYZ="465.0186, 162.5833, -522.9115" /> <!-- Artoirel -->
                     <TurnIn QuestId="67124" NpcId="1012348" XYZ="465.0186, 162.5833, -522.9115" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -574,11 +589,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67125" NpcId="1012328" XYZ="1.754761, 0.003450237, -9.750549" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <NoCombatMoveTo Name="Artoirel" XYZ="1.754761, 0.003450237, -9.750549" />
                     <TurnIn QuestId="67125" NpcId="1012328" XYZ="1.754761, 0.003450237, -9.750549" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -616,6 +633,7 @@
                     </If>
                     <NoCombatMoveTo Name="Laniaitte" XYZ="-277.6379, -184.5974, 741.6038" />
                     <TurnIn QuestId="67126" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -658,10 +676,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67127" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67127" NpcId="1011952" XYZ="-277.6379, -184.5974, 741.6038" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -706,10 +726,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67128" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67128" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -749,10 +771,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67129" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67129" NpcId="1012060" XYZ="-358.6633, -157.9937, 761.0131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -799,10 +823,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67130" NpcId="1012364" ItemId="2001574" XYZ="64.10315, -144.9241, 527.3669" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67130" NpcId="1012364" ItemId="2001574" XYZ="64.10315, -144.9241, 527.3669" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -845,6 +871,7 @@
                 <If Condition="GetQuestStep(67131) == 255">
                     <GetTo ZoneId="401" XYZ="-678.2483, -110.6741, 481.7731" /> <!-- Cid -->
                     <TurnIn QuestId="67131" NpcId="1012367" XYZ="-678.2483, -110.6741, 481.7731" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -888,11 +915,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67132" NpcId="1012329" XYZ="-7.309082, 0.003586963, -0.5036011" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Emmanellain" XYZ="-7.309082, 0.003586963, -0.5036011" />
                     <TurnIn QuestId="67132" NpcId="1012329" XYZ="-7.309082, 0.003586963, -0.5036011" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -958,6 +987,7 @@
                     -->
 
                     <TurnIn QuestId="67133" NpcId="1012381" XYZ="120.6531, 14.95313, -156.6339" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1019,6 +1049,7 @@
 
                     <MoveTo Name="Alphinaud" XYZ="0.6866455, 0.02225424, 4.623413" />
                     <TurnIn QuestId="67134" NpcId="1012387" XYZ="0.6866455, 0.02225424, 4.623413" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1067,6 +1098,7 @@
                 <If Condition="GetQuestStep(67135) == 255">
                     <GetTo ZoneId="156" XYZ="30.07544, 50.99997, -819.7299" /> <!-- Higiri -->
                     <TurnIn QuestId="67135" NpcId="1013018" XYZ="30.07544, 50.99997, -819.7299" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1092,6 +1124,7 @@
                 <If Condition="GetQuestStep(67136) == 255">
                     <GetTo ZoneId="145" XYZ="-380.8805, -23.06451, 388.632" /> <!-- Hozan -->
                     <TurnIn QuestId="67136" NpcId="1013028" XYZ="-380.8805, -23.06451, 388.632" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1189,11 +1222,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67137" NpcId="1013038" XYZ="1.998901, 1.147389E-06, -2.517761" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Alphinaud" XYZ="1.998901, 1.147389E-06, -2.517761" />
                     <TurnIn QuestId="67137" NpcId="1013038" XYZ="1.998901, 1.147389E-06, -2.517761" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1243,6 +1278,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="1.113892, 0.02225424, -4.409851" />
                     <TurnIn QuestId="67138" NpcId="1012579" XYZ="1.113892, 0.02225424, -4.409851" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1286,6 +1322,7 @@
                 <If Condition="GetQuestStep(67139) == 255">
                     <GetTo ZoneId="418" XYZ="107.6829, 24.3786, -6.698792" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67139" NpcId="1012588" XYZ="107.6829, 24.3786, -6.698792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1342,6 +1379,7 @@
                     -->
 
                     <TurnIn QuestId="67140" NpcId="1012592" XYZ="459.1592, 162.512, -524.651" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1382,10 +1420,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67141" NpcId="1012601" ItemId="2001578" XYZ="452.4147, 157.4083, -542.8397" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67141" NpcId="1012601" ItemId="2001578" XYZ="452.4147, 157.4083, -542.8397" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1426,6 +1466,7 @@
                 <If Condition="GetQuestStep(67142) == 255">
                     <GetTo ZoneId="397" XYZ="-288.8686, 127.0664, 13.19904" /> <!-- Jantellot -->
                     <TurnIn QuestId="67142" NpcId="1011907" XYZ="-288.8686, 127.0664, 13.19904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1453,6 +1494,7 @@
                 <If Condition="GetQuestStep(67143) == 255">
                     <GetTo ZoneId="397" XYZ="-311.1467, 126.5033, -6.729248" /> <!-- Pierriquet -->
                     <TurnIn QuestId="67143" NpcId="1012283" XYZ="-311.1467, 126.5033, -6.729248" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1485,6 +1527,7 @@
                     -->
 
                     <TurnIn QuestId="67144" NpcId="1012670" ItemId="2001584" XYZ="-631.9219, 142.1073, -322.7131" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1690,11 +1733,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67145" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <NoCombatMoveTo Name="Marcechamp" XYZ="470.0236, -49.89133, 20.37079" />
                     <TurnIn QuestId="67145" NpcId="1011916" XYZ="470.0236, -49.89133, 20.37079" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1737,10 +1782,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67146" NpcId="2005489" XYZ="169.604, -63.24872, -11.82581" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67146" NpcId="2005489" XYZ="169.604, -63.24872, -11.82581" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1793,11 +1840,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67147" NpcId="1012625" XYZ="-212.726, -37.57478, 185.1682" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <NoCombatMoveTo Name="Ysayle" XYZ="-212.726, -37.57478, 185.1682" />
                     <TurnIn QuestId="67147" NpcId="1012625" XYZ="-212.726, -37.57478, 185.1682" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1836,10 +1885,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67148" NpcId="1012629" ItemId="2001580" XYZ="200, -55.46249, -233.4478" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67148" NpcId="1012629" ItemId="2001580" XYZ="200, -55.46249, -233.4478" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1876,10 +1927,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67149" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67149" NpcId="1011928" XYZ="73.19751, -49.19563, -139.0555" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1943,6 +1996,7 @@
                 <If Condition="GetQuestStep(67150) == 255">
                     <GetTo ZoneId="398" XYZ="59.22021, -50.88858, -130.2358" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67150" NpcId="1013582" XYZ="59.22021, -50.88858, -130.2358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1977,6 +2031,7 @@
                 <If Condition="GetQuestStep(67151) == 255">
                     <GetTo ZoneId="398" XYZ="394.3694, -93.98035, 731.8073" /> <!-- Destination -->
                     <TurnIn QuestId="67151" NpcId="2006423" XYZ="394.3694, -93.98035, 731.8073" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2020,6 +2075,7 @@
                 <If Condition="GetQuestStep(67152) == 255">
                     <GetTo ZoneId="398" XYZ="56.35156, -50.57729, -142.5041" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67152" NpcId="1014544" XYZ="56.35156, -50.57729, -142.5041" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2074,6 +2130,7 @@
 
                     <NoCombatMoveTo Name="Alphinaud" XYZ="240.3142, -42.31706, 615.1063" />
                     <TurnIn QuestId="67153" NpcId="1012661" XYZ="240.3142, -42.31706, 615.1063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2208,6 +2265,7 @@
                 <If Condition="GetQuestStep(67154) == 255">
                     <GetTo ZoneId="400" XYZ="364.3091, -74.10719, 654.322" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67154" NpcId="1012664" XYZ="364.3091, -74.10719, 654.322" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2318,10 +2376,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67155" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67155" NpcId="1012077" XYZ="381.7043, -66.84979, 700.8619" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2385,10 +2445,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67158" NpcId="1012083" ItemId="2001583" XYZ="355.8556, -74.53787, 639.6123" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67158" NpcId="1012083" ItemId="2001583" XYZ="355.8556, -74.53787, 639.6123" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2439,10 +2501,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67157" NpcId="1012080" XYZ="392.2026, -72.34356, 649.5612" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67157" NpcId="1012080" XYZ="392.2026, -72.34356, 649.5612" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2462,10 +2526,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67156" NpcId="1012078" ItemId="2001581" XYZ="375.3567, -69.42934, 693.5072" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67156" NpcId="1012078" ItemId="2001581" XYZ="375.3567, -69.42934, 693.5072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2516,6 +2582,7 @@
                 <If Condition="GetQuestStep(67159) == 255">
                     <GetTo ZoneId="400" XYZ="375.3567, -69.42934, 693.5072" /> <!-- Moghan -->
                     <TurnIn QuestId="67159" NpcId="1012078" XYZ="375.3567, -69.42934, 693.5072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2545,6 +2612,7 @@
                 <If Condition="GetQuestStep(67160) == 255">
                     <GetTo ZoneId="400" XYZ="241.1992, -42.24947, 609.2775" /> <!-- Moghan -->
                     <TurnIn QuestId="67160" NpcId="1012682" XYZ="241.1992, -42.24947, 609.2775" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2584,10 +2652,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67161" NpcId="1013202" XYZ="-79.88104, -8.844478, 206.2256" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67161" NpcId="1013202" XYZ="-79.88104, -8.844478, 206.2256" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2632,10 +2702,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67162" NpcId="1012757" XYZ="-261.8297, 30.37311, 557.946" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67162" NpcId="1012757" XYZ="-261.8297, 30.37311, 557.946" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2681,10 +2753,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67163" NpcId="1012694" XYZ="-758.3276, 123.7287, 210.7423" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67163" NpcId="1012694" XYZ="-758.3276, 123.7287, 210.7423" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2727,10 +2801,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67164" NpcId="1012698" XYZ="569.1766, -1.191689, -370.2297" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67164" NpcId="1012698" XYZ="569.1766, -1.191689, -370.2297" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2773,6 +2849,7 @@
                 <If Condition="GetQuestStep(67165) == 255">
                     <GetTo ZoneId="418" XYZ="-160.5402, 16.97958, -39.96344" /> <!-- Biggs -->
                     <TurnIn QuestId="67165" NpcId="1012714" XYZ="-160.5402, 16.97958, -39.96344" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2845,10 +2922,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67364" NpcId="1013420" XYZ="-511.4672, 50, 347.0968" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67166" NpcId="1012729" XYZ="-229.2058, 33.90731, 428.4275" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2883,10 +2962,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67364" NpcId="1013420" XYZ="-511.4672, 50, 347.0968" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67167" NpcId="1012731" XYZ="-23.91095, 37.76, 78.81274" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2932,6 +3013,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="-1.876892, 7.450581E-09, -9.079163" />
                     <TurnIn QuestId="67168" NpcId="1012733" XYZ="-1.876892, 7.450581E-09, -9.079163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3007,6 +3089,7 @@
                 <If Condition="GetQuestStep(67169) == 255">
                     <GetTo ZoneId="418" XYZ="107.4692, 24.37563, -8.407776" /> <!-- Estinien -->
                     <TurnIn QuestId="67169" NpcId="1012589" XYZ="107.4692, 24.37563, -8.407776" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3044,6 +3127,7 @@
                     -->
 
                     <TurnIn QuestId="67170" NpcId="1012746" XYZ="550.4386, -1.191689, -354.9401" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3082,10 +3166,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67171" NpcId="1013172" XYZ="-756.0998, 123.7287, 214.8013" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67171" NpcId="1013172" XYZ="-756.0998, 123.7287, 214.8013" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3250,10 +3336,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67172" NpcId="1012750" XYZ="-163.8972, 27.97913, -116.4111" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67172" NpcId="1012750" XYZ="-163.8972, 27.97913, -116.4111" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3299,11 +3387,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67173" NpcId="1012753" XYZ="-2.578735, -7.450581E-09, 7.644714" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Lucia" XYZ="2.578735, -7.450581E-09, 7.644714" />
                     <TurnIn QuestId="67173" NpcId="1012753" XYZ="-2.578735, -7.450581E-09, 7.644714" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3350,10 +3440,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67174" NpcId="1013332" XYZ="94.95691, -22, 50.94983" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67174" NpcId="1013332" XYZ="94.95691, -22, 50.94983" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3392,10 +3484,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67529" NpcId="1011192" ItemId="2001591" XYZ="88.36499, 15.09468, 31.29626" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67529" NpcId="1011192" ItemId="2001591" XYZ="88.36499, 15.09468, 31.29626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3421,6 +3515,7 @@
                 <If Condition="GetQuestStep(67530) == 255">
                     <GetTo ZoneId="418" XYZ="88.36499, 15.09468, 31.29626" /> <!-- Gibrillont -->
                     <TurnIn QuestId="67530" NpcId="1011192" XYZ="88.36499, 15.09468, 31.29626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3446,6 +3541,7 @@
                 <If Condition="GetQuestStep(67531) == 255">
                     <GetTo ZoneId="418" XYZ="88.36499, 15.09468, 31.29626" /> <!-- Gibrillont -->
                     <TurnIn QuestId="67531" NpcId="1011192" XYZ="88.36499, 15.09468, 31.29626" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3471,6 +3567,7 @@
                 <If Condition="GetQuestStep(67532) == 255">
                     <GetTo ZoneId="418" XYZ="104.387, 15, 25.55884" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67532" NpcId="1013260" XYZ="104.387, 15, 25.55884" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3535,6 +3632,7 @@
                 <If Condition="GetQuestStep(67175) == 255">
                     <GetTo ZoneId="418" XYZ="86.38135, 23.97913, 12.80225" /> <!-- Hilda -->
                     <TurnIn QuestId="67175" NpcId="1012780" XYZ="86.38135, 23.97913, 12.80225" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3584,6 +3682,7 @@
                     </If>
                     <GetTo ZoneId="419" XYZ="14.8775, 16.00967, -4.196289" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67176" NpcId="1013227" XYZ="14.8775, 16.00967, -4.196289" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3615,6 +3714,7 @@
 
                     <MoveTo Name="Aymeric" XYZ="-0.01531982, 0.01999969, -6.302063" />
                     <TurnIn QuestId="67177" NpcId="1013183" XYZ="-0.01531982, 0.01999969, -6.302063" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3633,6 +3733,7 @@
                 <If Condition="GetQuestStep(67178) == 255">
                     <GetTo ZoneId="418" XYZ="-158.4955, 17.06621, -56.26001" /> <!-- Cid -->
                     <TurnIn QuestId="67178" NpcId="1013261" XYZ="-158.4955, 17.06621, -56.26001" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3675,6 +3776,7 @@
                     </If>
                     <NoCombatMoveTo Name="Alphinaud" XYZ="-805.5391, -57.82888, 157.6409" />
                     <TurnIn QuestId="67179" NpcId="1013085" XYZ="-805.5391, -57.82888, 157.6409" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3726,6 +3828,7 @@
                 <If Condition="GetQuestStep(67180) == 255">
                     <GetTo ZoneId="401" XYZ="-751.6747, -35.95642, 18.72278" /> <!-- Lonu Vanu -->
                     <TurnIn QuestId="67180" NpcId="1013089" XYZ="-751.6747, -35.95642, 18.72278" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3755,6 +3858,7 @@
                 <If Condition="GetQuestStep(67181) == 255">
                     <GetTo ZoneId="401" XYZ="-560.6927, -52.30738, -427.5731" /> <!-- Lonu Vanu -->
                     <TurnIn QuestId="67181" NpcId="1013095" XYZ="-560.6927, -52.30738, -427.5731" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3784,6 +3888,7 @@
                 <If Condition="GetQuestStep(67182) == 255">
                     <GetTo ZoneId="401" XYZ="-583.032, -52.12611, -447.4403" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67182" NpcId="1014570" XYZ="-583.032, -52.12611, -447.4403" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3828,6 +3933,7 @@
                     -->
 
                     <TurnIn QuestId="67183" NpcId="1014575" XYZ="-156.6644, -14.15376, -543.0228" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3962,6 +4068,7 @@
                     -->
 
                     <TurnIn QuestId="67184" NpcId="1012195" XYZ="-155.9319, -14.15376, -542.1378" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3987,6 +4094,7 @@
                     -->
 
                     <TurnIn QuestId="67185" NpcId="1013111" XYZ="162.89, -15.13437, 37.0946" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4018,6 +4126,7 @@
                 <If Condition="GetQuestStep(67186) == 255">
                     <GetTo ZoneId="418" XYZ="92.36279, 15.09468, 33.18835" /> <!-- Tataru -->
                     <TurnIn QuestId="67186" NpcId="1013162" XYZ="92.36279, 15.09468, 33.18835" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4047,6 +4156,7 @@
                 <If Condition="GetQuestStep(67187) == 255">
                     <GetTo ZoneId="133" XYZ="-158.1903, 4, -21.19489" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67187" NpcId="1012394" XYZ="-158.1903, 4, -21.19489" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4086,6 +4196,7 @@
                 <If Condition="GetQuestStep(67188) == 255">
                     <GetTo ZoneId="132" XYZ="35.53821, -8, 98.13074" /> <!-- Tataru -->
                     <TurnIn QuestId="67188" NpcId="1012398" XYZ="35.53821, -8, 98.13074" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4117,6 +4228,7 @@
                 <If Condition="GetQuestStep(67189) == 255">
                     <GetTo ZoneId="132" XYZ="35.53821, -8, 98.13074" /> <!-- Tataru -->
                     <TurnIn QuestId="67189" NpcId="1012398" ItemIds="2001798,2001799" XYZ="35.53821, -8, 98.13074" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4142,6 +4254,7 @@
                 <If Condition="GetQuestStep(67190) == 255">
                     <GetTo ZoneId="398" XYZ="587.457, -50.81134, 69.16907" /> <!-- Y'shtola -->
                     <TurnIn QuestId="67190" NpcId="1012406" XYZ="587.457, -50.81134, 69.16907" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4250,11 +4363,13 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67191" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <MoveTo Name="Slowfix" XYZ="73.3501, 205.8894, 23.48358" />
                     <TurnIn QuestId="67191" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4296,10 +4411,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67192" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67192" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4351,10 +4468,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67193" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67193" NpcId="1012097" XYZ="73.3501, 205.8894, 23.48358" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4390,10 +4509,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67194" NpcId="1012421" XYZ="77.98877, 203.9799, 127.9163" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67194" NpcId="1012421" XYZ="77.98877, 203.9799, 127.9163" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4534,6 +4655,7 @@
                 <If Condition="GetQuestStep(67195) == 255">
                     <GetTo ZoneId="399" XYZ="-476.585, 137.4297, 702.6931" /> <!-- Y'shtola -->
                     <TurnIn QuestId="67195" NpcId="1012423" XYZ="-476.585, 137.4297, 702.6931" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4609,6 +4731,7 @@
 
                     <MoveTo Name="Matoya" XYZ="19.27209, 38.43, 15.85406" />
                     <TurnIn QuestId="67196" NpcId="1012138" ItemId="2001575" XYZ="19.27209, 38.43, 15.85406" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4645,6 +4768,7 @@
                 <If Condition="GetQuestStep(67197) == 255">
                     <GetTo ZoneId="419" XYZ="167.0404, -14.3133, 51.28552" /> <!-- Cid -->
                     <TurnIn QuestId="67197" NpcId="1013163" XYZ="167.0404, -14.3133, 51.28552" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4704,6 +4828,7 @@
 
                     <GetTo ZoneId="419" XYZ="165.9418, -14.34896, 51.65173" /> <!-- Alphinaud -->
                     <TurnIn QuestId="67198" NpcId="1012430" XYZ="165.9418, -14.34896, 51.65173" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4756,6 +4881,7 @@
                     </If>
                     <NoCombatMoveTo Name="Cid" XYZ="-650.1717, -176.4502, -565.1484" />
                     <TurnIn QuestId="67199" NpcId="1012792" XYZ="-650.1717, -176.4502, -565.1484" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4807,10 +4933,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67200" NpcId="1014675" XYZ="-638.3612, -176.4502, -578.6679" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67200" NpcId="1014675" XYZ="-638.3612, -176.4502, -578.6679" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4854,10 +4982,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67201" NpcId="1012802" XYZ="235.9807, -72.83498, -619.8978" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67201" NpcId="1012802" XYZ="235.9807, -72.83498, -619.8978" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4914,10 +5044,12 @@
                     If you want a specific reward from the above list, replace the TurnIn tag below with the following and change the "Reward Slot" to the number you want:
 
                     <TurnIn QuestId="67202" NpcId="2006364" XYZ="778.8052, -17.99042, -483.5432" RewardSlot="0" />
+                    <WaitTimer WaitTime="2"/>
 
                     -->
 
                     <TurnIn QuestId="67202" NpcId="2006364" XYZ="778.8052, -17.99042, -483.5432" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4987,6 +5119,7 @@
 
                     <NoCombatMoveTo Name="Guidance Node" XYZ="-197.8638, -102.783, 456.5347" />
                     <TurnIn QuestId="67203" NpcId="1012834" XYZ="-197.8638, -102.783, 456.5347" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5013,6 +5146,7 @@
                     -->
 
                     <TurnIn QuestId="67204" NpcId="2005465" XYZ="-696.1318, -37.06427, 432.4253" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5146,6 +5280,7 @@
 
                     <!-- <MoveTo Name="Alphinaud" XYZ="0.7476196, 0.02225424, 4.623413" />
                     <TurnIn QuestId="67205" NpcId="1012857" XYZ="0.7476196, 0.02225424, 4.623413" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If> -->
         </If>

--- a/Questing/[O] [MSQ] Stormblood.xml
+++ b/Questing/[O] [MSQ] Stormblood.xml
@@ -132,6 +132,7 @@
                 <If Condition="GetQuestStep(67982) == 255">
                     <GetTo ZoneId="612" XYZ="-606.7445, 130, -506.9505" /> <!-- Raubahn -->
                     <TurnIn QuestId="67982" NpcId="1020304" XYZ="-606.7445, 130, -506.9505" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -169,6 +170,7 @@
                 <If Condition="GetQuestStep(67983) == 255">
                     <GetTo ZoneId="635" XYZ="-32.97479, 18.04509, 129.4117" /> <!-- Conrad -->
                     <TurnIn QuestId="67983" NpcId="1020329" XYZ="-32.97479, 18.04509, 129.4117" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -187,6 +189,7 @@
                 <If Condition="GetQuestStep(67984) == 255">
                     <GetTo ZoneId="635" XYZ="170.9163, 13.02367, -91.38635" /> <!-- Conrad -->
                     <TurnIn QuestId="67984" NpcId="1019466" XYZ="170.9163, 13.02367, -91.38635" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -224,6 +227,7 @@
                 <If Condition="GetQuestStep(67985) == 255">
                     <GetTo ZoneId="635" XYZ="59.67798, 0, -4.074219" /> <!-- Lyse -->
                     <TurnIn QuestId="67985" NpcId="1020347" XYZ="59.67798, 0, -4.074219" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -249,6 +253,7 @@
                 <If Condition="GetQuestStep(67986) == 255">
                     <GetTo ZoneId="635" XYZ="164.1412, 13.02367, -92.30188" /> <!-- Alisaie -->
                     <TurnIn QuestId="67986" NpcId="1020333" XYZ="164.1412, 13.02367, -92.30188" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -303,6 +308,7 @@
                 <If Condition="GetQuestStep(67987) == 255">
                     <GetTo ZoneId="612" XYZ="-95.84198, 59.80103, -551.9341" /> <!-- M'naago -->
                     <TurnIn QuestId="67987" NpcId="1020351" XYZ="-95.84198, 59.80103, -551.9341" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -331,6 +337,7 @@
                 <If Condition="GetQuestStep(67988) == 255">
                     <GetTo ZoneId="612" XYZ="-606.7445, 130, -506.9505" /> <!-- Raubahn -->
                     <TurnIn QuestId="67988" NpcId="1020304" XYZ="-606.7445, 130, -506.9505" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -373,6 +380,7 @@
                 <If Condition="GetQuestStep(67989) == 255">
                     <GetTo ZoneId="612" XYZ="-507.4388, 86.34846, -289.8452" /> <!-- M'naago -->
                     <TurnIn QuestId="67989" NpcId="1020361" XYZ="-507.4388, 86.34846, -289.8452" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -391,6 +399,7 @@
                 <If Condition="GetQuestStep(67990) == 255">
                     <GetTo ZoneId="635" XYZ="171.313, 13.02367, -89.95197" /> <!-- M'naago -->
                     <TurnIn QuestId="67990" NpcId="1020337" XYZ="171.313, 13.02367, -89.95197" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -414,6 +423,7 @@
                 <If Condition="GetQuestStep(67991) == 255">
                     <GetTo ZoneId="620" XYZ="36.42322, 117.956, -742.2446" /> <!-- Meffrid -->
                     <TurnIn QuestId="67991" NpcId="1020372" XYZ="36.42322, 117.956, -742.2446" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -442,6 +452,7 @@
                 <If Condition="GetQuestStep(67992) == 255">
                     <GetTo ZoneId="620" XYZ="89.21948, 119.4052, -684.7792" /> <!-- Meffrid -->
                     <TurnIn QuestId="67992" NpcId="1020374" XYZ="89.21948, 119.4052, -684.7792" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -503,6 +514,7 @@
                 <If Condition="GetQuestStep(68490) == 255">
                     <GetTo ZoneId="620" XYZ="81.55945, 118.1558, -717.8912" /> <!-- Griseldis -->
                     <TurnIn QuestId="68490" ItemIds="2002391,2002392" NpcId="1020842" XYZ="81.55945, 118.1558, -717.8912" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -512,6 +524,7 @@
                 <If Condition="GetQuestStep(68491) == 255">
                     <GetTo ZoneId="620" XYZ="113.7255, 118.1558, -715.6634" /> <!-- Angry Coeurl -->
                     <TurnIn QuestId="68491" ItemId="2002393" NpcId="1020848" XYZ="113.7255, 118.1558, -715.6634" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -544,6 +557,7 @@
                 <If Condition="GetQuestStep(67993) == 255">
                     <GetTo ZoneId="620" XYZ="85.40466, 118.1558, -719.9664" /> <!-- Meffrid -->
                     <TurnIn QuestId="67993" NpcId="1020379" XYZ="85.40466, 118.1558, -719.9664" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -605,6 +619,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="-284.596, 200.7199, -287.2511" /> <!-- Lyse -->
                     <TurnIn QuestId="67994" NpcId="1020382" XYZ="-284.596, 200.7199, -287.2511" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -646,6 +661,7 @@
                 <If Condition="GetQuestStep(67995) == 255">
                     <GetTo ZoneId="620" XYZ="-140.9476, 104.1659, -401.8159" /> <!-- Meffrid -->
                     <TurnIn QuestId="67995" NpcId="1020387" XYZ="-140.9476, 104.1659, -401.8159" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -713,6 +729,7 @@
                 <If Condition="GetQuestStep(68182) == 255">
                     <GetTo ZoneId="620" XYZ="-83.48212, 104.3904, -424.7654" /> <!-- Bent Frond -->
                     <TurnIn QuestId="68182" NpcId="1020860" XYZ="-83.48212, 104.3904, -424.7654" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -725,6 +742,7 @@
                 <If Condition="GetQuestStep(67996) == 255">
                     <GetTo ZoneId="635" XYZ="170.3059, 13.02367, -93.06476" /> <!-- Meffrid -->
                     <TurnIn QuestId="67996" NpcId="1020338" XYZ="170.3059, 13.02367, -93.06476" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -746,6 +764,7 @@
                 <If Condition="GetQuestStep(67997) == 255">
                     <GetTo ZoneId="635" XYZ="164.2633, 13.02367, -88.91437" /> <!-- M'naago -->
                     <TurnIn QuestId="67997" NpcId="1020390" XYZ="164.2633, 13.02367, -88.91437" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -801,6 +820,7 @@
                 <If Condition="GetQuestStep(68171) == 255">
                     <GetTo ZoneId="635" XYZ="152.1172, 13.15332, -118.4863" /> <!-- Beves -->
                     <TurnIn QuestId="68171" ItemId="2002076" NpcId="1019470" XYZ="152.1172, 13.15332, -118.4863" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -825,6 +845,7 @@
                 <If Condition="GetQuestStep(68173) == 255">
                     <GetTo ZoneId="635" XYZ="-43.96124, 0, -15.03015" /> <!-- Ananta Battlemaid -->
                     <TurnIn QuestId="68173" NpcId="1021167" XYZ="-43.96124, 0, -15.03015" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -855,6 +876,7 @@
                 <If Condition="GetQuestStep(68172) == 255">
                     <GetTo ZoneId="635" XYZ="77.25635, 0, -14.17566" /> <!-- Ahelissa -->
                     <TurnIn QuestId="68172" ItemId="2002077" NpcId="1019476" XYZ="77.25635, 0, -14.17566" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -883,6 +905,7 @@
                 <If Condition="GetQuestStep(68174) == 255">
                     <GetTo ZoneId="635" XYZ="152.8496, 13.09733, -94.16345" /> <!-- Swarthy Resistance Fighter -->
                     <TurnIn QuestId="68174" ItemId="2002334" NpcId="1023638" XYZ="152.8496, 13.09733, -94.16345" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -928,6 +951,7 @@
                 <If Condition="GetQuestStep(67998) == 255">
                     <GetTo ZoneId="612" XYZ="-609.6132, 130, -501.1216" /> <!-- Alisaie -->
                     <TurnIn QuestId="67998" NpcId="1020526" XYZ="-609.6132, 130, -501.1216" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -977,6 +1001,7 @@
                 <If Condition="GetQuestStep(67999) == 255">
                     <GetTo ZoneId="635" XYZ="71.30542, 0.02469154, -75.76111" /> <!-- Raubahn -->
                     <TurnIn QuestId="67999" NpcId="1020400" XYZ="71.30542, 0.02469154, -75.76111" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1002,6 +1027,7 @@
                 <If Condition="GetQuestStep(68000) == 255">
                     <GetTo ZoneId="635" XYZ="-135.8206, 0.5980504, -83.6347" /> <!-- Conrad -->
                     <TurnIn QuestId="68000" ItemId="2002109" NpcId="1020416" XYZ="-135.8206, 0.5980504, -83.6347" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1037,6 +1063,7 @@
                 <If Condition="GetQuestStep(68001) == 255">
                     <GetTo ZoneId="635" XYZ="-85.92358, 0, -18.05151" /> <!-- Flame Courier -->
                     <TurnIn QuestId="68001" ItemId="2002110" NpcId="1020422" XYZ="-85.92358, 0, -18.05151" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1066,6 +1093,7 @@
                 <If Condition="GetQuestStep(68002) == 255">
                     <GetTo ZoneId="612" XYZ="-610.2846, 130, -501.8845" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68002" NpcId="1020525" XYZ="-610.2846, 130, -501.8845" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1091,6 +1119,7 @@
                 <If Condition="GetQuestStep(68003) == 255">
                     <GetTo ZoneId="128" XYZ="13.30885, 44, -37.32566" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68003" NpcId="1020434" XYZ="13.30885, 44, -37.32566" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1139,6 +1168,7 @@
                     </If>
                     <GetTo ZoneId="156" XYZ="40.80162, 20.495, -649.8046" /> <!-- Lyse -->
                     <TurnIn QuestId="68004" NpcId="1020436" XYZ="40.80162, 20.495, -649.8046" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1189,6 +1219,7 @@
                 <If Condition="GetQuestStep(68005) == 255">
                     <GetTo ZoneId="628" XYZ="-123.0982, -6.999998, -59.63268" /> <!-- Carvallain -->
                     <TurnIn QuestId="68005" NpcId="1020454" XYZ="-123.0982, -6.999998, -59.63268" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1214,6 +1245,7 @@
                 <If Condition="GetQuestStep(68006) == 255">
                     <GetTo ZoneId="628" XYZ="16.59662, -6.198883E-06, -41.32873" /> <!-- Hancock -->
                     <TurnIn QuestId="68006" NpcId="1020460" XYZ="16.59662, -6.198883E-06, -41.32873" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1243,6 +1275,7 @@
                 <If Condition="GetQuestStep(68007) == 255">
                     <GetTo ZoneId="628" XYZ="96.17687, 8.02, 151.8455" /> <!-- Hancock -->
                     <TurnIn QuestId="68007" NpcId="1020462" XYZ="96.17687, 8.02, 151.8455" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1274,6 +1307,7 @@
                     </If>
                     <MoveTo Name="Alphinaud" XYZ="1.81313, 0, -0.1843593" />
                     <TurnIn QuestId="68008" NpcId="1020465" XYZ="1.81313, 0, -0.1843593" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1325,6 +1359,7 @@
                 <If Condition="GetQuestStep(68009) == 255">
                     <GetTo ZoneId="628" XYZ="-33.20004, 0.0298152, -68.53907" /> <!-- Lyse -->
                     <TurnIn QuestId="68009" NpcId="1020472" XYZ="-33.20004, 0.0298152, -68.53907" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1400,6 +1435,7 @@
                 <If Condition="GetQuestStep(68010) == 255">
                     <GetTo ZoneId="628" XYZ="147.6232, 14.77572, 92.13142" /> <!-- Lyse -->
                     <TurnIn QuestId="68010" NpcId="1020476" XYZ="147.6232, 14.77572, 92.13142" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1449,6 +1485,7 @@
                 <If Condition="GetQuestStep(68011) == 255">
                     <GetTo ZoneId="628" XYZ="127.4131, 14.51298, -101.0447" /> <!-- Lyse -->
                     <TurnIn QuestId="68011" NpcId="1020483" XYZ="127.4131, 14.51298, -101.0447" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1495,6 +1532,7 @@
                 <If Condition="GetQuestStep(68012) == 255">
                     <GetTo ZoneId="613" XYZ="852.4982, 5.923008, 848.586" /> <!-- Soroban -->
                     <TurnIn QuestId="68012" NpcId="1019891" XYZ="852.4982, 5.923008, 848.586" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1524,6 +1562,7 @@
                 <If Condition="GetQuestStep(68013) == 255">
                     <GetTo ZoneId="613" XYZ="465.0686, 30.19312, 791.2009" /> <!-- Tansui -->
                     <TurnIn QuestId="68013" NpcId="1019898" XYZ="465.0686, 30.19312, 791.2009" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1553,6 +1592,7 @@
                 <If Condition="GetQuestStep(68014) == 255">
                     <GetTo ZoneId="613" XYZ="404.9196, 19.55959, 755.218" /> <!-- Soroban -->
                     <TurnIn QuestId="68014" NpcId="1023650" XYZ="404.9196, 19.55959, 755.218" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1602,6 +1642,7 @@
                 <If Condition="GetQuestStep(68015) == 255">
                     <GetTo ZoneId="613" XYZ="-58.56174, 1.99137, -596.7916" /> <!-- Lyse -->
                     <TurnIn QuestId="68015" NpcId="1019930" XYZ="-58.56174, 1.99137, -596.7916" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1646,6 +1687,7 @@
                 <If Condition="GetQuestStep(68016) == 255">
                     <GetTo ZoneId="613" XYZ="69.44886, 25.00783, -643.0053" /> <!-- Alisaie -->
                     <TurnIn QuestId="68016" NpcId="1019939" XYZ="69.44886, 25.00783, -643.0053" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1719,6 +1761,7 @@
                 <If Condition="GetQuestStep(68215) == 255">
                     <GetTo ZoneId="613" XYZ="107.8049, 0.8069639, -574.5175" /> <!-- Aranami -->
                     <TurnIn QuestId="68215" NpcId="1021509" XYZ="107.8049, 0.8069639, -574.5175" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1728,6 +1771,7 @@
                 <If Condition="GetQuestStep(68217) == 255">
                     <GetTo ZoneId="613" XYZ="84.91299, 41.11266, -716.7828" /> <!-- Afumi -->
                     <TurnIn QuestId="68217" NpcId="1021517" XYZ="84.91299, 41.11266, -716.7828" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1755,6 +1799,7 @@
                 <If Condition="GetQuestStep(68489) == 255">
                     <GetTo ZoneId="613" XYZ="57.23657, 1.575162, -578.2407" /> <!-- Kajika -->
                     <TurnIn QuestId="68489" ItemIds="2002387,2002388" NpcId="1021507" XYZ="57.23657, 1.575162, -578.2407" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1804,6 +1849,7 @@
                 <If Condition="GetQuestStep(68017) == 255">
                     <GetTo ZoneId="613" XYZ="79.42322, 33.00897, -669.9474" /> <!-- Rasho -->
                     <TurnIn QuestId="68017" NpcId="1021505" XYZ="79.42322, 33.00897, -669.9474" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1837,6 +1883,7 @@
                 <If Condition="GetQuestStep(68018) == 255">
                     <GetTo ZoneId="613" XYZ="422.1102, -98.96018, -223.1022" /> <!-- Alisaie -->
                     <TurnIn QuestId="68018" NpcId="1019956" XYZ="422.1102, -98.96018, -223.1022" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1870,6 +1917,7 @@
                 <If Condition="GetQuestStep(68019) == 255">
                     <GetTo ZoneId="613" XYZ="420.3403, -99.19678, -221.3627" /> <!-- Soroban -->
                     <TurnIn QuestId="68019" ItemId="2002094" NpcId="1019958" XYZ="420.3403, -99.19678, -221.3627" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -1984,6 +2032,7 @@
                     <GetTo ZoneId="613" XYZ="19.42468, -197.5309, -143.9384" /> <!-- Lyse -->
                     <Dismount />
                     <TurnIn QuestId="68020" NpcId="1019970" XYZ="19.42468, -197.5309, -143.9384" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2090,6 +2139,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="20.24866, -197.5632, -145.4032" /> <!-- Alisaie -->
                     <TurnIn QuestId="68021" NpcId="1019971" XYZ="20.24866, -197.5632, -145.4032" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2290,6 +2340,7 @@
                     <MoveTo Name="Diving" Distance="1" UseMesh="False" XYZ="-228.3217, -170.3914, 185.3949" />
                     <MoveTo Name="Alisaie" Distance="0.1" UseMesh="False" XYZ="-227.863, -179.2102, 185.748" />
                     <TurnIn QuestId="68022" ItemId="2002095" NpcId="1019978" XYZ="-227.863, -179.2102, 185.748" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2349,6 +2400,7 @@
                 <If Condition="GetQuestStep(68023) == 255">
                     <GetTo ZoneId="613" XYZ="323.0487, -120.035, -249.012" /> <!-- Alisaie -->
                     <TurnIn QuestId="68023" NpcId="1019961" XYZ="323.0487, -120.035, -249.012" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2588,6 +2640,7 @@
                     </If>
                     <GetTo ZoneId="613" XYZ="-797.3602, 48.41823, 149.6453" /> <!-- Alisaie -->
                     <TurnIn QuestId="68024" NpcId="1019985" XYZ="-797.3602, 48.41823, 149.6453" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2721,6 +2774,7 @@
                 <If Condition="GetQuestStep(68025) == 255">
                     <GetTo ZoneId="613" XYZ="-761.8372, 4.763445, -455.2224" /> <!-- Lyse -->
                     <TurnIn QuestId="68025" NpcId="1019988" XYZ="-761.8372, 4.763445, -455.2224" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2753,6 +2807,7 @@
                 <If Condition="GetQuestStep(68026) == 255">
                     <GetTo ZoneId="613" XYZ="-761.8372, 4.763445, -453.4829" /> <!-- Alisaie -->
                     <TurnIn QuestId="68026" NpcId="1019989" XYZ="-761.8372, 4.763445, -453.4829" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2782,6 +2837,7 @@
                 <If Condition="GetQuestStep(68027) == 255">
                     <GetTo ZoneId="614" XYZ="527.9164, 43.697, -156.0541" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68027" NpcId="1019997" XYZ="527.9164, 43.697, -156.0541" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2857,6 +2913,7 @@
                     </If>
                     <MoveTo Name="Gosetsu" XYZ="277.9735, 3.262752, -378.9578" />
                     <TurnIn QuestId="68028" NpcId="1020007" XYZ="277.9735, 3.262752, -378.9578" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -2997,6 +3054,7 @@
 
                     <MoveTo Name="Yugiri" XYZ="-49.88184, -0.2605122, -12.89392" />
                     <TurnIn QuestId="68470" NpcId="1020011" XYZ="-49.88184, -0.2605122, -12.89392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3069,6 +3127,7 @@
                 <If Condition="GetQuestStep(68029) == 255">
                     <GetTo ZoneId="614" XYZ="486.9917, 50.48013, -115.404" /> <!-- Yugiri -->
                     <TurnIn QuestId="68029" NpcId="1020012" XYZ="486.9917, 50.48013, -115.404" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3110,6 +3169,7 @@
                 <If Condition="GetQuestStep(68030) == 255">
                     <GetTo ZoneId="614" XYZ="397.7568, 72.83517, -97.06268" /> <!-- Yugiri -->
                     <TurnIn QuestId="68030" NpcId="1020020" XYZ="397.7568, 72.83517, -97.06268" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3206,6 +3266,7 @@
                 <If Condition="GetQuestStep(68031) == 255">
                     <GetTo ZoneId="614" XYZ="406.2714, 14.64187, 626.1234" /> <!-- Yugiri -->
                     <TurnIn QuestId="68031" NpcId="1020283" XYZ="406.2714, 14.64187, 626.1234" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3259,6 +3320,7 @@
                 <If Condition="GetQuestStep(68032) == 255">
                     <GetTo ZoneId="614" XYZ="457.6943, 30.0019, 764.187" /> <!-- Captured Villager -->
                     <TurnIn QuestId="68032" NpcId="1020029" XYZ="457.6943, 30.0019, 764.187" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3345,6 +3407,7 @@
 
                     <MoveTo Name="Yugiri" XYZ="278.3093, 2.954496, -378.439" />
                     <TurnIn QuestId="68033" NpcId="1023787" XYZ="278.3093, 2.954496, -378.439" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3410,6 +3473,7 @@
                 <If Condition="GetQuestStep(68471) == 255">
                     <GetTo ZoneId="614" XYZ="-463.2181, 1.230005, 535.6068" /> <!-- Yugiri -->
                     <TurnIn QuestId="68471" NpcId="1020055" XYZ="-463.2181, 1.230005, 535.6068" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3456,6 +3520,7 @@
                 <If Condition="GetQuestStep(68034) == 255">
                     <GetTo ZoneId="614" XYZ="488.3038, 7.396728, 375.1429" /> <!-- Alisaie -->
                     <TurnIn QuestId="68034" NpcId="1020057" XYZ="488.3038, 7.396728, 375.1429" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3488,6 +3553,7 @@
                 <If Condition="GetQuestStep(68035) == 255">
                     <GetTo ZoneId="614" XYZ="446.6774, 68.02853, -74.47931" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68035" NpcId="1020067" XYZ="446.6774, 68.02853, -74.47931" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3581,6 +3647,7 @@
                 <If Condition="GetQuestStep(68166) == 255">
                     <GetTo ZoneId="622" XYZ="560.235, -19.50564, 408.6824" /> <!-- Yugiri -->
                     <TurnIn QuestId="68166" NpcId="1020079" XYZ="560.235, -19.50564, 408.6824" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3617,6 +3684,7 @@
                 <If Condition="GetQuestStep(68036) == 255">
                     <GetTo ZoneId="622" XYZ="571.5876, -19.50566, 313.7101" /> <!-- Cirina -->
                     <TurnIn QuestId="68036" NpcId="1020281" XYZ="571.5876, -19.50566, 313.7101" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3642,6 +3710,7 @@
                 <If Condition="GetQuestStep(68037) == 255">
                     <GetTo ZoneId="622" XYZ="571.5876, -19.50566, 313.7101" /> <!-- Cirina -->
                     <TurnIn QuestId="68037" ItemId="2002204" NpcId="1020281" XYZ="571.5876, -19.50566, 313.7101" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3667,6 +3736,7 @@
                 <If Condition="GetQuestStep(68038) == 255">
                     <GetTo ZoneId="622" XYZ="592.9198, 24.94365, 380.0564" /> <!-- Hien -->
                     <TurnIn QuestId="68038" NpcId="1020543" XYZ="592.9198, 24.94365, 380.0564" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3696,6 +3766,7 @@
                 <If Condition="GetQuestStep(68039) == 255">
                     <GetTo ZoneId="622" XYZ="484.4891, 40.21725, -469.5354" /> <!-- Cirina -->
                     <TurnIn QuestId="68039" NpcId="1020501" XYZ="484.4891, 40.21725, -469.5354" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3735,6 +3806,7 @@
                 <If Condition="GetQuestStep(68040) == 255">
                     <GetTo ZoneId="622" XYZ="484.4891, 40.21725, -469.5354" /> <!-- Cirina -->
                     <TurnIn QuestId="68040" ItemId="2002197" NpcId="1020501" XYZ="484.4891, 40.21725, -469.5354" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3783,6 +3855,7 @@
                 <If Condition="GetQuestStep(68041) == 255">
                     <GetTo ZoneId="622" XYZ="485.2522, 40.32777, -472.1904" /> <!-- Hien -->
                     <TurnIn QuestId="68041" NpcId="1020544" XYZ="485.2522, 40.32777, -472.1904" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3824,6 +3897,7 @@
                 <If Condition="GetQuestStep(68042) == 255">
                     <GetTo ZoneId="622" XYZ="-507.805, 71.23162, -512.0775" /> <!-- Hien -->
                     <TurnIn QuestId="68042" NpcId="1020679" XYZ="-507.805, 71.23162, -512.0775" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3849,6 +3923,7 @@
                 <If Condition="GetQuestStep(68043) == 255">
                     <GetTo ZoneId="622" XYZ="-507.4998, 70.84219, -501.4573" /> <!-- Lyse -->
                     <TurnIn QuestId="68043" NpcId="1020682" XYZ="-507.4998, 70.84219, -501.4573" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3867,6 +3942,7 @@
                 <If Condition="GetQuestStep(68044) == 255">
                     <GetTo ZoneId="622" XYZ="-39.41406, 122.1, 63.61487" /> <!-- Magnai -->
                     <TurnIn QuestId="68044" NpcId="1019417" XYZ="-39.41406, 122.1, 63.61487" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -3972,6 +4048,7 @@
                 <If Condition="GetQuestStep(68045) == 255">
                     <GetTo ZoneId="622" XYZ="-39.41406, 122.1, 63.61487" /> <!-- Magnai -->
                     <TurnIn QuestId="68045" NpcId="1019417" XYZ="-39.41406, 122.1, 63.61487" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4016,6 +4093,7 @@
                 <If Condition="GetQuestStep(68046) == 255">
                     <GetTo ZoneId="622" XYZ="-39.41406, 122.1, 63.61487" /> <!-- Magnai -->
                     <TurnIn QuestId="68046" NpcId="1019417" XYZ="-39.41406, 122.1, 63.61487" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4050,6 +4128,7 @@
                 <If Condition="GetQuestStep(68047) == 255">
                     <GetTo ZoneId="622" XYZ="-290.3334, 10.38987, 598.9928" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68047" NpcId="1021625" XYZ="-290.3334, 10.38987, 598.9928" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4085,6 +4164,7 @@
                 <If Condition="GetQuestStep(68048) == 255">
                     <GetTo ZoneId="622" XYZ="-399.0387, 2.257562, 599.2675" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68048" NpcId="1021615" XYZ="-399.0387, 2.257562, 599.2675" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4114,6 +4194,7 @@
                 <If Condition="GetQuestStep(68049) == 255">
                     <GetTo ZoneId="622" XYZ="-705.5009, 6.554513, 613.1837" /> <!-- Gosetsu -->
                     <TurnIn QuestId="68049" NpcId="1021628" XYZ="-705.5009, 6.554513, 613.1837" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4143,6 +4224,7 @@
                 <If Condition="GetQuestStep(68050) == 255">
                     <GetTo ZoneId="622" XYZ="498.2832, 40.8361, -508.2017" /> <!-- Cirina -->
                     <TurnIn QuestId="68050" NpcId="1020539" XYZ="498.2832, 40.8361, -508.2017" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4213,6 +4295,7 @@
                 <If Condition="GetQuestStep(68051) == 255">
                     <GetTo ZoneId="622" XYZ="486.6864, 40.08099, -465.7206" /> <!-- Hien -->
                     <TurnIn QuestId="68051" NpcId="1020540" XYZ="486.6864, 40.08099, -465.7206" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4248,6 +4331,7 @@
                 <If Condition="GetQuestStep(68052) == 255">
                     <GetTo ZoneId="622" XYZ="498.2832, 40.8361, -508.2017" /> <!-- Cirina -->
                     <TurnIn QuestId="68052" NpcId="1020539" XYZ="498.2832, 40.8361, -508.2017" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4277,6 +4361,7 @@
                 <If Condition="GetQuestStep(68053) == 255">
                     <GetTo ZoneId="622" XYZ="-167.895, 0.8849516, 816.8002" /> <!-- Cirina -->
                     <TurnIn QuestId="68053" NpcId="1021646" XYZ="-167.895, 0.8849516, 816.8002" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4306,6 +4391,7 @@
                 <If Condition="GetQuestStep(68054) == 255">
                     <GetTo ZoneId="614" XYZ="173.785, 5.16971, -417.4106" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68054" NpcId="1020519" XYZ="173.785, 5.16971, -417.4106" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4353,6 +4439,7 @@
                     </If>
                     <MoveTo Name="Tataru" XYZ="-1.571716, 0, -1.449646" />
                     <TurnIn QuestId="68055" NpcId="1023084" XYZ="-1.571716, 0, -1.449646" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4397,6 +4484,7 @@
                 <If Condition="GetQuestStep(68482) == 255">
                     <GetTo ZoneId="614" XYZ="173.785, 5.16971, -417.4106" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68482" ItemId="2002175" NpcId="1020519" XYZ="173.785, 5.16971, -417.4106" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4446,6 +4534,7 @@
                 <If Condition="GetQuestStep(68056) == 255">
                     <GetTo ZoneId="614" XYZ="235.8586, 4.456162, -382.8031" /> <!-- Alisaie -->
                     <TurnIn QuestId="68056" NpcId="1020520" XYZ="235.8586, 4.456162, -382.8031" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4475,6 +4564,7 @@
                 <If Condition="GetQuestStep(68057) == 255">
                     <GetTo ZoneId="614" XYZ="337.2701, 31.03499, 206.4392" /> <!-- Tsuranuki -->
                     <TurnIn QuestId="68057" NpcId="1020232" XYZ="337.2701, 31.03499, 206.4392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4527,6 +4617,7 @@
                 <If Condition="GetQuestStep(68483) == 255">
                     <GetTo ZoneId="614" XYZ="337.2701, 31.03499, 206.4392" /> <!-- Tsuranuki -->
                     <TurnIn QuestId="68483" ItemId="2002177" NpcId="1020232" XYZ="337.2701, 31.03499, 206.4392" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4570,6 +4661,7 @@
                 <If Condition="GetQuestStep(68058) == 255">
                     <GetTo ZoneId="614" XYZ="-291.4321, 53.21751, -614.313" /> <!-- Hien -->
                     <TurnIn QuestId="68058" ItemId="2002178" NpcId="1020239" XYZ="-291.4321, 53.21751, -614.313" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4601,6 +4693,7 @@
                 <If Condition="GetQuestStep(68059) == 255">
                     <GetTo ZoneId="614" XYZ="173.785, 5.16971, -417.4106" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68059" NpcId="1020519" XYZ="173.785, 5.16971, -417.4106" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4638,6 +4731,7 @@
                 <If Condition="GetQuestStep(68060) == 255">
                     <GetTo ZoneId="614" XYZ="-390.28, 30.64617, -455.8633" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68060" NpcId="1020248" XYZ="-390.28, 30.64617, -455.8633" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4680,6 +4774,7 @@
                 <If Condition="GetQuestStep(68061) == 255">
                     <GetTo ZoneId="628" XYZ="-175.9213, -7.000108, 53.81848" /> <!-- Rasho -->
                     <TurnIn QuestId="68061" NpcId="1020265" XYZ="-175.9213, -7.000108, 53.81848" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4717,6 +4812,7 @@
                 <If Condition="GetQuestStep(68062) == 255">
                     <GetTo ZoneId="129" XYZ="-355.5811, 8.000015, 40.78735" /> <!-- Lyse -->
                     <TurnIn QuestId="68062" NpcId="1020441" XYZ="-355.5811, 8.000015, 40.78735" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4746,6 +4842,7 @@
                 <If Condition="GetQuestStep(68063) == 255">
                     <GetTo ZoneId="612" XYZ="-605.2186, 130, -506.2486" /> <!-- Pipin -->
                     <TurnIn QuestId="68063" NpcId="1020354" XYZ="-605.2186, 130, -506.2486" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4809,6 +4906,7 @@
                 <If Condition="GetQuestStep(68064) == 255">
                     <GetTo ZoneId="612" XYZ="-91.23376, 50.00444, 187.8538" /> <!-- Lyse -->
                     <TurnIn QuestId="68064" NpcId="1020567" XYZ="-91.23376, 50.00444, 187.8538" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4839,6 +4937,7 @@
                 <If Condition="GetQuestStep(68065) == 255">
                     <GetTo ZoneId="612" XYZ="-92.42395, 50.00444, 185.6565" /> <!-- Conrad -->
                     <TurnIn QuestId="68065" NpcId="1020568" XYZ="-92.42395, 50.00444, 185.6565" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4868,6 +4967,7 @@
                 <If Condition="GetQuestStep(68066) == 255">
                     <GetTo ZoneId="612" XYZ="426.5659, 114.5499, 221.7898" /> <!-- M'naago -->
                     <TurnIn QuestId="68066" NpcId="1020578" XYZ="426.5659, 114.5499, 221.7898" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4893,6 +4993,7 @@
                 <If Condition="GetQuestStep(68067) == 255">
                     <GetTo ZoneId="612" XYZ="334.1267, 82.94969, -101.2742" /> <!-- Vajra -->
                     <TurnIn QuestId="68067" NpcId="1020827" XYZ="334.1267, 82.94969, -101.2742" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4935,6 +5036,7 @@
                 <If Condition="GetQuestStep(68068) == 255">
                     <GetTo ZoneId="612" XYZ="509.3918, 122.138, -242.1455" /> <!-- Lyse -->
                     <TurnIn QuestId="68068" NpcId="1020592" XYZ="509.3918, 122.138, -242.1455" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -4968,6 +5070,7 @@
                 <If Condition="GetQuestStep(68069) == 255">
                     <GetTo ZoneId="612" XYZ="424.7349, 114.6093, 222.1865" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68069" NpcId="1020596" XYZ="424.7349, 114.6093, 222.1865" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5060,6 +5163,7 @@
                 <If Condition="GetQuestStep(68070) == 255">
                     <GetTo ZoneId="620" XYZ="-286.7323, 256.9996, 696.2233" /> <!-- M'naago -->
                     <TurnIn QuestId="68070" NpcId="1020600" XYZ="-286.7323, 256.9996, 696.2233" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5085,6 +5189,7 @@
                 <If Condition="GetQuestStep(68071) == 255">
                     <GetTo ZoneId="620" XYZ="-297.4747, 257.5265, 765.3162" /> <!-- Alisaie -->
                     <TurnIn QuestId="68071" NpcId="1020630" XYZ="-297.4747, 257.5265, 765.3162" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5115,6 +5220,7 @@
                 <If Condition="GetQuestStep(68072) == 255">
                     <GetTo ZoneId="620" XYZ="-346.1509, 305.933, 149.0348" /> <!-- Alisaie -->
                     <TurnIn QuestId="68072" NpcId="1020608" XYZ="-346.1509, 305.933, 149.0348" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5188,6 +5294,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="7.827881, 317.5509, 112.4132" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68073" NpcId="1020611" XYZ="7.827881, 317.5509, 112.4132" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5229,6 +5336,7 @@
                 <If Condition="GetQuestStep(68074) == 255">
                     <GetTo ZoneId="620" XYZ="-286.5493, 256.8515, 693.1411" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68074" NpcId="1020601" XYZ="-286.5493, 256.8515, 693.1411" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5254,6 +5362,7 @@
                 <If Condition="GetQuestStep(68075) == 255">
                     <GetTo ZoneId="620" XYZ="-300.496, 257.5265, 765.0415" /> <!-- Lyse -->
                     <TurnIn QuestId="68075" NpcId="1020631" XYZ="-300.496, 257.5265, 765.0415" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5283,6 +5392,7 @@
                 <If Condition="GetQuestStep(68076) == 255">
                     <GetTo ZoneId="620" XYZ="-113.4203, 263.7311, 655.7563" /> <!-- Lyse -->
                     <TurnIn QuestId="68076" NpcId="1020633" XYZ="-113.4203, 263.7311, 655.7563" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5308,6 +5418,7 @@
                 <If Condition="GetQuestStep(68077) == 255">
                     <GetTo ZoneId="620" XYZ="-298.5123, 257.5265, 764.9805" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68077" NpcId="1020629" XYZ="-298.5123, 257.5265, 764.9805" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5369,6 +5480,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="353.7803, 323.7739, 273.3043" /> <!-- Lyse -->
                     <TurnIn QuestId="68078" NpcId="1022344" XYZ="353.7803, 323.7739, 273.3043" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5406,6 +5518,7 @@
                 <If Condition="GetQuestStep(68079) == 255">
                     <GetTo ZoneId="620" XYZ="257.8011, 314.4075, 416.1592" /> <!-- Young Hellsguard -->
                     <TurnIn QuestId="68079" NpcId="1020645" XYZ="257.8011, 314.4075, 416.1592" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5511,6 +5624,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="561.4556, 344.1177, 435.3551" /> <!-- Lyse -->
                     <TurnIn QuestId="68080" NpcId="1020647" XYZ="561.4556, 344.1177, 435.3551" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5541,6 +5655,7 @@
                 <If Condition="GetQuestStep(68081) == 255">
                     <GetTo ZoneId="620" XYZ="260.3951, 322.8362, 742.0309" /> <!-- Raubahn -->
                     <TurnIn QuestId="68081" NpcId="1020656" XYZ="260.3951, 322.8362, 742.0309" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5625,6 +5740,7 @@
                     </If>
                     <GetTo ZoneId="620" XYZ="318.1658, 324.3033, 376.8824" /> <!-- M'naago -->
                     <TurnIn QuestId="68082" NpcId="1020660" XYZ="318.1658, 324.3033, 376.8824" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5660,6 +5776,7 @@
                 <If Condition="GetQuestStep(68083) == 255">
                     <GetTo ZoneId="635" XYZ="-53.42188, -0.1167764, -28.61072" /> <!-- Lyse -->
                     <TurnIn QuestId="68083" NpcId="1020665" XYZ="-53.42188, -0.1167764, -28.61072" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5693,6 +5810,7 @@
                 <If Condition="GetQuestStep(68084) == 255">
                     <GetTo ZoneId="621" XYZ="-651.5145, 50.00002, -3.128174" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68084" NpcId="1021704" XYZ="-651.5145, 50.00002, -3.128174" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5750,6 +5868,7 @@
                 <If Condition="GetQuestStep(68085) == 255">
                     <GetTo ZoneId="621" XYZ="66.54456, 45.41022, 766.476" /> <!-- Lyse -->
                     <TurnIn QuestId="68085" NpcId="1021710" XYZ="66.54456, 45.41022, 766.476" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5923,6 +6042,7 @@
                 <If Condition="GetQuestStep(68086) == 255">
                     <GetTo ZoneId="621" XYZ="756.9542, 70, 445.4565" /> <!-- Alphinaud -->
                     <TurnIn QuestId="68086" NpcId="1021717" XYZ="756.9542, 70, 445.4565" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -5970,6 +6090,7 @@
                 <If Condition="GetQuestStep(68087) == 255">
                     <GetTo ZoneId="621" XYZ="-672.694, 49.99973, 14.99957" /> <!-- Raubahn -->
                     <TurnIn QuestId="68087" NpcId="1021698" XYZ="-672.694, 49.99973, 14.99957" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6081,6 +6202,7 @@
                 <If Condition="GetQuestStep(68088) == 255">
                     <GetTo ZoneId="621" XYZ="560.0519, 162, 72.28198" /> <!-- Pipin -->
                     <TurnIn QuestId="68088" NpcId="1021724" XYZ="560.0519, 162, 72.28198" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>
@@ -6137,6 +6259,7 @@
                 <If Condition="GetQuestStep(68089) == 255">
                     <GetTo ZoneId="635" XYZ="65.38477, -0.4161447, -80.24719" /> <!-- Lyse -->
                     <TurnIn QuestId="68089" NpcId="1021728" XYZ="65.38477, -0.4161447, -80.24719" />
+                    <WaitTimer WaitTime="2"/>
                 </If>
             </If>
         </If>


### PR DESCRIPTION
Prevents us from accepting a new quest from the same NPC before it's actually available.

Regex used was;

`(\h+)(<TurnIn.*\/>)` replaced with `(\1)(\2)\n(\1)<WaitTimer WaitTime="2"/>`

Additionally fixed AST NPC (Jannequinard) XYZ's being behind the counter, causing navigation issues.